### PR TITLE
add keyboard constant object

### DIFF
--- a/src/lib/builders/accordion/index.ts
+++ b/src/lib/builders/accordion/index.ts
@@ -1,4 +1,4 @@
-import { elementMultiDerived, getElementByMeltId, uuid } from '$lib/internal/helpers';
+import { elementMultiDerived, getElementByMeltId, kbd, uuid } from '$lib/internal/helpers';
 import { derived, writable } from 'svelte/store';
 
 type BaseAccordionArgs = {
@@ -93,7 +93,7 @@ export const createAccordion = (args?: CreateAccordionArgs) => {
 			});
 
 			attach('keydown', (e) => {
-				if (!['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(e.key)) {
+				if (![kbd.ARROW_DOWN, kbd.ARROW_UP, kbd.HOME, kbd.END].includes(e.key)) {
 					return;
 				}
 				e.preventDefault();
@@ -109,16 +109,16 @@ export const createAccordion = (args?: CreateAccordionArgs) => {
 				if (!items.length) return;
 				const elIdx = items.indexOf(el);
 
-				if (e.key === 'ArrowDown') {
+				if (e.key === kbd.ARROW_DOWN) {
 					items[(elIdx + 1) % items.length].focus();
 				}
-				if (e.key === 'ArrowUp') {
+				if (e.key === kbd.ARROW_UP) {
 					items[(elIdx - 1 + items.length) % items.length].focus();
 				}
-				if (e.key === 'Home') {
+				if (e.key === kbd.HOME) {
 					items[0].focus();
 				}
-				if (e.key === 'End') {
+				if (e.key === kbd.END) {
 					items[items.length - 1].focus();
 				}
 			});

--- a/src/lib/builders/checkbox/index.ts
+++ b/src/lib/builders/checkbox/index.ts
@@ -1,4 +1,4 @@
-import { elementDerived, styleToString } from '@melt-ui/svelte/internal/helpers';
+import { elementDerived, kbd, styleToString } from '@melt-ui/svelte/internal/helpers';
 import { derived, writable } from 'svelte/store';
 
 type CheckedState = boolean | 'indeterminate';
@@ -32,7 +32,7 @@ export function createCheckbox(args: CreateCheckboxArgs = {}) {
 	const root = elementDerived([checked, options], ([$checked, $options], attach) => {
 		attach('keydown', (event) => {
 			// According to WAI ARIA, Checkboxes don't activate on enter keypress
-			if (event.key === 'Enter') event.preventDefault();
+			if (event.key === kbd.ENTER) event.preventDefault();
 		});
 
 		attach('click', () => {

--- a/src/lib/builders/radio-group/index.ts
+++ b/src/lib/builders/radio-group/index.ts
@@ -1,4 +1,4 @@
-import { elementMultiDerived } from '@melt-ui/svelte/internal/helpers';
+import { elementMultiDerived, kbd } from '@melt-ui/svelte/internal/helpers';
 import { derived, writable } from 'svelte/store';
 
 type Orientation = 'horizontal' | 'vertical';
@@ -63,13 +63,13 @@ export function createRadioGroup(args: CreateRadioGroupArgs = {}) {
 			// TODO: detect dir
 			const dir = 'ltr' as 'ltr' | 'rtl';
 			const nextKey = {
-				horizontal: dir === 'rtl' ? 'ArrowLeft' : 'ArrowRight',
-				vertical: 'ArrowDown',
+				horizontal: dir === 'rtl' ? kbd.ARROW_LEFT : kbd.ARROW_RIGHT,
+				vertical: kbd.ARROW_DOWN,
 			}[$options.orientation ?? 'horizontal'];
 
 			const prevKey = {
-				horizontal: dir === 'rtl' ? 'ArrowRight' : 'ArrowLeft',
-				vertical: 'ArrowUp',
+				horizontal: dir === 'rtl' ? kbd.ARROW_RIGHT : kbd.ARROW_LEFT,
+				vertical: kbd.ARROW_UP,
 			}[$options.orientation ?? 'horizontal'];
 
 			attach('keydown', (e) => {
@@ -101,10 +101,10 @@ export function createRadioGroup(args: CreateRadioGroupArgs = {}) {
 					} else {
 						items[prevIndex].focus();
 					}
-				} else if (e.key === 'Home') {
+				} else if (e.key === kbd.HOME) {
 					e.preventDefault();
 					items[0].focus();
-				} else if (e.key === 'End') {
+				} else if (e.key === kbd.END) {
 					e.preventDefault();
 					items[items.length - 1].focus();
 				}

--- a/src/lib/builders/select/index.ts
+++ b/src/lib/builders/select/index.ts
@@ -4,6 +4,7 @@ import {
 	elementMultiDerived,
 	getElementByMeltId,
 	isBrowser,
+	kbd,
 	styleToString,
 } from '$lib/internal/helpers';
 import { sleep } from '$lib/internal/helpers/sleep';
@@ -101,7 +102,7 @@ export function createSelect() {
 			});
 
 			attach('keydown', (e) => {
-				if (e.key === 'Enter') {
+				if (e.key === kbd.ENTER) {
 					e.stopPropagation();
 					e.stopImmediatePropagation();
 					const el = e.currentTarget as HTMLElement;
@@ -145,7 +146,7 @@ export function createSelect() {
 			}
 
 			const keydownListener = (e: KeyboardEvent) => {
-				if (e.key === 'Escape') {
+				if (e.key === kbd.ESCAPE) {
 					open.set(false);
 					activeTrigger.set(null);
 					return;
@@ -155,12 +156,12 @@ export function createSelect() {
 				const focusedOption = allOptions.find((el) => el === document.activeElement);
 				const focusedIndex = allOptions.indexOf(focusedOption as HTMLElement);
 
-				if (e.key === 'ArrowDown') {
+				if (e.key === kbd.ARROW_DOWN) {
 					e.preventDefault();
 					const nextIndex = focusedIndex + 1 > allOptions.length - 1 ? 0 : focusedIndex + 1;
 					const nextOption = allOptions[nextIndex] as HTMLElement;
 					nextOption.focus();
-				} else if (e.key === 'ArrowUp') {
+				} else if (e.key === kbd.ARROW_UP) {
 					e.preventDefault();
 					const prevIndex = focusedIndex - 1 < 0 ? allOptions.length - 1 : focusedIndex - 1;
 					const prevOption = allOptions[prevIndex] as HTMLElement;

--- a/src/lib/builders/tabs/index.ts
+++ b/src/lib/builders/tabs/index.ts
@@ -3,6 +3,7 @@ import {
 	elementMultiDerived,
 	getElementByMeltId,
 	isBrowser,
+	kbd,
 	last,
 	next,
 	prev,
@@ -91,13 +92,13 @@ export function createTabs(args?: CreateTabsArgs) {
 			});
 
 			const nextKey = {
-				horizontal: options.dir === 'rtl' ? 'ArrowLeft' : 'ArrowRight',
-				vertical: 'ArrowDown',
+				horizontal: options.dir === 'rtl' ? kbd.ARROW_LEFT : kbd.ARROW_RIGHT,
+				vertical: kbd.ARROW_DOWN,
 			}[options.orientation ?? 'horizontal'];
 
 			const prevKey = {
-				horizontal: options.dir === 'rtl' ? 'ArrowRight' : 'ArrowLeft',
-				vertical: 'ArrowUp',
+				horizontal: options.dir === 'rtl' ? kbd.ARROW_RIGHT : kbd.ARROW_LEFT,
+				vertical: kbd.ARROW_UP,
 			}[options.orientation ?? 'horizontal'];
 
 			attach('keydown', (e) => {
@@ -113,13 +114,13 @@ export function createTabs(args?: CreateTabsArgs) {
 				} else if (e.key === prevKey) {
 					e.preventDefault();
 					prev(enabledTriggers, triggerIdx, options.loop)?.focus();
-				} else if (e.key === 'Enter' || e.key === ' ') {
+				} else if (e.key === kbd.ENTER || e.key === kbd.SPACE) {
 					e.preventDefault();
 					value.set(tabValue);
-				} else if (e.key === 'Home') {
+				} else if (e.key === kbd.HOME) {
 					e.preventDefault();
 					enabledTriggers[0]?.focus();
-				} else if (e.key === 'End') {
+				} else if (e.key === kbd.END) {
 					e.preventDefault();
 					last(enabledTriggers)?.focus();
 				}

--- a/src/lib/builders/toggle-group/index.ts
+++ b/src/lib/builders/toggle-group/index.ts
@@ -1,4 +1,4 @@
-import { elementMultiDerived } from '@melt-ui/svelte/internal/helpers';
+import { elementMultiDerived, kbd } from '@melt-ui/svelte/internal/helpers';
 import { derived, writable } from 'svelte/store';
 
 type Orientation = 'horizontal' | 'vertical';
@@ -88,13 +88,13 @@ export function createToggleGroup(args: CreateToggleGroupArgs = {}) {
 			// TODO: detect dir
 			const dir = 'ltr' as 'ltr' | 'rtl';
 			const nextKey = {
-				horizontal: dir === 'rtl' ? 'ArrowLeft' : 'ArrowRight',
-				vertical: 'ArrowDown',
+				horizontal: dir === 'rtl' ? kbd.ARROW_LEFT : kbd.ARROW_RIGHT,
+				vertical: kbd.ARROW_DOWN,
 			}[$options.orientation ?? 'horizontal'];
 
 			const prevKey = {
-				horizontal: dir === 'rtl' ? 'ArrowRight' : 'ArrowLeft',
-				vertical: 'ArrowUp',
+				horizontal: dir === 'rtl' ? kbd.ARROW_RIGHT : kbd.ARROW_LEFT,
+				vertical: kbd.ARROW_UP,
 			}[$options.orientation ?? 'horizontal'];
 
 			attach('keydown', (e) => {
@@ -128,10 +128,10 @@ export function createToggleGroup(args: CreateToggleGroupArgs = {}) {
 					} else {
 						items[prevIndex].focus();
 					}
-				} else if (e.key === 'Home') {
+				} else if (e.key === kbd.HOME) {
 					e.preventDefault();
 					items[0].focus();
-				} else if (e.key === 'End') {
+				} else if (e.key === kbd.END) {
 					e.preventDefault();
 					items[items.length - 1].focus();
 				}

--- a/src/lib/internal/helpers/index.ts
+++ b/src/lib/internal/helpers/index.ts
@@ -9,3 +9,4 @@ export * from './style';
 export * from './browser';
 export * from './uuid';
 export * from './builder';
+export * from './keyboard';

--- a/src/lib/internal/helpers/keyboard.ts
+++ b/src/lib/internal/helpers/keyboard.ts
@@ -20,4 +20,4 @@ export const kbd = {
 	SHIFT: 'Shift',
 	SPACE: ' ',
 	TAB: 'Tab',
-};
+} as const;

--- a/src/lib/internal/helpers/keyboard.ts
+++ b/src/lib/internal/helpers/keyboard.ts
@@ -1,0 +1,23 @@
+/**
+ * A constant object that maps commonly used keyboard keys to their corresponding string values.
+ * This object can be used in other parts of the application to handle keyboard input and prevent
+ * hard-coded strings throughout.
+ */
+export const kbd = {
+	BACKSPACE: 'Backspace',
+	CONTROL: 'Control',
+	DELETE: 'Delete',
+	DOWN_ARROW: 'ArrowDown',
+	END: 'End',
+	ENTER: 'Enter',
+	ESCAPE: 'Escape',
+	HOME: 'Home',
+	LEFT_ARROW: 'ArrowLeft',
+	PAGE_DOWN: 'PageDown',
+	PAGE_UP: 'PageUp',
+	RIGHT_ARROW: 'ArrowRight',
+	SHIFT: 'Shift',
+	SPACE: ' ',
+	TAB: 'Tab',
+	UP_ARROW: 'ArrowUp',
+};

--- a/src/lib/internal/helpers/keyboard.ts
+++ b/src/lib/internal/helpers/keyboard.ts
@@ -4,20 +4,20 @@
  * hard-coded strings throughout.
  */
 export const kbd = {
+	ARROW_DOWN: 'ArrowDown',
+	ARROW_LEFT: 'ArrowLeft',
+	ARROW_RIGHT: 'ArrowRight',
+	ARROW_UP: 'ArrowUp',
 	BACKSPACE: 'Backspace',
 	CONTROL: 'Control',
 	DELETE: 'Delete',
-	DOWN_ARROW: 'ArrowDown',
 	END: 'End',
 	ENTER: 'Enter',
 	ESCAPE: 'Escape',
 	HOME: 'Home',
-	LEFT_ARROW: 'ArrowLeft',
 	PAGE_DOWN: 'PageDown',
 	PAGE_UP: 'PageUp',
-	RIGHT_ARROW: 'ArrowRight',
 	SHIFT: 'Shift',
 	SPACE: ' ',
 	TAB: 'Tab',
-	UP_ARROW: 'ArrowUp',
 };

--- a/src/lib/internal/helpers/keyboard.ts
+++ b/src/lib/internal/helpers/keyboard.ts
@@ -20,4 +20,4 @@ export const kbd = {
 	SHIFT: 'Shift',
 	SPACE: ' ',
 	TAB: 'Tab',
-} as const;
+};


### PR DESCRIPTION
I added a `kbd` object which maps commonly used keyboard keys to their corresponding string values.

This prevents us from hard-coding strings all over the place & also guarantees typesafety/accuracy considering `KeyboardEvent.key` is just typed as a `string`.