### PR TITLE
[Accordion] Finish adding aria attributes & add example previews

### DIFF
--- a/.changeset/chatty-hotels-fetch.md
+++ b/.changeset/chatty-hotels-fetch.md
@@ -1,5 +1,7 @@
 ---
-"@melt-ui/svelte": patch
+"@melt-ui/svelte": minor
 ---
 
-[Accordion] Add missing aria attributes
+[Accordion]
+- Add missing aria attributes
+- Add `heading` builder to apply aria attributes to non-heading elements used as headings

--- a/.changeset/chatty-hotels-fetch.md
+++ b/.changeset/chatty-hotels-fetch.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+[Accordion] Add missing aria attributes

--- a/src/docs/components/callout.svelte
+++ b/src/docs/components/callout.svelte
@@ -19,8 +19,6 @@
 	export let type: VariantProps<typeof calloutVariants>['type'] = 'default';
 </script>
 
-<div class={cn(calloutVariants({ type, className }))}>
-	<p>
-		<slot />
-	</p>
+<div class={cn(calloutVariants({ type, className }))} data-callout>
+	<slot />
 </div>

--- a/src/docs/components/callout.svelte
+++ b/src/docs/components/callout.svelte
@@ -2,7 +2,7 @@
 	import { tv, type VariantProps } from 'tailwind-variants';
 	import { cn } from '$docs/utils';
 	const calloutVariants = tv({
-		base: 'relative rounded-tr-md rounded-br-md px-5 py-3 before:absolute before:left-0 before:top-0 before:h-full before:w-0.5 before:content-[""] my-6 text-sm',
+		base: 'relative rounded-tr-md rounded-br-md px-5 py-3 before:absolute before:left-0 before:top-0 before:h-full before:w-0.5 before:content-[""] my-6 ',
 		variants: {
 			type: {
 				default: 'before:bg-magnum-700 bg-magnum-700/10 text-white border-magnum-700',

--- a/src/docs/components/markdown/a.svelte
+++ b/src/docs/components/markdown/a.svelte
@@ -2,10 +2,11 @@
 	import External from '~icons/lucide/external-link';
 
 	export let href: string;
-	export let rel: string | undefined = undefined;
-	export let target: string | undefined = undefined;
 
 	$: internal = href.startsWith('/');
+
+	$: rel = !internal ? 'noopener noreferrer' : undefined;
+	$: target = !internal ? '_blank' : undefined;
 </script>
 
 <a

--- a/src/docs/content/builders/accordion.md
+++ b/src/docs/content/builders/accordion.md
@@ -25,9 +25,38 @@ description:
 To create an accordion, use the `createAccordion` builder function. Follow the anatomy or the
 example at the top of this page to create your accordion.
 
-<Callout type="warning">
-To ensure the accordion you create is accessible, wrap the trigger in an element with the <code>role="heading"</code> attribute, and set the <code>aria-level</code> attribute to the appropriate heading level. Alternatively, you can wrap the trigger in a heading element, as we have done in the preview above.
-</Callout>
+
+### Ensuring items are accessible
+
+The easy way to ensure your accordion items are accessible is to wrap each trigger element in a
+heading element, like so:
+
+```svelte
+<h2>
+  <button melt={$trigger(id)}>
+    {title}
+  </button>
+</h2>
+```
+
+However, there may be times when you can't use or don't want to use a heading element. In those
+cases, use the `heading` builder to apply the necessary aria attributes to the element. The argument
+passed to the `heading` builder is the heading level you wish to use. In the example below,
+we set the heading level to 4.
+
+```svelte /heading/#hi
+<script lang="ts">
+  const { content, item, trigger, isSelected, root, heading } = createAccordion()
+</script>
+```
+
+```svelte {1}
+<span melt={$heading(4)}>
+    <button melt={$trigger(id)}>
+        {title}
+    </button>
+<span>
+```
 
 ### Disabling a single item
 
@@ -50,7 +79,7 @@ Pass in the `type` argument to `createAccordion` with a value of `'multiple'`.
   const { content, item, trigger, isSelected, root } = createAccordion({
     type: 'multiple'
   })
-</script>
+</>
 ```
 
 <Preview code={snippets.multiple}>

--- a/src/docs/content/builders/accordion.md
+++ b/src/docs/content/builders/accordion.md
@@ -6,9 +6,11 @@ description:
 ---
 
 <script>
-    import { KbdTable, APIReference, APIWrapper, APITable } from '$docs/components'
+    import { KbdTable, APIReference, Preview, Callout } from '$docs/components'
     export let schemas
     export let keyboard
+    export let snippets
+    export let previews
 </script>
 
 ## Anatomy
@@ -23,6 +25,10 @@ description:
 To create an accordion, use the `createAccordion` builder function. Follow the anatomy or the
 example at the top of this page to create your accordion.
 
+<Callout type="warning">
+To ensure the accordion you create is accessible, wrap the trigger in an element with the <code>role="heading"</code> attribute, and set the <code>aria-level</code> attribute to the appropriate heading level. Alternatively, you can wrap the trigger in a heading element, as we have done in the preview above.
+</Callout>
+
 ### Disabling a single item
 
 To disable a single item, you can pass in an object instead of a string to the function.
@@ -30,6 +36,10 @@ To disable a single item, you can pass in an object instead of a string to the f
 ```svelte /{ value: 'item-3', disabled: true }/#hi
 <div class="accordion-item" melt={$item({ value: 'item-3', disabled: true })}>Item 3</div>
 ```
+
+<Preview code={snippets.disabled}>
+    <svelte:component this={previews.disabled} />
+</Preview>
 
 ### Opening multiple items at once
 
@@ -42,6 +52,10 @@ Pass in the `type` argument to `createAccordion` with a value of `'multiple'`.
   })
 </script>
 ```
+
+<Preview code={snippets.multiple}>
+    <svelte:component this={previews.multiple} />
+</Preview>
 
 ### Controlled access
 

--- a/src/docs/content/builders/accordion.md
+++ b/src/docs/content/builders/accordion.md
@@ -6,7 +6,7 @@ description:
 ---
 
 <script>
-    import { KbdTable, APIReference, Preview, Callout } from '$docs/components'
+    import { KbdTable, APIReference, Preview } from '$docs/components'
     export let schemas
     export let keyboard
     export let snippets
@@ -25,7 +25,6 @@ description:
 To create an accordion, use the `createAccordion` builder function. Follow the anatomy or the
 example at the top of this page to create your accordion.
 
-
 ### Ensuring items are accessible
 
 The easy way to ensure your accordion items are accessible is to wrap each trigger element in a
@@ -41,8 +40,8 @@ heading element, like so:
 
 However, there may be times when you can't use or don't want to use a heading element. In those
 cases, use the `heading` builder to apply the necessary aria attributes to the element. The argument
-passed to the `heading` builder is the heading level you wish to use. In the example below,
-we set the heading level to 4.
+passed to the `heading` builder is the heading level you wish to use. In the example below, we set
+the heading level to 4.
 
 ```svelte /heading/#hi
 <script lang="ts">

--- a/src/docs/data/builders/accordion.ts
+++ b/src/docs/data/builders/accordion.ts
@@ -125,16 +125,16 @@ const trigger: APISchema = {
 	],
 	dataAttributes: [
 		{
-			name: 'data-melt-accordion-trigger',
-			value: ATTRS.MELT('accordion trigger'),
-		},
-		{
 			name: 'data-disabled',
 			value: ATTRS.DISABLED('trigger'),
 		},
 		{
 			name: 'data-value',
 			value: 'The value of the associated item.',
+		},
+		{
+			name: 'data-melt-accordion-trigger',
+			value: ATTRS.MELT('accordion trigger'),
 		},
 	],
 };
@@ -163,6 +163,10 @@ const content: APISchema = {
 		{
 			name: 'data-disabled',
 			value: ATTRS.DISABLED('content'),
+		},
+		{
+			name: 'data-value',
+			value: 'The value of the associated item',
 		},
 		{
 			name: 'data-melt-accordion-content',

--- a/src/docs/data/builders/accordion.ts
+++ b/src/docs/data/builders/accordion.ts
@@ -58,6 +58,11 @@ const builder: APISchema = {
 			description: 'The builder store used to create accordion content.',
 			link: '#content',
 		},
+		{
+			name: 'heading',
+			description: 'The builder store used to create accordion headings.',
+			link: '#heading',
+		},
 	],
 };
 
@@ -175,6 +180,29 @@ const content: APISchema = {
 	],
 };
 
+const heading: APISchema = {
+	title: 'heading',
+	description:
+		'The heading for an accordion item. It should be nested inside of its associated `item`.',
+	props: [
+		{
+			name: 'level',
+			type: ['1', '2', '3', '4', '5', '6'],
+			description: 'The heading level to use for the element.',
+		},
+	],
+	dataAttributes: [
+		{
+			name: 'data-heading-level',
+			value: 'The heading level applied to the element.',
+		},
+		{
+			name: 'data-melt-accordion-heading',
+			value: ATTRS.MELT('accordion heading'),
+		},
+	],
+};
+
 const keyboard: KeyboardSchema = [
 	{
 		key: KBD.SPACE,
@@ -210,7 +238,7 @@ const keyboard: KeyboardSchema = [
 	},
 ];
 
-const schemas: BuilderData['schemas'] = [builder, root, trigger, item, content];
+const schemas: BuilderData['schemas'] = [builder, root, trigger, item, content, heading];
 
 const features: BuilderData['features'] = [
 	'Full keyboard navigation',

--- a/src/docs/previews/accordion/disabled/css.svelte
+++ b/src/docs/previews/accordion/disabled/css.svelte
@@ -1,0 +1,158 @@
+<script lang="ts">
+	import { createAccordion } from '@melt-ui/svelte';
+	import { slide } from 'svelte/transition';
+
+	const { content, item, trigger, isSelected, root } = createAccordion();
+
+	const items = [
+		{
+			id: 'item-1',
+			title: 'Is it accessible?',
+			description: 'Yes. It adheres to the WAI-ARIA design pattern.',
+			disabled: false,
+		},
+		{
+			id: 'item-2',
+			title: "I'm a disabled accordion item",
+			description: "You can't open me.",
+			disabled: true,
+		},
+		{
+			id: 'item-3',
+			title: 'Can it be animated?',
+			description:
+				'Yes! You can use the transition prop to configure the animation.',
+			disabled: false,
+		},
+	];
+</script>
+
+<div class="root" melt={$root}>
+	{#each items as { id, title, description, disabled }, i}
+		<div melt={$item(id)} class="item">
+			<h2>
+				<button
+					id={i === 0 ? 'accordion-trigger' : undefined}
+					melt={$trigger({ value: id, disabled })}
+					class="trigger"
+				>
+					{title}
+				</button>
+			</h2>
+			{#if $isSelected(id)}
+				<div class="content" melt={$content(id)} transition:slide>
+					<div>{description}</div>
+				</div>
+			{/if}
+		</div>
+	{/each}
+</div>
+
+<style lang="postcss">
+	.root {
+		margin-left: auto;
+		margin-right: auto;
+		width: 100%;
+		max-width: var(--tw-width-md);
+		border-radius: var(--tw-border-radius-md);
+		--tw-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1),
+			0 4px 6px -4px rgb(0 0 0 / 0.1);
+		--tw-shadow-colored: 0 10px 15px -3px var(--tw-shadow-color),
+			0 4px 6px -4px var(--tw-shadow-color);
+		box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000),
+			var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+	}
+
+	.item {
+		margin-top: var(--tw-size-px);
+		overflow: hidden;
+		transition-property: color, background-color, border-color, fill, stroke,
+			-webkit-text-decoration-color;
+		transition-property: color, background-color, border-color,
+			text-decoration-color, fill, stroke;
+		transition-property: color, background-color, border-color,
+			text-decoration-color, fill, stroke, -webkit-text-decoration-color;
+		transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+		transition-duration: 150ms;
+	}
+
+	.item:first-child {
+		margin-top: var(--tw-size-0);
+		border-top-left-radius: var(--tw-border-radius-default);
+		border-top-right-radius: var(--tw-border-radius-default);
+	}
+
+	.item:last-child {
+		border-bottom-right-radius: var(--tw-border-radius-default);
+		border-bottom-left-radius: var(--tw-border-radius-default);
+	}
+
+	.item:focus-within {
+		position: relative;
+		z-index: 10;
+		--tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0
+			var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+		--tw-ring-shadow: var(--tw-ring-inset) 0 0 0
+			calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+		box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow),
+			var(--tw-shadow, 0 0 #0000);
+		--tw-ring-opacity: 1;
+		--tw-ring-color: rgb(var(--tw-color-magnum-400) / var(--tw-ring-opacity));
+	}
+
+	.item > h2 {
+		display: flex;
+	}
+
+	.trigger {
+		display: flex;
+		height: var(--tw-size-12);
+		flex: 1 1 0%;
+		cursor: pointer;
+		align-items: center;
+		justify-content: space-between;
+		--tw-bg-opacity: 1;
+		background-color: rgb(var(--tw-color-white) / var(--tw-bg-opacity));
+		padding-left: var(--tw-size-5);
+		padding-right: var(--tw-size-5);
+		font-size: var(--tw-font-size-base);
+		line-height: var(--tw-line-height-6);
+		font-weight: var(--tw-font-weight-medium);
+		line-height: var(--tw-line-height-none);
+		--tw-text-opacity: 1;
+		color: rgb(var(--tw-color-magnum-700) / var(--tw-text-opacity));
+		--tw-shadow: 0 1px 0;
+		--tw-shadow-colored: 0 1px 0 var(--tw-shadow-color);
+		box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000),
+			var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+		transition-property: color, background-color, border-color, fill, stroke,
+			-webkit-text-decoration-color;
+		transition-property: color, background-color, border-color,
+			text-decoration-color, fill, stroke;
+		transition-property: color, background-color, border-color,
+			text-decoration-color, fill, stroke, -webkit-text-decoration-color;
+		transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+		transition-duration: 150ms;
+	}
+
+	.trigger:hover {
+		--tw-bg-opacity: 0.95;
+	}
+
+	.content {
+		overflow: hidden;
+		--tw-bg-opacity: 1;
+		background-color: rgb(var(--tw-color-neutral-100) / var(--tw-bg-opacity));
+		font-size: var(--tw-font-size-sm);
+		line-height: var(--tw-line-height-5);
+		--tw-text-opacity: 1;
+		color: rgb(var(--tw-color-neutral-900) / var(--tw-text-opacity));
+	}
+
+	.content > div {
+		padding-left: var(--tw-size-5);
+		padding-right: var(--tw-size-5);
+		padding-top: var(--tw-size-4);
+		padding-bottom: var(--tw-size-4);
+	}
+</style>

--- a/src/docs/previews/accordion/disabled/tailwind.svelte
+++ b/src/docs/previews/accordion/disabled/tailwind.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+	import { createAccordion } from '@melt-ui/svelte';
+	import { slide } from 'svelte/transition';
+
+	const { content, item, trigger, isSelected, root } = createAccordion();
+
+	const items = [
+		{
+			id: 'item-1',
+			title: 'Is it accessible?',
+			description: 'Yes. It adheres to the WAI-ARIA design pattern.',
+			disabled: false,
+		},
+		{
+			id: 'item-2',
+			title: "I'm a disabled accordion item",
+			description: "You can't open me.",
+			disabled: true,
+		},
+		{
+			id: 'item-3',
+			title: 'Can it be animated?',
+			description:
+				'Yes! You can use the transition prop to configure the animation.',
+			disabled: false,
+		},
+	];
+</script>
+
+<div class="mx-auto w-full max-w-md rounded-md shadow-lg" {...$root}>
+	{#each items as { id, title, description, disabled }, i}
+		<div
+			melt={$item(id)}
+			class="overflow-hidden transition-colors first:rounded-t
+            last:rounded-b focus-within:relative focus-within:z-10 focus-within:ring
+            focus-within:ring-magnum-400"
+		>
+			<h2 class="flex">
+				<button
+					id={i === 0 ? 'accordion-trigger' : undefined}
+					melt={$trigger({ value: id, disabled })}
+					class="flex h-12 flex-1 cursor-pointer items-center justify-between border-b border-b-magnum-700
+                 bg-white px-5 text-base font-medium
+                 leading-none text-magnum-700 transition-colors hover:bg-opacity-95 focus:!ring-0
+								 {i === items.length - 1 ? 'border-b-0' : ''} {disabled
+						? 'cursor-not-allowed bg-neutral-300 text-opacity-60'
+						: ''}"
+				>
+					{title}
+				</button>
+			</h2>
+			{#if $isSelected(id)}
+				<div
+					class="overflow-hidden bg-neutral-100 text-sm text-neutral-900"
+					melt={$content(id)}
+					transition:slide
+				>
+					<div class="px-5 py-4">
+						{description}
+					</div>
+				</div>
+			{/if}
+		</div>
+	{/each}
+</div>

--- a/src/docs/previews/accordion/multiple/css.svelte
+++ b/src/docs/previews/accordion/multiple/css.svelte
@@ -1,0 +1,158 @@
+<script lang="ts">
+	import { createAccordion } from '@melt-ui/svelte';
+	import { slide } from 'svelte/transition';
+
+	const { content, item, trigger, isSelected, root } = createAccordion({
+		type: 'multiple',
+	});
+
+	const items = [
+		{
+			id: 'item-1',
+			title: 'Is it accessible?',
+			description: 'Yes. It adheres to the WAI-ARIA design pattern.',
+		},
+		{
+			id: 'item-2',
+			title: 'Is it unstyled?',
+			description:
+				"Yes. It's unstyled by default, giving you freedom over the look and feel.",
+		},
+		{
+			id: 'item-3',
+			title: 'Can it be animated?',
+			description:
+				'Yes! You can use the transition prop to configure the animation.',
+		},
+	];
+</script>
+
+<div class="root" melt={$root}>
+	{#each items as { id, title, description }, i}
+		<div melt={$item(id)} class="item">
+			<h2>
+				<button
+					id={i === 0 ? 'accordion-trigger' : undefined}
+					melt={$trigger(id)}
+					class="trigger"
+				>
+					{title}
+				</button>
+			</h2>
+			{#if $isSelected(id)}
+				<div class="content" melt={$content(id)} transition:slide>
+					<div>{description}</div>
+				</div>
+			{/if}
+		</div>
+	{/each}
+</div>
+
+<style lang="postcss">
+	.root {
+		margin-left: auto;
+		margin-right: auto;
+		width: 100%;
+		max-width: var(--tw-width-md);
+		border-radius: var(--tw-border-radius-md);
+		--tw-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1),
+			0 4px 6px -4px rgb(0 0 0 / 0.1);
+		--tw-shadow-colored: 0 10px 15px -3px var(--tw-shadow-color),
+			0 4px 6px -4px var(--tw-shadow-color);
+		box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000),
+			var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+	}
+
+	.item {
+		margin-top: var(--tw-size-px);
+		overflow: hidden;
+		transition-property: color, background-color, border-color, fill, stroke,
+			-webkit-text-decoration-color;
+		transition-property: color, background-color, border-color,
+			text-decoration-color, fill, stroke;
+		transition-property: color, background-color, border-color,
+			text-decoration-color, fill, stroke, -webkit-text-decoration-color;
+		transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+		transition-duration: 150ms;
+	}
+
+	.item:first-child {
+		margin-top: var(--tw-size-0);
+		border-top-left-radius: var(--tw-border-radius-default);
+		border-top-right-radius: var(--tw-border-radius-default);
+	}
+
+	.item:last-child {
+		border-bottom-right-radius: var(--tw-border-radius-default);
+		border-bottom-left-radius: var(--tw-border-radius-default);
+	}
+
+	.item:focus-within {
+		position: relative;
+		z-index: 10;
+		--tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0
+			var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+		--tw-ring-shadow: var(--tw-ring-inset) 0 0 0
+			calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+		box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow),
+			var(--tw-shadow, 0 0 #0000);
+		--tw-ring-opacity: 1;
+		--tw-ring-color: rgb(var(--tw-color-magnum-400) / var(--tw-ring-opacity));
+	}
+
+	.item > h2 {
+		display: flex;
+	}
+
+	.trigger {
+		display: flex;
+		height: var(--tw-size-12);
+		flex: 1 1 0%;
+		cursor: pointer;
+		align-items: center;
+		justify-content: space-between;
+		--tw-bg-opacity: 1;
+		background-color: rgb(var(--tw-color-white) / var(--tw-bg-opacity));
+		padding-left: var(--tw-size-5);
+		padding-right: var(--tw-size-5);
+		font-size: var(--tw-font-size-base);
+		line-height: var(--tw-line-height-6);
+		font-weight: var(--tw-font-weight-medium);
+		line-height: var(--tw-line-height-none);
+		--tw-text-opacity: 1;
+		color: rgb(var(--tw-color-magnum-700) / var(--tw-text-opacity));
+		--tw-shadow: 0 1px 0;
+		--tw-shadow-colored: 0 1px 0 var(--tw-shadow-color);
+		box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000),
+			var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+		transition-property: color, background-color, border-color, fill, stroke,
+			-webkit-text-decoration-color;
+		transition-property: color, background-color, border-color,
+			text-decoration-color, fill, stroke;
+		transition-property: color, background-color, border-color,
+			text-decoration-color, fill, stroke, -webkit-text-decoration-color;
+		transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+		transition-duration: 150ms;
+	}
+
+	.trigger:hover {
+		--tw-bg-opacity: 0.95;
+	}
+
+	.content {
+		overflow: hidden;
+		--tw-bg-opacity: 1;
+		background-color: rgb(var(--tw-color-neutral-100) / var(--tw-bg-opacity));
+		font-size: var(--tw-font-size-sm);
+		line-height: var(--tw-line-height-5);
+		--tw-text-opacity: 1;
+		color: rgb(var(--tw-color-neutral-900) / var(--tw-text-opacity));
+	}
+
+	.content > div {
+		padding-left: var(--tw-size-5);
+		padding-right: var(--tw-size-5);
+		padding-top: var(--tw-size-4);
+		padding-bottom: var(--tw-size-4);
+	}
+</style>

--- a/src/docs/previews/accordion/multiple/tailwind.svelte
+++ b/src/docs/previews/accordion/multiple/tailwind.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+	import { createAccordion } from '@melt-ui/svelte';
+	import { slide } from 'svelte/transition';
+
+	const { content, item, trigger, isSelected, root } = createAccordion({
+		type: 'multiple',
+	});
+
+	const items = [
+		{
+			id: 'item-1',
+			title: 'Is it accessible?',
+			description: 'Yes. It adheres to the WAI-ARIA design pattern.',
+		},
+		{
+			id: 'item-2',
+			title: 'Is it unstyled?',
+			description:
+				"Yes. It's unstyled by default, giving you freedom over the look & feel.",
+		},
+		{
+			id: 'item-3',
+			title: 'Can it be animated?',
+			description:
+				'Yes! You can use the transition prop to configure the animation.',
+		},
+	];
+</script>
+
+<div class="mx-auto w-full max-w-md rounded-md shadow-lg" {...$root}>
+	{#each items as { id, title, description }, i}
+		<div
+			melt={$item(id)}
+			class="overflow-hidden transition-colors first:rounded-t
+            last:rounded-b focus-within:relative focus-within:z-10 focus-within:ring
+            focus-within:ring-magnum-400"
+		>
+			<h2 class="flex">
+				<button
+					id={i === 0 ? 'accordion-trigger' : undefined}
+					melt={$trigger(id)}
+					class="flex h-12 flex-1 cursor-pointer items-center justify-between border-b border-b-magnum-700
+                 bg-white px-5 text-base font-medium
+                 leading-none text-magnum-700 transition-colors hover:bg-opacity-95 focus:!ring-0
+								 {i === items.length - 1 ? 'border-b-0' : ''}"
+				>
+					{title}
+				</button>
+			</h2>
+			{#if $isSelected(id)}
+				<div
+					class="overflow-hidden bg-neutral-100 text-sm text-neutral-900"
+					melt={$content(id)}
+					transition:slide
+				>
+					<div class="px-5 py-4">
+						{description}
+					</div>
+				</div>
+			{/if}
+		</div>
+	{/each}
+</div>

--- a/src/lib/builders/accordion/create.ts
+++ b/src/lib/builders/accordion/create.ts
@@ -9,10 +9,10 @@ import {
 } from '$lib/internal/helpers';
 import type { Defaults } from '$lib/internal/types';
 import { derived, get, writable } from 'svelte/store';
-import type { AccordionItemProps, CreateAccordionProps } from './types';
+import type { AccordionHeadingProps, AccordionItemProps, CreateAccordionProps } from './types';
 import { tick } from 'svelte';
 
-type AccordionParts = 'trigger' | 'item' | 'content';
+type AccordionParts = 'trigger' | 'item' | 'content' | 'heading';
 const { name, selector } = createElHelpers<AccordionParts>('accordion');
 
 const defaults = {
@@ -51,6 +51,14 @@ export const createAccordion = (props?: CreateAccordionProps) => {
 	const parseItemProps = (props: AccordionItemProps) => {
 		if (typeof props === 'string') {
 			return { value: props };
+		} else {
+			return props;
+		}
+	};
+
+	const parseHeadingProps = (props: AccordionHeadingProps) => {
+		if (typeof props === 'number') {
+			return { level: props };
 		} else {
 			return props;
 		}
@@ -176,6 +184,19 @@ export const createAccordion = (props?: CreateAccordionProps) => {
 		},
 	});
 
+	const heading = builder(name('heading'), {
+		returned: () => {
+			return (props: AccordionHeadingProps) => {
+				const { level } = parseHeadingProps(props);
+				return {
+					role: 'heading',
+					'aria-level': level,
+					'data-heading-level': level,
+				};
+			};
+		},
+	});
+
 	return {
 		root,
 		value,
@@ -184,5 +205,6 @@ export const createAccordion = (props?: CreateAccordionProps) => {
 		content,
 		isSelected: isSelectedStore,
 		options,
+		heading,
 	};
 };

--- a/src/lib/builders/accordion/create.ts
+++ b/src/lib/builders/accordion/create.ts
@@ -170,7 +170,6 @@ export const createAccordion = (props?: CreateAccordionProps) => {
 				if (!parentTrigger) return;
 
 				node.id = contentId;
-				node.setAttribute('aria-labelledby', triggerId || '');
 				parentTrigger.setAttribute('aria-controls', contentId);
 				parentTrigger.id = triggerId;
 			});

--- a/src/lib/builders/accordion/types.ts
+++ b/src/lib/builders/accordion/types.ts
@@ -24,4 +24,10 @@ export type AccordionItemProps =
 	  }
 	| string;
 
+export type AccordionHeadingProps =
+	| {
+			level: 1 | 2 | 3 | 4 | 5 | 6;
+	  }
+	| number;
+
 export type CreateAccordionReturn = ReturnType<typeof createAccordion>;

--- a/src/markdown.postcss
+++ b/src/markdown.postcss
@@ -78,3 +78,7 @@
 [data-rehype-pretty-code-title] + pre {
 	@apply mt-2;
 }
+
+[data-callout] > p:last-child {
+	@apply mb-0 !important;
+}


### PR DESCRIPTION
This PR adds the missing `aria-controls` attribute to the accordion item trigger and adds previews that showcase a `multiple` accordion, as well as an accordion with a `disabled` item. I've also added a callout to the docs that mention the importance of wrapping the trigger in either a heading element or an element with the `role="heading"` and the `aria-level` attributes to ensure their components are accessible.