### PR TITLE
[Combobox] Fix Open/Close Flickering

### DIFF
--- a/.changeset/silly-dodos-clean.md
+++ b/.changeset/silly-dodos-clean.md
@@ -1,0 +1,7 @@
+---
+"@melt-ui/svelte": patch
+---
+
+[Combobox]
+- Fix Open/Close Flickering
+- Returns a `label` element builder

--- a/src/docs/content/builders/combobox.md
+++ b/src/docs/content/builders/combobox.md
@@ -15,6 +15,7 @@ description: A filterable list of items that supports selection.
   the list
 - **Menu**: The popover menu
 - **Item**: The individual list item
+- **Label**: The label for the input
 
 ## API Reference
 

--- a/src/docs/data/builders/combobox.ts
+++ b/src/docs/data/builders/combobox.ts
@@ -88,6 +88,11 @@ const builder: APISchema = {
 			description: 'The builder store used to create the menu item.',
 			link: '#item',
 		},
+		{
+			name: 'label',
+			description: 'The builder store used to create the label for the combobox.',
+			link: '#label',
+		},
 	],
 };
 
@@ -163,6 +168,17 @@ const item: APISchema = {
 	],
 };
 
+const label: APISchema = {
+	title: 'label',
+	description: 'The label element for the combobox',
+	dataAttributes: [
+		{
+			name: 'data-melt-combobox-label',
+			value: ATTRS.MELT('combobox label'),
+		},
+	],
+};
+
 const arrow: APISchema = {
 	title: 'arrow',
 	description: 'An optional arrow element',
@@ -214,7 +230,7 @@ const keyboard: KeyboardSchema = [
 	},
 ];
 
-const schemas = [builder, menu, input, item, arrow];
+const schemas = [builder, menu, input, item, label, arrow];
 
 const features = [
 	'Full keyboard navigation',

--- a/src/docs/previews/combobox/main/css.svelte
+++ b/src/docs/previews/combobox/main/css.svelte
@@ -63,24 +63,32 @@
 		},
 	];
 
-	const { open, input, menu, item, inputValue, isSelected, filteredItems } =
-		createCombobox({
-			filterFunction: (item, inputValue) => {
-				// Example string normalization function. Replace as needed.
-				const normalize = (str: string) => str.normalize().toLowerCase();
-				const normalizedInput = normalize(inputValue);
-				return (
-					normalizedInput === '' ||
-					normalize(item.title).includes(normalizedInput) ||
-					normalize(item.author).includes(normalizedInput)
-				);
-			},
-			items: books,
-			itemToString: (item) => item.title,
-		});
+	const {
+		open,
+		input,
+		menu,
+		item,
+		inputValue,
+		isSelected,
+		filteredItems,
+		label,
+	} = createCombobox({
+		filterFunction: (item, inputValue) => {
+			// Example string normalization function. Replace as needed.
+			const normalize = (str: string) => str.normalize().toLowerCase();
+			const normalizedInput = normalize(inputValue);
+			return (
+				normalizedInput === '' ||
+				normalize(item.title).includes(normalizedInput) ||
+				normalize(item.author).includes(normalizedInput)
+			);
+		},
+		items: books,
+		itemToString: (item) => item.title,
+	});
 </script>
 
-<label>
+<label melt={$label}>
 	<span>Choose your favorite book:</span>
 	<div>
 		<input melt={$input} placeholder="Best book ever" value={$inputValue} />

--- a/src/docs/previews/combobox/main/tailwind.svelte
+++ b/src/docs/previews/combobox/main/tailwind.svelte
@@ -63,24 +63,32 @@
 		},
 	];
 
