### PR TITLE
[Checkbox] Unsub checkbox click event

### DIFF
--- a/.changeset/lazy-pianos-kneel.md
+++ b/.changeset/lazy-pianos-kneel.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+[Checkbox] Unsub checkbox click event

--- a/src/lib/builders/checkbox/create.ts
+++ b/src/lib/builders/checkbox/create.ts
@@ -43,17 +43,17 @@ export function createCheckbox(props: CreateCheckboxProps = {}) {
 				addEventListener(node, 'keydown', (event) => {
 					// According to WAI ARIA, Checkboxes don't activate on enter keypress
 					if (event.key === kbd.ENTER) event.preventDefault();
+				}),
+				addEventListener(node, 'click', () => {
+					const $options = get(options);
+					if ($options.disabled) return;
+
+					checked.update((value) => {
+						if (value === 'indeterminate') return true;
+						return !value;
+					});
 				})
 			);
-			addEventListener(node, 'click', () => {
-				const $options = get(options);
-				if ($options.disabled) return;
-
-				checked.update((value) => {
-					if (value === 'indeterminate') return true;
-					return !value;
-				});
-			});
 
 			return {
 				destroy: unsub,


### PR DESCRIPTION
Somewhere along the way, the `click` event listener got moved outside the `unsub`. This PR moves it back where it belongs :)