### PR TITLE
refactor (select): align select with menu & share typeahead

### DIFF
--- a/.changeset/modern-drinks-think.md
+++ b/.changeset/modern-drinks-think.md
@@ -1,0 +1,10 @@
+---
+"@melt-ui/svelte": minor
+---
+
+Select improvements:
+- Improved Typeahead support for repeated characters to cycle through elements with that same character.
+- Shared typeahead with DropdownMenu & Select
+- Added createGroup builder returned from createSelect to assist with creating accessible option groups.
+- Updated preview/example
+- Add loop option to loop through items

--- a/src/lib/internal/helpers/array.ts
+++ b/src/lib/internal/helpers/array.ts
@@ -26,3 +26,12 @@ export function prev<T>(array: T[], index: number, loop = true): T | undefined {
 export function last<T>(array: T[]): T | undefined {
 	return array[array.length - 1];
 }
+
+/**
+ * Wraps an array around itself at a given start index
+ * Example: `wrapArray(['a', 'b', 'c', 'd'], 2) === ['c', 'd', 'a', 'b']`
+ * Reference: https://github.com/radix-ui/primitives
+ */
+export function wrapArray<T>(array: T[], startIndex: number) {
+	return array.map((_, index) => array[(startIndex + index) % array.length]);
+}

--- a/src/routes/docs/builders/select/(examples)/(preview)/preview.svelte
+++ b/src/routes/docs/builders/select/(examples)/(preview)/preview.svelte
@@ -3,11 +3,11 @@
 	import Check from '~icons/lucide/check';
 	import ChevronDown from '~icons/lucide/chevron-down';
 
-	const { label, trigger, menu, option, isSelected } = createSelect();
+	const { label, trigger, menu, option, isSelected, createGroup } = createSelect();
 
 	const options = {
-		fruits: ['Apple', 'Banana', 'Pineapple'],
-		vegetables: ['Broccoli', 'Potato', 'Tomato'],
+		sweet: ['Caramel', 'Chocolate', 'Strawberry', 'Cookies & Cream'],
+		savory: ['Basil', 'Bacon', 'Rosemary', 'Balsamic Fig'],
 	};
 </script>
 
@@ -16,28 +16,32 @@
 	<ChevronDown />
 </button>
 
-<ul class="menu" {...$menu} use:menu.action>
+<div class="menu" {...$menu} use:menu.action>
 	{#each Object.entries(options) as [key, arr]}
-		<li class="label">{key}</li>
-		{#each arr as item}
-			<li class="option" {...$option({ value: item, label: item })} use:option.action>
-				{#if $isSelected(item)}
-					<div class="check">
-						<Check />
-					</div>
-				{/if}
-				{item}
-			</li>
-		{/each}
+		{@const { group, label } = createGroup()}
+		<div {...group}>
+			<div class="label" {...label}>{key}</div>
+			{#each arr as item}
+				<div class="option" {...$option({ value: item, label: item })} use:option.action>
+					{#if $isSelected(item)}
+						<div class="check">
+							<Check />
+						</div>
+					{/if}
+					{item}
+				</div>
+			{/each}
+		</div>
 	{/each}
-</ul>
+</div>
 
 <style lang="postcss">
 	.label {
-		@apply py-1 pl-4 pr-4 font-semibold capitalize text-neutral-800;
+		@apply py-1 pl-4 pr-4  font-semibold capitalize text-neutral-800;
 	}
+
 	.menu {
-		@apply z-10 flex max-h-[360px] flex-col overflow-y-auto;
+		@apply z-10 flex max-h-[360px]  flex-col overflow-y-auto;
 		@apply rounded-md bg-white p-1;
 		@apply ring-0 !important;
 	}
@@ -48,11 +52,11 @@
 		@apply data-[selected]:bg-magnum-100 data-[selected]:text-magnum-900;
 	}
 	.trigger {
-		@apply flex h-10 w-[180px] items-center justify-between rounded-md bg-white px-3;
+		@apply flex h-10 min-w-[220px] items-center justify-between rounded-md bg-white px-3;
 		@apply py-2 text-magnum-700 transition-opacity hover:opacity-90;
 	}
 	.check {
-		@apply absolute left-2 top-1/2 text-magnum-500;
+		@apply absolute left-2 top-1/2 z-20 text-magnum-500;
 		translate: 0 calc(-50% + 1px);
 	}
 </style>

--- a/src/routes/docs/builders/select/(examples)/(preview)/preview.svelte
+++ b/src/routes/docs/builders/select/(examples)/(preview)/preview.svelte
@@ -37,16 +37,19 @@
 		@apply py-1 pl-4 pr-4 font-semibold capitalize text-neutral-800;
 	}
 	.menu {
-		@apply z-10 flex max-h-[360px] flex-col gap-2 overflow-y-auto;
+		@apply z-10 flex max-h-[360px] flex-col overflow-y-auto;
 		@apply rounded-md bg-white p-1;
+		@apply ring-0 !important;
 	}
 	.option {
 		@apply relative cursor-pointer rounded-md py-1 pl-8 pr-4 text-neutral-800;
-		@apply focus:bg-magnum-100 focus:text-magnum-700;
+		@apply focus:z-10 focus:text-magnum-700;
+		@apply data-[highlighted]:bg-magnum-50 data-[highlighted]:text-magnum-900;
+		@apply data-[selected]:bg-magnum-100 data-[selected]:text-magnum-900;
 	}
 	.trigger {
 		@apply flex h-10 w-[180px] items-center justify-between rounded-md bg-white px-3;
-		@apply py-2 text-magnum-700  hover:opacity-75;
+		@apply py-2 text-magnum-700 transition-opacity hover:opacity-90;
 	}
 	.check {
 		@apply absolute left-2 top-1/2 text-magnum-500;

--- a/src/routes/docs/builders/select/(examples)/(preview)/tailwind.ignore-svelte
+++ b/src/routes/docs/builders/select/(examples)/(preview)/tailwind.ignore-svelte
@@ -2,11 +2,11 @@
 	import { createSelect } from '@melt-ui/svelte';
 	import { Check, ChevronDown } from 'icons';
 
-	const { label, trigger, menu, option, isSelected } = createSelect();
+	const { label, trigger, menu, option, isSelected, createGroup } = createSelect();
 
 	const options = {
-		fruits: ['Apple', 'Banana', 'Pineapple'],
-		vegetables: ['Broccoli', 'Potato', 'Tomato'],
+		sweet: ['Caramel', 'Chocolate', 'Strawberry', 'Cookies & Cream'],
+		savory: ['Basil', 'Bacon', 'Rosemary', 'Balsamic Fig'],
 	};
 </script>
 
@@ -15,40 +15,47 @@
 	<ChevronDown />
 </button>
 
-<ul class="menu" {...$menu} use:menu.action>
+<div class="menu" {...$menu} use:menu.action>
 	{#each Object.entries(options) as [key, arr]}
-		<li class="label">{key}</li>
-		{#each arr as item}
-			<li class="option" {...$option({ value: item, label: item })} use:option.action>
-				{#if $isSelected(item)}
-					<div class="check">
-						<Check />
-					</div>
-				{/if}
-				{item}
-			</li>
-		{/each}
+		{@const { group, label } = createGroup()}
+		<div {...group}>
+			<div class="label" {...label}>{key}</div>
+			{#each arr as item}
+				<div class="option" {...$option({ value: item, label: item })} use:option.action>
+					{#if $isSelected(item)}
+						<div class="check">
+							<Check />
+						</div>
+					{/if}
+					{item}
+				</div>
+			{/each}
+		</div>
 	{/each}
-</ul>
+</div>
 
 <style lang="postcss">
 	.label {
-		@apply py-1 pl-4 pr-4 font-semibold capitalize text-neutral-800;
+		@apply py-1 pl-4 pr-4  font-semibold capitalize text-neutral-800;
 	}
+
 	.menu {
-		@apply z-10 flex max-h-[360px] flex-col gap-2 overflow-y-auto;
+		@apply z-10 flex max-h-[360px]  flex-col overflow-y-auto;
 		@apply rounded-md bg-white p-1;
+		@apply ring-0 !important;
 	}
 	.option {
 		@apply relative cursor-pointer rounded-md py-1 pl-8 pr-4 text-neutral-800;
-		@apply focus:bg-magnum-100 focus:text-magnum-700;
+		@apply focus:z-10 focus:text-magnum-700;
+		@apply data-[highlighted]:bg-magnum-50 data-[highlighted]:text-magnum-900;
+		@apply data-[selected]:bg-magnum-100 data-[selected]:text-magnum-900;
 	}
 	.trigger {
-		@apply flex h-10 w-[180px] items-center justify-between rounded-md bg-white px-3;
-		@apply py-2 text-magnum-700  hover:opacity-75;
+		@apply flex h-10 min-w-[220px] items-center justify-between rounded-md bg-white px-3;
+		@apply py-2 text-magnum-700 transition-opacity hover:opacity-90;
 	}
 	.check {
-		@apply absolute left-2 top-1/2 text-magnum-500;
+		@apply absolute left-2 top-1/2 z-20 text-magnum-500;
 		translate: 0 calc(-50% + 1px);
 	}
 </style>

--- a/src/routes/docs/builders/select/+page.svelte
+++ b/src/routes/docs/builders/select/+page.svelte
@@ -35,6 +35,8 @@
 <Docs.API schema={schemas.builder} />
 <Docs.API schema={schemas.trigger} />
 <Docs.API schema={schemas.option} />
+<Docs.API schema={schemas.group} />
+<Docs.API schema={schemas.separator} />
 
 <Docs.H2>Accessibility</Docs.H2>
 <Docs.P>

--- a/src/routes/docs/builders/select/+page.svelte
+++ b/src/routes/docs/builders/select/+page.svelte
@@ -15,7 +15,7 @@
 
 <Docs.H1>Select</Docs.H1>
 <Docs.Description>
-	Displays a list of options for the user to pick from—triggered by a button.
+	Presents a selection of choices to the user, activated by a button.
 </Docs.Description>
 
 <Docs.Preview {...data.preview} />

--- a/src/routes/docs/builders/select/schemas.ts
+++ b/src/routes/docs/builders/select/schemas.ts
@@ -75,6 +75,16 @@ const arrow: APISchema = {
 	],
 };
 
+const separator: APISchema = {
+	title: 'Separator',
+	description: 'An optional separator element',
+};
+
+const group: APISchema = {
+	title: 'createGroup',
+	description: 'An optional builder used to group options together.',
+};
+
 const keyboard: APISchema = {
 	title: 'Keyboard Interactions',
 	description: '',
@@ -111,5 +121,7 @@ export const schemas = {
 	trigger,
 	option,
 	arrow,
+	group,
+	separator,
 	keyboard,
 };

--- a/src/routes/docs/builders/select/schemas.ts
+++ b/src/routes/docs/builders/select/schemas.ts
@@ -31,6 +31,11 @@ const builder: APISchema = {
 			type: 'boolean',
 			default: true,
 		},
+		{
+			label: 'loop',
+			type: 'boolean',
+			default: false,
+		},
 	],
 };
 

--- a/src/routes/docs/builders/select/schemas.ts
+++ b/src/routes/docs/builders/select/schemas.ts
@@ -26,6 +26,11 @@ const builder: APISchema = {
 			label: 'name',
 			type: 'string',
 		},
+		{
+			label: 'preventScroll',
+			type: 'boolean',
+			default: true,
+		},
 	],
 };
 


### PR DESCRIPTION
Refactor / enhance the `Select` builder to better align/share functionality with the `DropdownMenu` where applicable. 

- [x] Improved Typeahead support for repeated characters to cycle through elements with that same character.
- [x] Shared typeahead with `DropdownMenu` & `Select`
- [x] Added `createGroup` builder returned from `createSelect` to assist with creating accessible option groups.
- [x] Updated preview/example
- [x] Add `loop` option to loop through items 

Closes: #114 