### PR TITLE
Remove md:max-h-none class from select menu example

### DIFF
--- a/src/routes/docs/builders/select/code.ignore-svelte
+++ b/src/routes/docs/builders/select/code.ignore-svelte
@@ -38,7 +38,7 @@
 	}
 	.menu {
 		@apply z-10 flex max-h-[300px] flex-col gap-2 overflow-y-auto;
-		@apply rounded-md bg-white p-1 lg:max-h-none;
+		@apply rounded-md bg-white p-1;
 	}
 	.option {
 		@apply relative cursor-pointer rounded-md py-1 pl-8 pr-4 text-neutral-800;

--- a/src/routes/docs/builders/select/preview.svelte
+++ b/src/routes/docs/builders/select/preview.svelte
@@ -42,7 +42,7 @@
 	}
 	.menu {
 		@apply z-10 flex max-h-[300px] flex-col gap-2 overflow-y-auto;
-		@apply rounded-md bg-white p-1 lg:max-h-none;
+		@apply rounded-md bg-white p-1;
 	}
 	.option {
 		@apply relative cursor-pointer rounded-md py-1 pl-8 pr-4 text-neutral-800;


### PR DESCRIPTION
This small PR fixes a style issue in the menu class for the select example, so it keeps its max size and show the scrollable section when a long list of elements are provided