### PR TITLE
feat: add color transition for switch component

### DIFF
--- a/src/routes/docs/builders/switch/preview.svelte
+++ b/src/routes/docs/builders/switch/preview.svelte
@@ -12,7 +12,7 @@
 			<button
 				{...$root}
 				class="relative h-6 w-11 cursor-default rounded-full bg-magnum-800 outline-none
-			focus:ring focus:ring-magnum-400 data-[state=checked]:bg-magnum-950"
+				transition-colors focus:ring focus:ring-magnum-400 data-[state=checked]:bg-magnum-950"
 				id="airplane-mode"
 			>
 				<span


### PR DESCRIPTION
This pull request adds just a small enhancement to the switch component by including the `transition-colors` class, which enables a smooth transition effect for the background color change.