### PR TITLE
[Select/Combobox] Support PageUp + PageDown keyboard controls

### DIFF
--- a/.changeset/cuddly-turtles-develop.md
+++ b/.changeset/cuddly-turtles-develop.md
@@ -1,0 +1,6 @@
+---
+'@melt-ui/svelte': minor
+---
+
+[Select] Support PageUp and PageDown keyboard navigation.
+[Combobox] Support PageUp and PageDown keyboard navigation.

--- a/.changeset/cuddly-turtles-develop.md
+++ b/.changeset/cuddly-turtles-develop.md
@@ -2,5 +2,5 @@
 '@melt-ui/svelte': minor
 ---
 
-[Select] Support PageUp and PageDown keyboard navigation.
-[Combobox] Support PageUp and PageDown keyboard navigation.
+[Select] Support <kbd>Page Up</kbd> and <kbd>Page Down</kbd> keyboard navigation.
+[Combobox] Support <kbd>Page Up</kbd> and <kbd>Page Down</kbd> keyboard navigation.

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,6 +3,9 @@ node_modules
 /build
 /.svelte-kit
 /package
+/coverage
+vite.config.js.timestamp-*
+vite.config.ts.timestamp-*
 .env
 .env.*
 !.env.example

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,68 +10,68 @@ import { defineConfig, devices } from '@playwright/test';
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
-  testDir: './e2e',
-  /* Run tests in files in parallel */
-  fullyParallel: true,
-  /* Fail the build on CI if you accidentally left test.only in the source code. */
-  forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
-  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
-  use: {
-    /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://127.0.0.1:3000',
+	testDir: './e2e',
+	/* Run tests in files in parallel */
+	fullyParallel: true,
+	/* Fail the build on CI if you accidentally left test.only in the source code. */
+	forbidOnly: !!process.env.CI,
+	/* Retry on CI only */
+	retries: process.env.CI ? 2 : 0,
+	/* Opt out of parallel tests on CI. */
+	workers: process.env.CI ? 1 : undefined,
+	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
+	reporter: 'html',
+	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+	use: {
+		/* Base URL to use in actions like `await page.goto('/')`. */
+		// baseURL: 'http://127.0.0.1:3000',
 
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
-  },
+		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+		trace: 'on-first-retry',
+	},
 
-  /* Configure projects for major browsers */
-  projects: [
-    {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
-    },
+	/* Configure projects for major browsers */
+	projects: [
+		{
+			name: 'chromium',
+			use: { ...devices['Desktop Chrome'] },
+		},
 
-    {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
-    },
+		{
+			name: 'firefox',
+			use: { ...devices['Desktop Firefox'] },
+		},
 
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
-    },
+		{
+			name: 'webkit',
+			use: { ...devices['Desktop Safari'] },
+		},
 
-    /* Test against mobile viewports. */
-    // {
-    //   name: 'Mobile Chrome',
-    //   use: { ...devices['Pixel 5'] },
-    // },
-    // {
-    //   name: 'Mobile Safari',
-    //   use: { ...devices['iPhone 12'] },
-    // },
+		/* Test against mobile viewports. */
+		// {
+		//   name: 'Mobile Chrome',
+		//   use: { ...devices['Pixel 5'] },
+		// },
+		// {
+		//   name: 'Mobile Safari',
+		//   use: { ...devices['iPhone 12'] },
+		// },
 
-    /* Test against branded browsers. */
-    // {
-    //   name: 'Microsoft Edge',
-    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
-    // },
-    // {
-    //   name: 'Google Chrome',
-    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
-    // },
-  ],
+		/* Test against branded browsers. */
+		// {
+		//   name: 'Microsoft Edge',
+		//   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+		// },
+		// {
+		//   name: 'Google Chrome',
+		//   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+		// },
+	],
 
-  /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'npm run start',
-  //   url: 'http://127.0.0.1:3000',
-  //   reuseExistingServer: !process.env.CI,
-  // },
+	/* Run your local dev server before starting the tests */
+	// webServer: {
+	//   command: 'npm run start',
+	//   url: 'http://127.0.0.1:3000',
+	//   reuseExistingServer: !process.env.CI,
+	// },
 });

