### PR TITLE
Fix: Declaration merging type

### DIFF
--- a/.changeset/modern-ligers-yawn.md
+++ b/.changeset/modern-ligers-yawn.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+Fix: Type issue with `melt` attribute on certain elements

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -4,7 +4,7 @@ import type { Action } from 'svelte/action';
 declare global {
 	// eslint-disable-next-line @typescript-eslint/no-namespace
 	namespace svelteHTML {
-		interface HTMLAttributes {
+		interface HTMLAttributes<T> extends T {
 			/**
 			 * A special attribute for Melt UI's preprocessor `@melt-ui/pp`.
 			 *


### PR DESCRIPTION
This may look weird, but this is how the type should look so that it applies to all the elements.

I've tested it with the reproductions and was no longer able to reproduce the type error after making this change.