### PR TITLE
refactor(select): label attr & unknown value

### DIFF
--- a/.changeset/quick-carpets-arrive.md
+++ b/.changeset/quick-carpets-arrive.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+refactor(select): label attr & unknown value

--- a/src/lib/builders/select/index.ts
+++ b/src/lib/builders/select/index.ts
@@ -14,7 +14,6 @@ import {
 } from '$lib/internal/helpers';
 import { sleep } from '$lib/internal/helpers/sleep';
 import type { Defaults } from '$lib/internal/types';
-import { tick } from 'svelte';
 import { derived, writable } from 'svelte/store';
 
 /**
@@ -33,7 +32,7 @@ export type CreateSelectArgs = {
 	arrowSize?: number;
 	required?: boolean;
 	disabled?: boolean;
-	selected?: string | number;
+	selected?: unknown;
 	name?: string;
 };
 
@@ -52,7 +51,7 @@ export function createSelect(args?: CreateSelectArgs) {
 	const options = writable(omit(withDefaults, 'selected'));
 
 	const open = writable(false);
-	const selected = writable(withDefaults.selected ?? null);
+	const selected = writable<unknown>(withDefaults.selected ?? null);
 	const selectedText = writable<string | number | null>(null);
 	const activeTrigger = writable<HTMLElement | null>(null);
 
@@ -121,26 +120,28 @@ export function createSelect(args?: CreateSelectArgs) {
 		}),
 	}));
 
-	type OptionArgs =
-		| {
-				value: string | number;
-		  }
-		| string
-		| number;
+	type OptionArgs = {
+		value: unknown;
+		label?: string;
+	};
 
 	const option = elementMultiDerived([selected], ([$selected], { attach }) => {
 		return (args: OptionArgs) => {
-			const value = typeof args === 'object' ? args.value : args;
+			const { value, label } = args;
 
-			attach('click', () => {
+			attach('click', (e) => {
+				const el = e.currentTarget as HTMLElement | null;
 				selected.set(value);
+				selectedText.set(label ?? el?.textContent ?? null);
 				open.set(false);
 			});
 
 			attach('keydown', (e) => {
+				const el = e.currentTarget as HTMLElement | null;
 				if (e.key === kbd.ENTER || e.key === kbd.SPACE) {
 					e.preventDefault();
 					selected.set(value);
+					selectedText.set(label ?? el?.textContent ?? null);
 					open.set(false);
 				}
 			});
@@ -159,8 +160,6 @@ export function createSelect(args?: CreateSelectArgs) {
 				role: 'option',
 				'aria-selected': $selected === value,
 				'data-selected': $selected === value ? '' : undefined,
-				'data-value': value,
-				'data-type': typeof value,
 				tabindex: 0,
 			};
 		};
@@ -244,27 +243,6 @@ export function createSelect(args?: CreateSelectArgs) {
 			// Hacky way to prevent the keydown event from triggering on the trigger
 			sleep(1).then(() => $activeTrigger.focus());
 		}
-	});
-
-	effect([menu], ([$menu]) => {
-		tick().then(() => {
-			const menuEl = getElementByMeltId($menu['data-melt-id']);
-			if (!menuEl) return;
-
-			const selectedOption = menuEl.querySelector('[role=option][data-selected]') as
-				| HTMLElement
-				| undefined;
-			if (selectedOption) {
-				const data = selectedOption.getAttribute('data-value');
-				if (data) {
-					if (selectedOption.getAttribute('data-type') === 'number') {
-						selectedText.set(+data);
-					} else {
-						selectedText.set(data);
-					}
-				}
-			}
-		});
 	});
 
 	const isSelected = derived([selected], ([$selected]) => {

--- a/src/routes/docs/builders/select/code.ignore-svelte
+++ b/src/routes/docs/builders/select/code.ignore-svelte
@@ -12,7 +12,6 @@
 
 <button class="trigger" {...$trigger} aria-label="Food">
 	{$selectedText || 'Select an option'}
-
 	<ChevronDown />
 </button>
 
@@ -20,7 +19,7 @@
 	{#each Object.entries(options) as [key, arr]}
 		<li class="label">{key}</li>
 		{#each arr as item}
-			<li class="option" {...$option(item)}>
+			<li class="option" {...$option({ value: item })}>
 				{#if $isSelected(item)}
 					<div class="check">
 						<Check />

--- a/src/routes/docs/builders/select/preview.svelte
+++ b/src/routes/docs/builders/select/preview.svelte
@@ -15,7 +15,6 @@
 <Docs.PreviewWrapper>
 	<button class="trigger" {...$trigger} aria-label="Food">
 		{$selectedText || 'Select an option'}
-
 		<ChevronDown />
 	</button>
 

--- a/src/routes/docs/builders/select/preview.svelte
+++ b/src/routes/docs/builders/select/preview.svelte
@@ -23,7 +23,7 @@
 		{#each Object.entries(options) as [key, arr]}
 			<li class="label">{key}</li>
 			{#each arr as item}
-				<li class="option" {...$option(item)}>
+				<li class="option" {...$option({ value: item })}>
 					{#if $isSelected(item)}
 						<div class="check">
 							<Check />


### PR DESCRIPTION
## Description
- Adds optional label attribute to select
	- When label is not present, uses textContent
- Sets type of selected to `unknown`

Motivations for this are: It's more intuitive to not pass in a label, coming from native select. But sometimes you'd want to override this, so we allow the label attribute to be set. This will be documented accordingly.

@huntabyte @geerew would love your thoughts on this!

Closes #35 & #39 
