### PR TITLE
fix: Adjusts `typeVerisons` map to fix incorrect auto-imported path

### DIFF
--- a/.changeset/new-trees-eat.md
+++ b/.changeset/new-trees-eat.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+fix: Adjusts `typeVerisons` map to fix incorrect auto-imported path

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 	},
 	"typesVersions": {
 		">4.0": {
-			"index": [
+			"index.d.ts": [
 				"./dist/index.d.ts"
 			],
 			"internal/*": [


### PR DESCRIPTION
**The issue:** packages that are auto-imported will always get `/index` appended to the end of their paths, which in most cases, isn't a valid path and will lead to runtime errors if left alone. 

Here's a quick example if you've never ran into this before:
![img](https://i.imgur.com/6wERuiy.gif)

This has become a _very_ common issue across Svelte packages because of SvelteKit's ["Packaging"](https://kit.svelte.dev/docs/packaging#typescript) documentation incorrectly stating to add `index`, rather than `index.d.ts`, to the `typeVersions` map. I think it may very well be a typo on their part.

We've [experienced this issue](https://github.com/skeletonlabs/skeleton/issues/1581) over at Skeleton and [added this fix](https://github.com/skeletonlabs/skeleton/pull/1587) not too long ago and it's been working great ever since!