### PR TITLE
[Tabs] Force focus on click for buttons in safari

### DIFF
--- a/.changeset/cyan-monkeys-return.md
+++ b/.changeset/cyan-monkeys-return.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+[Tabs] Force focus on click for buttons in safari

--- a/src/lib/builders/tabs/create.ts
+++ b/src/lib/builders/tabs/create.ts
@@ -79,6 +79,7 @@ export function createTabs(props?: CreateTabsProps) {
 				}
 
 				return {
+					type: 'button',
 					role: 'tab',
 					'data-state': isBrowser
 						? $value === tabValue
@@ -97,6 +98,9 @@ export function createTabs(props?: CreateTabsProps) {
 		},
 		action: (node: HTMLElement) => {
 			const unsub = executeCallbacks(
+				addEventListener(node, 'click', () => {
+					node.focus();
+				}),
 				addEventListener(node, 'focus', () => {
 					const $options = get(options);
 					const disabled = node.dataset.disabled === 'true';
@@ -142,19 +146,19 @@ export function createTabs(props?: CreateTabsProps) {
 
 					if (e.key === nextKey) {
 						e.preventDefault();
-						next(enabledTriggers, triggerIdx, $options.loop)?.focus();
+						next(enabledTriggers, triggerIdx, $options.loop).focus();
 					} else if (e.key === prevKey) {
 						e.preventDefault();
-						prev(enabledTriggers, triggerIdx, $options.loop)?.focus();
+						prev(enabledTriggers, triggerIdx, $options.loop).focus();
 					} else if (e.key === kbd.ENTER || e.key === kbd.SPACE) {
 						e.preventDefault();
 						value.set(tabValue);
 					} else if (e.key === kbd.HOME) {
 						e.preventDefault();
-						enabledTriggers[0]?.focus();
+						enabledTriggers[0].focus();
 					} else if (e.key === kbd.END) {
 						e.preventDefault();
-						last(enabledTriggers)?.focus();
+						last(enabledTriggers).focus();
 					}
 				})
 			);


### PR DESCRIPTION
This is odd but it at least allows you to click and navigate the tabs with the arrow keys. The issue of not being able to go back to the tabs using the keyboard (unless I'm missing a setting) is still there.

Closes: #204

I do think we should discuss how to best approach supporting Safari's odd native behavior.