### PR TITLE
#183 - fix grail-ui link according to grail-ui docs

### DIFF
--- a/src/docs/content/introduction.md
+++ b/src/docs/content/introduction.md
@@ -84,5 +84,5 @@ Some of the project's we've been inspired by in no particular order:
 
 - Zag - [https://zagjs.com](https://zagjs.com)
 - Radix UI - [https://radix-ui.com](https://radix-ui.com)
-- Grail UI - [https://grail-ui.com](https://grail-ui.com)
+- Grail UI - [https://grail-ui.vercel.app](https://grail-ui.vercel.app)
 - Skeleton - [https://skeleton.dev](https://skeleton.dev)


### PR DESCRIPTION
Swapped out the incorrect grail-ui.com link for [grail-ui.vercel.app](https://grail-ui.vercel.app/) according to the [grail-ui-docs](https://github.com/grail-ui/grail-ui).