-	const { open, input, menu, item, inputValue, isSelected, filteredItems } =
-		createCombobox({
-			filterFunction: (item, inputValue) => {
-				// Example string normalization function. Replace as needed.
-				const normalize = (str: string) => str.normalize().toLowerCase();
-				const normalizedInput = normalize(inputValue);
-				return (
-					normalizedInput === '' ||
-					normalize(item.title).includes(normalizedInput) ||
-					normalize(item.author).includes(normalizedInput)
-				);
-			},
-			items: books,
-			itemToString: (item) => item.title,
-		});
+	const {
+		open,
+		input,
+		menu,
+		item,
+		inputValue,
+		isSelected,
+		filteredItems,
+		label,
+	} = createCombobox({
+		filterFunction: (item, inputValue) => {
+			// Example string normalization function. Replace as needed.
+			const normalize = (str: string) => str.normalize().toLowerCase();
+			const normalizedInput = normalize(inputValue);
+			return (
+				normalizedInput === '' ||
+				normalize(item.title).includes(normalizedInput) ||
+				normalize(item.author).includes(normalizedInput)
+			);
+		},
+		items: books,
+		itemToString: (item) => item.title,
+	});
 </script>
 
-<label class="cursor-pointer">
+<label class="cursor-pointer" melt={$label}>
 	<span class="block pb-1 capitalize">Choose your favorite book:</span>
 	<div class="relative">
 		<input

--- a/src/lib/builders/combobox/create.ts
+++ b/src/lib/builders/combobox/create.ts
@@ -30,6 +30,7 @@ import type { Defaults } from '$lib/internal/types';
 import { tick } from 'svelte';
 import { derived, get, readonly, writable } from 'svelte/store';
 import type { ComboboxItemProps, CreateComboboxProps } from './types';
+import { createLabel } from '../label';
 
 // prettier-ignore
 export const INTERACTION_KEYS = [kbd.ARROW_LEFT, kbd.ARROW_RIGHT, kbd.SHIFT, kbd.CAPS_LOCK, kbd.CONTROL, kbd.ALT, kbd.META, kbd.ENTER, kbd.F1, kbd.F2, kbd.F3, kbd.F4, kbd.F5, kbd.F6, kbd.F7, kbd.F8, kbd.F9, kbd.F10, kbd.F11, kbd.F12];
@@ -335,7 +336,16 @@ export function createCombobox<T>(props: CreateComboboxProps<T>) {
 									floating: { placement: 'bottom', sameWidth: true },
 									focusTrap: null,
 									clickOutside: {
-										handler: () => {
+										handler: (e) => {
+											const target = e.target;
+											if (isHTMLElement(target)) {
+												const closestLabel = target.closest(selector('label'));
+												const isTrigger = target === $activeTrigger;
+												const isLabel = target.id === ids.label;
+												if (closestLabel || isTrigger || isLabel) {
+													return;
+												}
+											}
 											reset();
 											closeMenu();
 										},
@@ -361,6 +371,19 @@ export function createCombobox<T>(props: CreateComboboxProps<T>) {
 				},
 			};
 		},
+	});
+
+	// Use our existing label builder to create a label for the combobox input.
+	const labelBuilder = createLabel();
+	const { action: labelAction } = get(labelBuilder);
+
+	const label = builder(name('label'), {
+		returned: () => {
+			return {
+				id: ids.label,
+			};
+		},
+		action: labelAction,
 	});
 
 	const item = builder(name('item'), {
@@ -438,5 +461,6 @@ export function createCombobox<T>(props: CreateComboboxProps<T>) {
 		menu,
 		input,
 		item,
+		label,
 	};
 }


### PR DESCRIPTION
Closes: #277 

This PR adds a `label`  return to the Combobox builder to ensure the `aria-labelledby` of the input is set to an actual element. 

It's also to ensure the menu doesn't do the close/open flicker when clicking on the label or content within it when the menu is already open.

An alternative I considered was having the user import the label from the label builder separately, but then we'd also have to return an `id` or have them provide an `id` to use for the label and ensure they apply it to the label. This seemed like a bit much to expect. So I went with the more hands-off approach.