### PR TITLE
fix: prevent scroll on dropdown option

### DIFF
--- a/src/lib/builders/dropdown-menu/index.ts
+++ b/src/lib/builders/dropdown-menu/index.ts
@@ -16,7 +16,7 @@ import {
 	hiddenAction,
 	createTypeaheadSearch,
 	handleRovingFocus,
-    removeScroll,
+	removeScroll,
 } from '$lib/internal/helpers';
 import type { Defaults, TextDirection } from '$lib/internal/types';
 import { onMount, tick } from 'svelte';
@@ -93,7 +93,7 @@ const defaults = {
 	positioning: {
 		placement: 'bottom',
 	},
-    preventScroll: true,
+	preventScroll: true,
 } satisfies Defaults<CreateDropdownMenuArgs>;
 
 export function createDropdownMenu(args?: CreateDropdownMenuArgs) {
@@ -999,13 +999,13 @@ export function createDropdownMenu(args?: CreateDropdownMenuArgs) {
 	 * -----------------------------------------------------------------------------------------------*/
 
 	effect([rootOpen, rootActiveTrigger], ([$rootOpen, $rootActiveTrigger]) => {
-        const unsubs: Array<() => void> = [];
+		const unsubs: Array<() => void> = [];
 		if (!isBrowser) return;
-        const $options = get(rootOptions);
+		const $options = get(rootOptions);
 
-        if ($rootOpen && $options.preventScroll) {
-                unsubs.push(removeScroll())
-        }
+		if ($rootOpen && $options.preventScroll) {
+			unsubs.push(removeScroll());
+		}
 
 		if (!$rootOpen && $rootActiveTrigger) {
 			handleRovingFocus($rootActiveTrigger);
@@ -1029,9 +1029,9 @@ export function createDropdownMenu(args?: CreateDropdownMenuArgs) {
 				}
 			}
 		});
-        return () => {
-            unsubs.forEach(unsub => unsub())
-        }
+		return () => {
+			unsubs.forEach((unsub) => unsub());
+		};
 	});
 
 	onMount(() => {

--- a/src/lib/builders/dropdown-menu/index.ts
+++ b/src/lib/builders/dropdown-menu/index.ts
@@ -37,7 +37,7 @@ const SUB_CLOSE_KEYS: Record<TextDirection, string[]> = {
 };
 
 export type CreateDropdownMenuArgs = {
-	/*
+	/**
 	 * Options for positioning the popover menu.
 	 *
 	 * @default { placement: 'bottom' }

--- a/src/routes/docs/builders/dropdown-menu/schemas.ts
+++ b/src/routes/docs/builders/dropdown-menu/schemas.ts
@@ -14,6 +14,11 @@ const builder: APISchema = {
 			type: 'number',
 			default: 8,
 		},
+		{
+			label: 'preventScroll',
+			type: 'boolean',
+			default: true,
+		},
 	],
 };
 


### PR DESCRIPTION
Exposes a `preventScroll` option to the `createDropdownMenu` builder which is set to `true` by default to prevent scrolling while the dropdown is open.

Closes: #117 