### PR TITLE
selectedText should hold the correct value and support numbers

### DIFF
--- a/.changeset/brave-mirrors-appear.md
+++ b/.changeset/brave-mirrors-appear.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+refactor: update selectedText to support numbers

--- a/src/lib/builders/select/index.ts
+++ b/src/lib/builders/select/index.ts
@@ -51,7 +51,7 @@ export function createSelect(args?: CreateSelectArgs) {
 
 	const open = writable(false);
 	const selected = writable(withDefaults.selected ?? null);
-	const selectedText = writable<string | null>(null);
+	const selectedText = writable<string | number | null>(null);
 	const activeTrigger = writable<HTMLElement | null>(null);
 
 	const ids = {

--- a/src/lib/builders/select/index.ts
+++ b/src/lib/builders/select/index.ts
@@ -157,6 +157,8 @@ export function createSelect(args?: CreateSelectArgs) {
 				role: 'option',
 				'aria-selected': $selected === value,
 				'data-selected': $selected === value ? '' : undefined,
+				'data-value': value,
+				'data-type': typeof value,
 				tabindex: 0,
 			};
 		};
@@ -251,7 +253,14 @@ export function createSelect(args?: CreateSelectArgs) {
 				| HTMLElement
 				| undefined;
 			if (selectedOption) {
-				selectedText.set(selectedOption.innerText);
+				const data = selectedOption.getAttribute('data-value');
+				if (data) {
+					if (selectedOption.getAttribute('data-type') === 'number') {
+						selectedText.set(+data);
+					} else {
+						selectedText.set(data);
+					}
+				}
 			}
 		});
 	});


### PR DESCRIPTION
This update is 2 fold:
1. Update selectedText store to take in a number
2. Option now sets 2 additional data-* attributes (value and type) which is used when setting selectedText
    - Value holds the option value
    - Type holds the value type (string, number

Testing:
- Passed in an array containing both strings and numbers
- Asserted type-ahead works with numbers
- Mornitored the reactivitey of selectedText to ensure it's correct