### PR TITLE
fix: Dialog is closed on right button click

### DIFF
--- a/.changeset/giant-feet-flow.md
+++ b/.changeset/giant-feet-flow.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+[Dialog]: Dialog no longer closes on right-click

--- a/src/lib/builders/dialog/create.ts
+++ b/src/lib/builders/dialog/create.ts
@@ -6,6 +6,7 @@ import {
 	effect,
 	generateId,
 	isBrowser,
+	isLeftClick,
 	last,
 	noop,
 	sleep,
@@ -114,6 +115,10 @@ export function createDialog(props: CreateDialogProps = {}) {
 					e.preventDefault();
 					e.stopImmediatePropagation();
 
+					if (e instanceof MouseEvent && !isLeftClick(e)) {
+						return false;
+					}
+
 					const $options = get(options);
 					const $openDialogIds = get(openDialogIds);
 					const isLast = last($openDialogIds) === ids.content;
@@ -124,7 +129,6 @@ export function createDialog(props: CreateDialogProps = {}) {
 
 					return false;
 				},
-
 				returnFocusOnDeactivate: false,
 				fallbackFocus: node,
 			});

--- a/src/lib/internal/helpers/is.ts
+++ b/src/lib/internal/helpers/is.ts
@@ -25,6 +25,6 @@ export function isTouch(event: PointerEvent): boolean {
 	return event.pointerType === 'touch';
 }
 
-export function isLeftClick(event: PointerEvent): boolean {
+export function isLeftClick(event: PointerEvent | MouseEvent): boolean {
 	return event.button === 0 && event.ctrlKey === false && event.metaKey === false;
 }


### PR DESCRIPTION
Resolves: https://github.com/melt-ui/melt-ui/issues/251

This is very straight forward changes for closing `Dialog` component only if the left click was clicked outside `content`.