--- a/src/docs/previews/accordion/main/tailwind.svelte
+++ b/src/docs/previews/accordion/main/tailwind.svelte
@@ -38,9 +38,9 @@
 					id={i === 0 ? 'accordion-trigger' : undefined}
 					{...$trigger(id)}
 					use:trigger
-					class="flex h-12 flex-1 cursor-pointer items-center text-magnum-700 justify-between bg-white
-                 px-5 text-base font-medium leading-none
-                 transition-colors hover:bg-opacity-95 focus:!ring-0 border-b border-b-magnum-700
+					class="flex h-12 flex-1 cursor-pointer items-center justify-between border-b border-b-magnum-700
+                 bg-white px-5 text-base font-medium
+                 leading-none text-magnum-700 transition-colors hover:bg-opacity-95 focus:!ring-0
 								 {i === items.length - 1 ? 'border-b-0' : ''}"
 				>
 					{title}

--- a/src/lib/builders/combobox/create.ts
+++ b/src/lib/builders/combobox/create.ts
@@ -43,7 +43,6 @@ const { name, selector } = createElHelpers('combobox');
  * Creates an ARIA-1.2-compliant combobox.
  *
  * @TODO support providing an initial selected item
- * @TODO support PAGE_UP/PAGE_DOWN navigation (+10,-10)
  * @TODO expose a nice mechanism for clearing the input.
  * @TODO would it be useful to have a callback for when an item is selected?
  * @TODO multi-select using `tags-input` builder?

