### PR TITLE
Update copy in +page.svelte

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,7 +7,7 @@
 	let copied = false;
 	let copytimeout: ReturnType<typeof setTimeout>;
 	function copyInstallCommand() {
-		navigator.clipboard.writeText(`npm install melt-ui`);
+		navigator.clipboard.writeText(`npm install @melt-ui/svelte`);
 		copied = true;
 		clearTimeout(copytimeout);
 		copytimeout = setTimeout(() => {


### PR DESCRIPTION
Fixes the copy button on the home page to npm install @melt-ui/svelte