### PR TITLE
Documentation for toggle and allow it disabled state to be changed

### DIFF
--- a/.changeset/thirty-numbers-drive.md
+++ b/.changeset/thirty-numbers-drive.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+feat(toggle): allow disabled state to be changed

--- a/src/lib/builders/toggle/index.ts
+++ b/src/lib/builders/toggle/index.ts
@@ -28,5 +28,6 @@ export function createToggle(args: CreateToggleArgs = {}) {
 	return {
 		toggle,
 		pressed,
+		disabled,
 	};
 }

--- a/src/routes/docs/builders/toggle/(snippets)/controlled.ignore-svelte
+++ b/src/routes/docs/builders/toggle/(snippets)/controlled.ignore-svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { createToggle } from '@melt-ui/svelte';
+
+	export let pressed = true;
+	export let disabled = false;
+
+	const { pressed: pressedStore, disabled: disabledStore } = createToggle({
+		pressed,
+		disabled,
+	});
+
+	$: pressedStore.set(pressed);
+	pressedStore.subscribe((v) => (pressed = v));
+
+	$: disabledStore.set(pressed);
+	disabledStore.subscribe((v) => (disabled = v));
+</script>

--- a/src/routes/docs/builders/toggle/(snippets)/disable.ignore-svelte
+++ b/src/routes/docs/builders/toggle/(snippets)/disable.ignore-svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import { createToggle } from '@melt-ui/svelte';
+
+	const { toggle, pressed, disabled } = createToggle({
+		disabled: true,
+	});
+	// or
+	disabled.set(true);
+	// or
+	disabled.update((d) => !d);
+</script>

--- a/src/routes/docs/builders/toggle/(snippets)/index.ts
+++ b/src/routes/docs/builders/toggle/(snippets)/index.ts
@@ -1,0 +1,7 @@
+import disable from './disable.ignore-svelte?raw';
+import controlled from './controlled.ignore-svelte?raw';
+
+export const snippets = {
+	disable,
+	controlled,
+};

--- a/src/routes/docs/builders/toggle/+page.svelte
+++ b/src/routes/docs/builders/toggle/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Docs } from '$routes/(components)';
+	import { snippets } from './(snippets)';
 	import code from './code.ignore-svelte?raw';
 	import Preview from './preview.svelte';
 </script>
@@ -11,4 +12,63 @@
 
 <Docs.CodeBlock {code} />
 
-<Docs.Construction />
+<Docs.H2>Features</Docs.H2>
+<Docs.Ul>
+	<Docs.Li>Full keyboard navigation</Docs.Li>
+	<Docs.Li>Can be controlled or uncontrolled</Docs.Li>
+</Docs.Ul>
+
+<Docs.H2>Anatomy</Docs.H2>
+<Docs.Ul>
+	<Docs.Li><b>Toggle:</b> The trigger for the toggle</Docs.Li>
+</Docs.Ul>
+
+<Docs.H2>Usage</Docs.H2>
+<Docs.P>
+	To create a toggle, use the <Docs.Code>createToggle</Docs.Code> builder function. Follow the anatomy
+	or the example above to create your toggle.
+</Docs.P>
+
+<Docs.H3>Disabling the toggle</Docs.H3>
+<Docs.P>
+	To disable a the toggle,, set the <Docs.Code>disabled</Docs.Code> argument as
+	<Docs.Code>true</Docs.Code>.
+</Docs.P>
+<Docs.CodeBlock collapsible={false} code={snippets.disable} />
+
+<Docs.H3>Controlled access</Docs.H3>
+<Docs.P>
+	To programmatically control the Toggle, you can directly set the <Docs.Code>pressed</Docs.Code> store.
+	you can also directly set the <Docs.Code>disabled</Docs.Code> store.
+</Docs.P>
+<Docs.CodeBlock collapsible={false} code={snippets.controlled} />
+
+<Docs.H2>Accessibility</Docs.H2>
+<Docs.A href="https://www.w3.org/WAI/ARIA/apg/patterns/button/">WAI-ARIA pattern</Docs.A>
+
+<Docs.H3>Keyboard Interactions</Docs.H3>
+
+<Docs.P>
+	When the toggle has focus, pressing <Docs.Kbd>Enter</Docs.Kbd> or <Docs.Kbd>Space</Docs.Kbd> key changes
+	the state of the toggle.
+</Docs.P>
+
+<Docs.H2>API Reference</Docs.H2>
+<Docs.API
+	schema={{
+		title: 'createToggle',
+		description: 'The object you pass into createToggle. Optional.',
+		args: [
+			{
+				label: 'pressed',
+				type: 'boolean',
+				default: false,
+			},
+			{
+				label: 'disabled',
+				type: 'boolean',
+				default: false,
+			},
+		],
+	}}
+/>


### PR DESCRIPTION
Updates documentation for [toggle](https://www.melt-ui.com/docs/builders/toggle), so it is up the same standard as `Accordion` and `Checkbox`

Also fixes #81 so it possible to disable the toggle after creation