### PR TITLE
feat(select): updates & touchups

### DIFF
--- a/src/lib/builders/select/index.ts
+++ b/src/lib/builders/select/index.ts
@@ -32,6 +32,7 @@ const defaults = {
 	arrowSize: 8,
 	positioning: {
 		placement: 'bottom',
+		sameWidth: true,
 	},
 } satisfies CreateSelectArgs;
 

--- a/src/routes/docs/builders/select/code.ignore-svelte
+++ b/src/routes/docs/builders/select/code.ignore-svelte
@@ -1,30 +1,57 @@
 <script lang="ts">
 	import { createSelect } from '@melt-ui/svelte';
-	const { selectedText, trigger, menu, option } = createSelect();
+	import Check from '~icons/lucide/check';
+	import ChevronDown from '~icons/lucide/chevron-down';
+
+	const { selectedText, trigger, menu, option, isSelected } = createSelect();
+
+	const options = {
+		fruits: ['Apple', 'Banana', 'Orange', 'Pineapple'],
+		vegetables: ['Broccoli', 'Carrot', 'Potato', 'Tomato'],
+	};
 </script>
 
-<button
-	class="rounded-md bg-white px-4 py-1 text-magnum-700 outline-none
-	hover:opacity-75 focus:ring focus:ring-magnum-400"
-	{...$trigger()}
->
+<button class="trigger" {...$trigger()}>
 	{$selectedText || 'Select an option'}
+	<span class="opacity-50">
+		<ChevronDown />
+	</span>
 </button>
 
