### PR TITLE
fix: avatar description

### DIFF
--- a/src/routes/docs/builders/avatar/+page.svelte
+++ b/src/routes/docs/builders/avatar/+page.svelte
@@ -12,7 +12,7 @@
 </script>
 
 <Docs.H1>Avatar</Docs.H1>
-<Docs.P>An image element with a fallback for representing the user.</Docs.P>
+<Docs.Description>An image element with a fallback for representing the user.</Docs.Description>
 
 <Docs.Preview {...data.preview} />
 


### PR DESCRIPTION
The description text of the avatar was using the `Docs.P` component when it should be using the `Docs.Description` like the rest of the docs.