### PR TITLE
Fix tag-input focus

### DIFF
--- a/.changeset/friendly-houses-tease.md
+++ b/.changeset/friendly-houses-tease.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+Fix tag-input focus

--- a/src/lib/builders/tags-input/create.ts
+++ b/src/lib/builders/tags-input/create.ts
@@ -30,7 +30,7 @@ const defaults = {
 } satisfies Defaults<CreateTagsInputArgs>;
 
 type TagsInputParts = '' | 'tag' | 'delete-trigger' | 'edit' | 'input';
-const { name, selector } = createElHelpers<TagsInputParts>('tags-input');
+const { name, attribute, selector } = createElHelpers<TagsInputParts>('tags-input');
 
 export function createTagsInput(args?: CreateTagsInputArgs) {
 	const withDefaults = { ...defaults, ...args } as CreateTagsInputArgs;
@@ -189,6 +189,21 @@ export function createTagsInput(args?: CreateTagsInputArgs) {
 				'data-disabled': $options.disabled ? true : undefined,
 				disabled: $options.disabled,
 			} as const;
+		},
+		action: (node: HTMLElement) => {
+			const unsub = executeCallbacks(
+				addEventListener(node, 'mousedown', (e) => {
+					// Focus on input when root is the target
+					if ((e.target as HTMLElement).hasAttribute(attribute())) {
+						e.preventDefault();
+						focusInput(ids.input);
+					}
+				})
+			);
+
+			return {
+				destroy: unsub,
+			};
 		},
 	});
 

--- a/src/lib/internal/helpers/builder.ts
+++ b/src/lib/internal/helpers/builder.ts
@@ -233,11 +233,13 @@ export type BuilderReturn<
 
 export function createElHelpers<Part extends string = string>(prefix: string) {
 	const name = (part?: Part) => (part ? `${prefix}-${part}` : prefix);
+	const attribute = (part?: Part) => `data-melt-${prefix}${part ? `-${part}` : ''}`;
 	const selector = (part?: Part) => `[data-melt-${prefix}${part ? `-${part}` : ''}]`;
 	const getEl = (part?: Part) => document.querySelector(selector(part));
 
 	return {
 		name,
+		attribute,
 		selector,
 		getEl,
 	};

--- a/src/routes/docs/builders/tags-input/(examples)/(preview)/tailwind.svelte
+++ b/src/routes/docs/builders/tags-input/(examples)/(preview)/tailwind.svelte
@@ -11,6 +11,7 @@
 <div class="flex flex-col items-start justify-center gap-2">
 	<div
 		{...$root}
+		use:root
 		class="flex min-w-[280px] flex-row flex-wrap gap-2.5 rounded-md bg-white px-3 py-2 text-magnum-700
 		focus-within:ring focus-within:ring-magnum-400"
 	>


### PR DESCRIPTION
- Add new `attrribute` helper function to `createElHelpers()` which returns the full name (without the selectors)
- Fixes focusing on input when the $root is selected