-<ul
-	class="absolute flex min-w-[200px] translate-y-2 flex-col gap-2 rounded-md bg-white p-2 text-magnum-700"
-	{...$menu}
->
-	<li
-		class="cursor-pointer rounded-md px-4 py-1 outline-none hocus:bg-zinc-200"
-		{...$option({ value: 'option-1' })}
-	>
-		Option 1
-	</li>
-	<li
-		class="cursor-pointer rounded-md px-4 py-1 outline-none hocus:bg-zinc-200"
-		{...$option({ value: 'option-2' })}
-	>
-		Option 2
-	</li>
+<ul class="menu" {...$menu}>
+	{#each Object.entries(options) as [key, arr]}
+		<li class="label">{key}</li>
+		{#each arr as item}
+			<li class="option" {...$option({ value: item })}>
+				{#if $isSelected(item)}
+					<div class="check">
+						<Check />
+					</div>
+				{/if}
+				{item}
+			</li>
+		{/each}
+	{/each}
 </ul>
+
+<style lang="postcss">
+	.label {
+		@apply py-1 pl-4 pr-4 font-bold capitalize text-neutral-800;
+	}
+	.menu {
+		@apply z-10 flex max-h-[300px] flex-col gap-2 overflow-y-auto;
+		@apply rounded-md bg-white p-1 lg:max-h-none;
+	}
+	.option {
+		@apply relative cursor-pointer rounded-md py-1 pl-8 pr-4 text-neutral-800;
+		@apply outline-none hocus:bg-magnum-100 hocus:text-magnum-700;
+	}
+	.trigger {
+		@apply flex h-10 w-[180px] items-center justify-between rounded-md bg-white px-3;
+		@apply py-2 text-magnum-700 outline-none hover:opacity-75 focus:ring focus:ring-magnum-400;
+	}
+	.check {
+		@apply absolute left-2 top-1/2 text-magnum-500;
+		translate: 0 calc(-50% + 1px);
+	}
+</style>

--- a/src/routes/docs/builders/select/preview.svelte
+++ b/src/routes/docs/builders/select/preview.svelte
@@ -2,6 +2,7 @@
 	import { createSelect } from '$lib';
 	import { Docs } from '$routes/(components)';
 	import Check from '~icons/lucide/check';
+	import ChevronDown from '~icons/lucide/chevron-down';
 
 	const { selectedText, trigger, menu, option, isSelected } = createSelect();
 
@@ -12,27 +13,18 @@
 </script>
 
 <Docs.PreviewWrapper>
-	<button
-		class="rounded-md bg-white px-4 py-1 text-magnum-700 outline-none
-	hover:opacity-75 focus:ring focus:ring-magnum-400"
-		{...$trigger()}
-	>
+	<button class="trigger" {...$trigger()}>
 		{$selectedText || 'Select an option'}
+		<span class="opacity-50">
+			<ChevronDown />
+		</span>
 	</button>
 
-	<ul
-		class="z-10 flex max-h-[300px] min-w-[200px] flex-col gap-2 overflow-y-auto rounded-md
-	bg-white p-1 lg:max-h-none"
-		{...$menu}
-	>
+	<ul class="menu" {...$menu}>
 		{#each Object.entries(options) as [key, arr]}
-			<li class="py-1 pl-4 pr-4 font-bold capitalize text-neutral-800">{key}</li>
+			<li class="label">{key}</li>
 			{#each arr as item}
-				<li
-					class="relative cursor-pointer rounded-md py-1 pl-8 pr-4 text-neutral-800 outline-none
-					hocus:bg-magnum-100 hocus:text-magnum-700"
-					{...$option({ value: item })}
-				>
+				<li class="option" {...$option({ value: item })}>
 					{#if $isSelected(item)}
 						<div class="check">
 							<Check />
@@ -46,8 +38,23 @@
 </Docs.PreviewWrapper>
 
 <style lang="postcss">
+	.label {
+		@apply py-1 pl-4 pr-4 font-bold capitalize text-neutral-800;
+	}
+	.menu {
+		@apply z-10 flex max-h-[300px] flex-col gap-2 overflow-y-auto;
+		@apply rounded-md bg-white p-1 lg:max-h-none;
+	}
+	.option {
+		@apply relative cursor-pointer rounded-md py-1 pl-8 pr-4 text-neutral-800;
+		@apply outline-none hocus:bg-magnum-100 hocus:text-magnum-700;
+	}
+	.trigger {
+		@apply flex h-10 w-[180px] items-center justify-between rounded-md bg-white px-3;
+		@apply py-2 text-magnum-700 outline-none hover:opacity-75 focus:ring focus:ring-magnum-400;
+	}
 	.check {
-		@apply absolute left-2 top-1/2  text-magnum-500;
+		@apply absolute left-2 top-1/2 text-magnum-500;
 		translate: 0 calc(-50% + 1px);
 	}
 </style>


### PR DESCRIPTION
Things complete with this PR:
- [x] Update select preview code snippet
- [x] Add ChevronDown Icon to preview
- [x] Move longer tailwind classes to `<style>` block for clarity
- [x] Add `disabled` and `required` props to builder function
- [x] Add additional aria & data attributes 


Some additional thoughts:

### Accessibility 
Some things I'm starting to realize is that if we want to truly provide an "out of the box" accessible component, with little thought from the user required to do so, we're going to have to take some more props and possibly add some additional elements to the builder.

For example, with a select, the "dropdown icon" should never be part of the accessibility tree, so by providing some default `icon` attributes that can be applied, more specifically `aria-hidden`. Of course, the beauty with builders is that a lot of things can be "opt-out"/"opt-in", by simply not using/spreading the element, but I think it would be nice to provide it.

### Typeahead Support
If we want to align with [WAI-ARIA guidlines](https://www.w3.org/WAI/ARIA/apg/patterns/listbox/) for listbox, then we'll need typeahead support. I've thought of a few different ways we might approach this:

#### Option A: Using the values
Since the user has to pass a value into the `...$option`, we could have a builder-root level `values` store which would be an array of values and use that to search against. 

The issue with this is that sometimes non user-friendly values are used, think something like languages, which might use the locale ISO code as the value, but display the language's name for the label. So this is probably not an ideal approach.

#### Option B:
Forcing the user to pass a `label`/`name` into the option like so `...$option({ value: "pt", label: "Portuguese"})`

#### Option C:
Instead of forcing the user to pass in a label/name, if they provide one, we use that for typeahead, if not, we use the value.