### PR TITLE
Fix pagination issue when fewer than 7 pages

### DIFF
--- a/src/lib/builders/pagination/index.ts
+++ b/src/lib/builders/pagination/index.ts
@@ -66,25 +66,34 @@ export function createPagination(args: CreatePaginationArgs) {
 		const firstItemWithSiblings = 3 + siblingCount;
 		const lastItemWithSiblings = $totalPages - 3 - siblingCount;
 
-		if ($page < firstItemWithSiblings) {
-			for (let i = 2; i <= firstItemWithSiblings + siblingCount; i++) {
-				addPage(i);
-			}
-			addEllipsis();
-		} else if ($page > lastItemWithSiblings) {
-			addEllipsis();
-			for (let i = lastItemWithSiblings - siblingCount + 1; i <= $totalPages - 1; i++) {
+		if ($totalPages <= 6) {
+			// 6 or fewer pages. Show them all
+			for (let i = 2; i <= $totalPages - 1; i++) {
 				addPage(i);
 			}
 		} else {
-			addEllipsis();
-			for (let i = $page - siblingCount; i <= $page + siblingCount; i++) {
-				addPage(i);
+			// 7 or more pages
+			if ($page < firstItemWithSiblings) {
+				for (let i = 2; i <= firstItemWithSiblings + siblingCount; i++) {
+					addPage(i);
+				}
+				addEllipsis();
+			} else if ($page > lastItemWithSiblings) {
+				addEllipsis();
+				for (let i = lastItemWithSiblings - siblingCount + 1; i <= $totalPages - 1; i++) {
+					addPage(i);
+				}
+			} else {
+				addEllipsis();
+				for (let i = $page - siblingCount; i <= $page + siblingCount; i++) {
+					addPage(i);
+				}
+				addEllipsis();
 			}
-			addEllipsis();
 		}
 
-		addPage($totalPages);
+		if ($totalPages > 1) addPage($totalPages);
+
 		return res;
 	});
 


### PR DESCRIPTION
There is a bug when there are fewer than 7 pages. This PR fixes this

When there are 1 - 6 pages, all the pages will show for example 

`1 2 3 4 5 6` if there are 6 pages 
`1` is there is only 1 page

when there are 7 pages or more, the original functionality takes over