### PR TITLE
fixed pnpm add instead of pnpm install

### DIFF
--- a/src/docs/content/installation.md
+++ b/src/docs/content/installation.md
@@ -31,7 +31,7 @@ yarn add @melt-ui/svelte
 <span slot="pnpm">
 
 ```bash /@melt-ui/#melt /svelte/#melt
-pnpm install @melt-ui/svelte
+pnpm add @melt-ui/svelte
 ```
 
 </span>


### PR DESCRIPTION
Installation of a package and it's dependencies should be done with `pnpm add` instead of `pnpm install`.