--- a/src/lib/builders/combobox/create.ts
+++ b/src/lib/builders/combobox/create.ts
@@ -1,11 +1,13 @@
 import { usePopper } from '$lib/internal/actions';
 import {
 	addEventListener,
+	back,
 	builder,
 	createElHelpers,
 	effect,
 	executeCallbacks,
 	FIRST_LAST_KEYS,
+	forward,
 	generateId,
 	isBrowser,
 	isElementDisabled,
@@ -22,7 +24,6 @@ import {
 	styleToString,
 } from '$lib/internal/helpers';
 import { getOptions } from '$lib/internal/helpers/list';
-
 import type { Defaults } from '$lib/internal/types';
 import { tick } from 'svelte';
 import { derived, get, readonly, writable } from 'svelte/store';
@@ -252,15 +253,21 @@ export function createCombobox<T>(props: CreateComboboxProps<T>) {
 						// Get the index of the currently highlighted item.
 						const $currentItem = get(highlightedItem);
 						const currentIndex = $currentItem ? candidateNodes.indexOf($currentItem) : -1;
-						// Calculate the index of the next menu item to highlight.
+						// Find the next menu item to highlight.
 						const loop = $options.loop;
-						let nextItem: HTMLElement | undefined;
+						let nextItem: HTMLElement;
 						switch (e.key) {
 							case kbd.ARROW_DOWN:
 								nextItem = next(candidateNodes, currentIndex, loop);
 								break;
+							case kbd.PAGE_DOWN:
+								nextItem = forward(candidateNodes, currentIndex, 10, loop);
+								break;
 							case kbd.ARROW_UP:
 								nextItem = prev(candidateNodes, currentIndex, loop);
+								break;
+							case kbd.PAGE_UP:
+								nextItem = back(candidateNodes, currentIndex, 10, loop);
 								break;
 							case kbd.HOME:
 								nextItem = candidateNodes[0];
@@ -271,11 +278,6 @@ export function createCombobox<T>(props: CreateComboboxProps<T>) {
 							default:
 								return;
 						}
-						/**
-						 * Bail if `next` or `prev` return `undefined`.
-						 * Theoretically this shouldn't be possible but it's a good check anyway.
-						 */
-						if (typeof nextItem === 'undefined') return;
 						// Highlight the new item and scroll it into view.
 						highlightedItem.set(nextItem);
 						nextItem.scrollIntoView({ block: $options.scrollAlignment });

--- a/src/lib/internal/helpers/array.ts
+++ b/src/lib/internal/helpers/array.ts
@@ -1,7 +1,42 @@
 /**
- * Returns next item in array given an index. If index is last item, returns the first item.
- * If the index is not found, returns undefined.
- * @category Array
+ * Returns the element some number before the given index. If the target index is out of bounds:
+ *   - If looping is disabled, the first element will be returned.
+ *   - If looping is enabled, the last element will be returned.
+ * @param array the array.
+ * @param currentIndex the index of the current element.
+ * @param increment the number of elements to move forward.
+ * @param loop loop to the beginning of the array if the target index is out of bounds?
+ */
+export function back<T>(array: T[], index: number, increment: number, loop = true): T {
+	const previousIndex = index - increment;
+	if (previousIndex <= 0) {
+		return loop ? array[array.length - 1] : array[0];
+	}
+	return array[previousIndex];
+}
+
+/**
+ * Returns the element some number after the given index. If the target index is out of bounds:
+ *   - If looping is disabled, the last element will be returned.
+ *   - If looping is enabled, the first element will be returned.
+ * @param array the array.
+ * @param currentIndex the index of the current element.
+ * @param increment the number of elements to move forward.
+ * @param loop loop to the beginning of the array if the target index is out of bounds?
+ */
+export function forward<T>(array: T[], index: number, increment: number, loop = true): T {
+	const nextIndex = index + increment;
+	if (nextIndex > array.length - 1) {
+		return loop ? array[0] : array[array.length - 1];
+	}
+	return array[nextIndex];
+}
+
+/**
+ * Returns the array element after to the given index.
+ * @param array the array.
+ * @param currentIndex the index of the current element.
+ * @param loop loop to the beginning of the array if the next index is out of bounds?
  */
 export function next<T>(array: T[], index: number, loop = true): T {
 	if (index === array.length - 1) {
@@ -11,29 +46,33 @@ export function next<T>(array: T[], index: number, loop = true): T {
 }
 
 /**
- * Returns previous item in array given an index. If index is first item, returns the last item.
- * If the index is not found, returns undefined.
- * @category Array
+ * Returns the array element prior to the given index.
+ * @param array the array.
+ * @param currentIndex the index of the current element.
+ * @param loop loop to the end of the array if the previous index is out of bounds?
  */
-export function prev<T>(array: T[], index: number, loop = true): T {
-	if (index <= 0) {
-		return loop ? array[array.length - 1] : array[index];
+export function prev<T>(array: T[], currentIndex: number, loop = true): T {
+	if (currentIndex <= 0) {
+		return loop ? array[array.length - 1] : array[0];
 	}
-	return array[index - 1];
+	return array[currentIndex - 1];
 }
 
 /**
- * Returns last item in array.
- * @category Array
+ * Returns the last element in an array.
+ * @param array the array.
  */
 export function last<T>(array: T[]): T {
 	return array[array.length - 1];
 }
 
 /**
- * Wraps an array around itself at a given start index
- * Example: `wrapArray(['a', 'b', 'c', 'd'], 2) === ['c', 'd', 'a', 'b']`
- * Reference: https://github.com/radix-ui/primitives
+ * Wraps an array around itself at a given starting index.
+ * @example ```ts
+ * wrapArray(['a', 'b', 'c', 'd'], 2);
+ * // ['c', 'd', 'a', 'b']
+ * ```
+ * @see https://github.com/radix-ui/primitives
  */
 export function wrapArray<T>(array: T[], startIndex: number): T[] {
 	return array.map((_, index) => array[(startIndex + index) % array.length]);

--- a/src/lib/internal/helpers/tests/array.spec.ts
+++ b/src/lib/internal/helpers/tests/array.spec.ts
@@ -1,5 +1,41 @@
 import { describe, expect, test } from 'vitest';
-import { last, next, prev, wrapArray } from '../array';
+import { back, forward, last, next, prev, wrapArray } from '../array';
+
+describe('back', () => {
+	test.each([
+		// No elements.
+		{ array: [], index: 0, increment: 1, loop: true, expected: undefined },
+		// Happy path: finding the next element.
+		{ array: ['a', 'b', 'c', 'd'], index: 3, increment: 2, loop: false, expected: 'b' },
+		// With looping disabled, the last element should be returned.
+		{ array: ['a', 'b', 'c', 'd'], index: 2, increment: 5, loop: false, expected: 'a' },
+		// With looping enabled, the first element should be returned.
+		{ array: ['a', 'b', 'c', 'd'], index: 0, increment: 5, loop: true, expected: 'd' },
+	])(
+		'back($array, $index, $increment, $loop) -> $expected',
+		({ array, index, increment, loop, expected }) => {
+			expect(back(array, index, increment, loop)).toBe(expected);
+		}
+	);
+});
+
+describe('forward', () => {
+	test.each([
+		// No elements.
+		{ array: [], index: 0, increment: 1, loop: true, expected: undefined },
+		// Happy path: finding the next element.
+		{ array: ['a', 'b', 'c', 'd'], index: 0, increment: 2, loop: false, expected: 'c' },
+		// With looping disabled, the last element should be returned.
+		{ array: ['a', 'b', 'c', 'd'], index: 0, increment: 5, loop: false, expected: 'd' },
+		// With looping enabled, the first element should be returned.
+		{ array: ['a', 'b', 'c', 'd'], index: 0, increment: 5, loop: true, expected: 'a' },
+	])(
+		'forward($array, $index, $increment, $loop) -> $expected',
+		({ array, index, increment, loop, expected }) => {
+			expect(forward(array, index, increment, loop)).toBe(expected);
+		}
+	);
+});
 
 describe('last', () => {
 	test.each([
@@ -15,7 +51,7 @@ describe('next', () => {
 		// Out of bounds.
 		{ array: [], index: 0, loop: true, expected: undefined },
 		{ array: ['a', 'b', 'c'], index: 4, loop: true, expected: undefined },
-		// Happy path: finding the next item.
+		// Happy path: finding the next element.
 		{ array: ['a', 'b', 'c'], index: 0, loop: false, expected: 'b' },
 		// Looping behavior.
 		{ array: ['a', 'b', 'c'], index: 2, loop: false, expected: 'c' },
@@ -30,10 +66,11 @@ describe('prev', () => {
 		// Out of bounds.
 		{ array: [], index: 0, loop: true, expected: undefined },
 		{ array: ['a', 'b', 'c'], index: 4, loop: true, expected: undefined },
-		// Happy path: finding the previous item.
+		// Returning the previous element.
 		{ array: ['a', 'b', 'c'], index: 1, loop: false, expected: 'a' },
-		// Looping behavior.
+		// With looping disabled, the first element should be returned.
 		{ array: ['a', 'b', 'c'], index: 0, loop: false, expected: 'a' },
+		// With looping enabled, the last element should be returned.
 		{ array: ['a', 'b', 'c'], index: 0, loop: true, expected: 'c' },
 		{ array: ['a', 'b', 'c'], index: -1, loop: true, expected: 'c' },
 	])('prev($array, $index, $loop) -> $expected', ({ array, index, loop, expected }) => {


### PR DESCRIPTION
### Summary

This PR adds support for PageUp / PageDown keyboard controls when selecting items in the Combobox and Select builders.

It also fixes some files that weren't formatted correctly—causing the CI Linting job to fail.

### Details

- Replicated some entries from `.gitignore` to `.prettierignore`
- Formatted `playwright.config.ts` and `src/docs/previews/accordion/main/tailwind.svelte`
- Added `forward` and `back` array utilities for array traversal.
- [Combobox] Added cases for <kbd>Page Up</kbd> and <kbd>Page Down</kbd> to navigate +10 items and -10 items. The [aria spec](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/) is vague about the increment of movement:
  > Moves focus up an author-determined number of rows, typically scrolling so the top row in the currently visible set of rows becomes one of the last visible rows. If focus is in the first row of the grid, focus does not move.

  ...but [Downshift uses +-10](https://github.com/downshift-js/downshift/blob/1730fbeb5e64381dbc72ccf4aebd934614ab2210/src/hooks/useSelect/README.md?plain=1#L846), which seems reasonable to me.

- [Select] Migrated highlighting to use the same logic and utilities as the Combobox.