### PR TITLE
fix: add transition-colors class to code.ignore-svelte

### DIFF
--- a/src/routes/docs/builders/switch/code.ignore-svelte
+++ b/src/routes/docs/builders/switch/code.ignore-svelte
@@ -10,7 +10,7 @@
 		<label class="pr-4 leading-none text-white" for="airplane-mode"> Airplane mode </label>
 		<button
 			{...$root}
-			class="relative h-6 w-11 cursor-default rounded-full bg-magnum-800 outline-none
+			class="relative h-6 w-11 cursor-default rounded-full transition-colors bg-magnum-800 outline-none
 			focus:ring focus:ring-magnum-400 data-[state=checked]:bg-magnum-950"
 			id="airplane-mode"
 		>


### PR DESCRIPTION
Added the `transition-colors` class to `code.ignore-svelte` in the switch component.