### PR TITLE
improve: popper options/config

### DIFF
--- a/src/lib/internal/actions/popper/popper.types.ts
+++ b/src/lib/internal/actions/popper/popper.types.ts
@@ -1,10 +1,16 @@
-import type { ClickOutsideConfig, FloatingConfig, FocusTrapConfig } from '$lib/internal/actions';
+import type {
+	ClickOutsideConfig,
+	FloatingConfig,
+	FocusTrapConfig,
+	PortalConfig,
+} from '$lib/internal/actions';
 import type { Writable } from 'svelte/store';
 
 export type PopperConfig = {
 	floating?: FloatingConfig;
 	focusTrap?: FocusTrapConfig | null;
-	clickOutside?: ClickOutsideConfig;
+	clickOutside?: ClickOutsideConfig | null;
+	portal?: PortalConfig | null;
 };
 
 export type PopperArgs = {


### PR DESCRIPTION
This PR gives us the ability to disable the `useClickOutside` and `usePortal` actions for the internal `usePopper` action. It also enables the popper to accept options for the portal, defaulting to `'body'` if an element or other string isn't passed.