### PR TITLE
fix: select preview

### DIFF
--- a/src/lib/builders/select/index.ts
+++ b/src/lib/builders/select/index.ts
@@ -10,7 +10,7 @@ import {
 } from '$lib/internal/helpers';
 import { sleep } from '$lib/internal/helpers/sleep';
 import type { FloatingConfig } from '$lib/internal/actions';
-import { derived, writable } from 'svelte/store';
+import { writable } from 'svelte/store';
 
 /**
  * Features:
@@ -27,7 +27,6 @@ type CreateSelectArgs = {
 };
 
 const defaults = {
-	arrowSize: 8,
 	positioning: {
 		placement: 'bottom',
 	},
@@ -93,15 +92,6 @@ export function createSelect(args?: CreateSelectArgs) {
 			};
 		}
 	);
-
-	const arrow = derived(options, ($options) => ({
-		'data-arrow': true,
-		style: styleToString({
-			position: 'absolute',
-			width: `var(--arrow-size, ${$options.arrowSize}px)`,
-			height: `var(--arrow-size, ${$options.arrowSize}px)`,
-		}),
-	}));
 
 	type OptionArgs = {
 		value: string;
@@ -195,5 +185,5 @@ export function createSelect(args?: CreateSelectArgs) {
 		}
 	});
 
-	return { trigger, menu, open, option, selected, selectedText, arrow };
+	return { trigger, menu, open, option, selected, selectedText };
 }

--- a/src/lib/builders/select/index.ts
+++ b/src/lib/builders/select/index.ts
@@ -10,7 +10,7 @@ import {
 } from '$lib/internal/helpers';
 import { sleep } from '$lib/internal/helpers/sleep';
 import type { FloatingConfig } from '$lib/internal/actions';
-import { writable } from 'svelte/store';
+import { derived, writable } from 'svelte/store';
 
 /**
  * Features:
@@ -27,6 +27,7 @@ type CreateSelectArgs = {
 };
 
 const defaults = {
+	arrowSize: 8,
 	positioning: {
 		placement: 'bottom',
 	},
@@ -92,6 +93,15 @@ export function createSelect(args?: CreateSelectArgs) {
 			};
 		}
 	);
+
+	const arrow = derived(options, ($options) => ({
+		'data-arrow': true,
+		style: styleToString({
+			position: 'absolute',
+			width: `var(--arrow-size, ${$options.arrowSize}px)`,
+			height: `var(--arrow-size, ${$options.arrowSize}px)`,
+		}),
+	}));
 
 	type OptionArgs = {
 		value: string;
@@ -185,5 +195,5 @@ export function createSelect(args?: CreateSelectArgs) {
 		}
 	});
 
-	return { trigger, menu, open, option, selected, selectedText };
+	return { trigger, menu, open, option, selected, selectedText, arrow };
 }

--- a/src/routes/docs/builders/select/preview.svelte
+++ b/src/routes/docs/builders/select/preview.svelte
@@ -2,7 +2,7 @@
 	import { createSelect } from '$lib';
 	import { Docs } from '$routes/(components)';
 
-	const { selectedText, trigger, menu, option, arrow } = createSelect();
+	const { selectedText, trigger, menu, option } = createSelect();
 </script>
 
 <Docs.PreviewWrapper>
@@ -15,10 +15,9 @@
 	</button>
 
 	<ul
-		class="absolute flex min-w-[200px] translate-y-2 flex-col gap-2 rounded-md bg-white p-2 text-magnum-700"
+		class="z-10 flex min-w-[200px] flex-col gap-2 rounded-md bg-white p-2 text-magnum-700"
 		{...$menu}
 	>
-		<div {...$arrow} />
 		<li
 			class="cursor-pointer rounded-md px-4 py-1 outline-none hocus:bg-zinc-200"
 			{...$option({ value: 'option-1' })}


### PR DESCRIPTION
Having the arrow on the preview by default for a select feels odd. We can definitely keep it as an option for those who would want that and can possibly add an example of using the arrow within the `Select` docs!

I updated the styles of the preview as well to get rid of the bug and also position the popper appropriately for a select. I think it's best to avoid using `translate` css properties to move it around, and instead rely on the `positioning` options.

I'm not sure whether they would conflict with one another, but the CSS property definitely overrides any default positioning props. This is something we can investigate further. 