### PR TITLE
feat: css example for avatar

### DIFF
--- a/src/docs/previews/avatar/main/css.svelte
+++ b/src/docs/previews/avatar/main/css.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+	import { createAvatar } from '@melt-ui/svelte';
+
+	const { image, fallback } = createAvatar({
+		src: 'https://avatars.githubusercontent.com/u/1162160?v=4',
+	});
+
+	// With an exaggerated fallback delay
+	const { image: imageA, fallback: fallbackA } = createAvatar({
+		src: 'https://avatars.githubusercontent.com/u/5968653?v=4',
+		delayMs: 650,
+	});
+
+	// A blank source to demonstrate the fallback
+	const { image: imageB, fallback: fallbackB } = createAvatar({
+		src: '',
+	});
+</script>
+
+<div class="root">
+	<div class="item">
+		<img melt={$image} alt="Avatar" class="avatar" />
+		<span melt={$fallback} class="fallback">RH</span>
+	</div>
+
+	<div class="item">
+		<img melt={$imageA} alt="Avatar" class="avatar" />
+		<span melt={$fallbackA} class="fallback">SH</span>
+	</div>
+
+	<div class="item">
+		<img melt={$imageB} alt="Avatar" class="avatar" />
+		<span melt={$fallbackB} class="fallback">UI</span>
+	</div>
+</div>
+
+<style lang="postcss">
+	.root {
+		display: flex;
+		width: 100%;
+		align-items: center;
+		justify-content: center;
+		gap: var(--tw-size-6);
+	}
+
+	.item {
+		display: flex;
+		height: var(--tw-size-16);
+		width: var(--tw-size-16);
+		align-items: center;
+		justify-content: center;
+		border-radius: var(--tw-rounded-full);
+		--tw-bg-opacity: 1;
+		background-color: rgb(245 245 245 / var(--tw-bg-opacity));
+	}
+
+	.item > .avatar {
+		height: 100%;
+		width: 100%;
+		border-radius: inherit;
+	}
+
+	.item > .fallback {
+		font-size: var(--tw-font-size-3xl);
+		line-height: var(--tw-line-height-3xl);
+		font-weight: var(--tw-font-weight-medium);
+		--tw-text-opacity: 1;
+		color: rgb(189 87 17 / var(--tw-text-opacity));
+	}
+</style>


### PR DESCRIPTION
Hi.

This adds the css example for the `avatar` component builder.

If this is acceptable, I wanted to gradually open P.R's for the remaining builders in a similar manner.



Qn: I sort of couldn't find a guide for the tw-css variables, e.g `line-height` and I'm not sure if you guys have your own custom ones. Any hint to where I could look to in the future would be appreciated.

As always, love what you're building. 💙 