### PR TITLE
Adjust isBrowser detection

### DIFF
--- a/.changeset/forty-hounds-beg.md
+++ b/.changeset/forty-hounds-beg.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+Adjust browser detection function

--- a/package.json
+++ b/package.json
@@ -116,5 +116,5 @@
 	"svelte": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"type": "module",
-	"packageManager": "pnpm@8.4.0"
+	"packageManager": "pnpm@8.6.2"
 }

--- a/src/lib/internal/helpers/is.ts
+++ b/src/lib/internal/helpers/is.ts
@@ -1,4 +1,4 @@
-export const isBrowser = typeof window !== 'undefined';
+export const isBrowser = typeof document !== 'undefined';
 // eslint-disable-next-line @typescript-eslint/ban-types
 export const isFunction = (v: unknown): v is Function => typeof v === 'function';
 


### PR DESCRIPTION
This PR adjusts isBrowser detection to not rely on the window variable, which can be declared in various environments, such as e.g. Deno. 

Prior art: https://github.com/TanStack/virtual/pull/516 https://github.com/framer/motion/pull/1522 https://remix.run/docs/en/1.16.1/pages/gotchas#typeof-window-checks

I've also updated the packageManager field in package.json. It looks like the pnpm-lock was generated using newer version than this field suggested. It didn't work properly using corepack for automatically managing pnpm version