### PR TITLE
[Tooltip] Fix a11y attrs & behavior

### DIFF
--- a/.changeset/blue-pugs-learn.md
+++ b/.changeset/blue-pugs-learn.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+[Tooltip] Fix a11y attributes & behavior

--- a/src/docs/content/builders/tooltip.md
+++ b/src/docs/content/builders/tooltip.md
@@ -6,7 +6,7 @@ description:
 ---
 
 <script>
-    import { APIReference, KbdTable } from '$docs/components'
+    import { APIReference, KbdTable, Callout } from '$docs/components'
     export let schemas
     export let keyboard
 </script>
@@ -23,6 +23,19 @@ description:
 
 ## Accessibility
 
-Adheres to the [Tooltip WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/)
+Adheres to the
+[WAI-ARIA tooltip role design pattern](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tooltip_role)
+
+<Callout type="warning">
+
+Tooltips are only opened on hover/focus and not on press, as the tooltip content is used to describe
+the element that would be activated by the press, such as an trashcan icon button which would delete
+something. If the button is pressed, an action should be taken, which in that case it is too late to
+display a tooltip.
+
+Chances are if you have a need to display the tooltip on press, using a tooltip isn't
+accessible/appropriate, and should instead consider using a [Popover](/docs/builders/popover).
+
+</Callout>
 
 <KbdTable {keyboard} />

--- a/src/docs/previews/tooltip/main/tailwind.svelte
+++ b/src/docs/previews/tooltip/main/tailwind.svelte
@@ -10,7 +10,6 @@
 		openDelay: 500,
 		closeDelay: 250,
 	});
-	$: console.log($open);
 </script>
 
 <button

--- a/src/docs/previews/tooltip/main/tailwind.svelte
+++ b/src/docs/previews/tooltip/main/tailwind.svelte
@@ -10,6 +10,7 @@
 		openDelay: 500,
 		closeDelay: 250,
 	});
+	$: console.log($open);
 </script>
 
 <button

--- a/src/lib/builders/tooltip/create.ts
+++ b/src/lib/builders/tooltip/create.ts
@@ -4,7 +4,6 @@ import {
 	createElHelpers,
 	executeCallbacks,
 	generateId,
-	isTouch,
 	noop,
 	omit,
 	styleToString,
@@ -72,15 +71,9 @@ export function createTooltip(props?: CreateTooltipProps) {
 	}) as Readable<() => void>;
 
 	const trigger = builder(name('trigger'), {
-		stores: open,
-		returned: ($open) => {
+		returned: () => {
 			return {
-				role: 'button' as const,
-				'aria-haspopup': 'dialog' as const,
-				'aria-expanded': $open,
-				'data-state': $open ? 'open' : 'closed',
-				'aria-controls': ids.content,
-				id: ids.trigger,
+				'aria-describedby': ids.content,
 			};
 		},
 		action: (node: HTMLElement) => {
@@ -88,19 +81,7 @@ export function createTooltip(props?: CreateTooltipProps) {
 				addEventListener(node, 'mouseover', () => get(openTooltip)()),
 				addEventListener(node, 'mouseout', () => get(closeTooltip)()),
 				addEventListener(node, 'focus', () => open.set(true)),
-				addEventListener(node, 'blur', () => open.set(false)),
-				addEventListener(node, 'pointerdown', (e) => {
-					if (isTouch(e)) {
-						return;
-					}
-
-					e.preventDefault();
-
-					const $options = get(options);
-					if ($options.closeOnPointerDown) {
-						open.set(false);
-					}
-				})
+				addEventListener(node, 'blur', () => open.set(false))
 			);
 
 			return {
@@ -113,6 +94,7 @@ export function createTooltip(props?: CreateTooltipProps) {
 		stores: open,
 		returned: ($open) => {
 			return {
+				role: 'tooltip',
 				hidden: $open ? undefined : true,
 				tabindex: -1,
 				style: styleToString({
@@ -130,7 +112,7 @@ export function createTooltip(props?: CreateTooltipProps) {
 			const unsubOpen = open.subscribe(($open) => {
 				if ($open) {
 					tick().then(() => {
-						const triggerEl = document.getElementById(ids.trigger);
+						const triggerEl = document.querySelector(`[aria-describedby="${ids.content}"]`);
 						if (!triggerEl || node.hidden) return;
 						const $options = get(options);
 						const floatingReturn = useFloating(triggerEl, node, $options.positioning);


### PR DESCRIPTION
Closes: #276

This PR reverts tooltip behavior to align with MDN's [ARIA tooltip role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tooltip_role). Up to this point we had been a bit confused on how to handle the tooltip, but upon reading that pattern ~10 times, here's the conclusion we have come to:

If you expect the tooltip trigger to open the tooltip on click or touch, you shouldn't be using a tooltip, and should instead consider using a popover or collapsible. A common use-case I'd imagine you'd expect the tooltip content to open when pressing the trigger would be something like an "i" or info ⓘ icon, which is not appropriate as described here:
![image](https://github.com/melt-ui/melt-ui/assets/64506580/e4c0c0af-4223-439d-a2cc-a06b5fe708b2)

The appearance of the tooltip should be automatic, and not intentionally controlled by the user:
![image](https://github.com/melt-ui/melt-ui/assets/64506580/d74cdd94-f69e-4d74-bdb4-247359330d10)


