### PR TITLE
fix: docs scrollbar styling

### DIFF
--- a/src/app.postcss
+++ b/src/app.postcss
@@ -36,3 +36,30 @@ code:not(pre > code) {
 		color: theme('colors.zinc.300');
 	}
 }
+
+/* Firefox */
+* {
+	scrollbar-width: thin;
+	scrollbar-color: theme('colors.neutral.700') transparent;
+}
+
+/* Other browsers */
+*::-webkit-scrollbar {
+	width: 1rem;
+}
+
+*::-webkit-scrollbar-track {
+	background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+	background: theme('colors.neutral.700');
+	background-clip: padding-box;
+	border-radius: 0.5rem;
+	border: 0.25rem solid transparent;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+	background: theme('colors.neutral.600');
+	background-clip: padding-box;
+}

--- a/src/app.postcss
+++ b/src/app.postcss
@@ -63,3 +63,7 @@ code:not(pre > code) {
 	background: theme('colors.neutral.600');
 	background-clip: padding-box;
 }
+
+*::-webkit-scrollbar-corner {
+	background: transparent;
+}


### PR DESCRIPTION
This fixes a theming issue where the scrollbars appeared too light compared to everything else and felt distracting.
This also fixes a minor problem where the example box corners were not rounded on the right side.

The background is left transparent. The scrollbar-thumb uses a lighter shade of the same color palette as the body.