### PR TITLE
Wrong header level

### DIFF
--- a/src/docs/content/builders/tags-input.md
+++ b/src/docs/content/builders/tags-input.md
@@ -189,10 +189,10 @@ The following example disallows a tag with the value `one` to be deleted.
 </script>
 ```
 
-### API Reference
+## API Reference
 
 <APIReference {schemas} />
 
-### Accessibility
+## Accessibility
 
 <KbdTable {keyboard} />


### PR DESCRIPTION
API References and Accessibility were nested inside Usage on this page