### PR TITLE
fix: Remove `@melt-ui/svelte` alias, add text transform

### DIFF
--- a/.changeset/sour-beds-clap.md
+++ b/.changeset/sour-beds-clap.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+fix: Remove `@melt-ui/svelte` alias, add text transform

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -2,7 +2,7 @@
 /// <reference types="@sveltejs/kit" />
 /// <reference types="unplugin-icons/types/svelte" />
 
-import type { TextDirection } from '@melt-ui/svelte/internal/types';
+import type { TextDirection } from '$lib/internal/types';
 
 // for information about these interfaces
 declare global {

--- a/src/docs/components/info-popover.svelte
+++ b/src/docs/components/info-popover.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { cn } from '$docs/utils';
-	import { createPopover } from '@melt-ui/svelte';
+	import { createPopover } from '$lib';
 	import { fade } from 'svelte/transition';
 	import Info from '~icons/lucide/info';
 

--- a/src/docs/components/nav/mobile-nav.svelte
+++ b/src/docs/components/nav/mobile-nav.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createDialog } from '@melt-ui/svelte';
+	import { createDialog } from '$lib';
 	import { fade, fly } from 'svelte/transition';
 	import Menu from '~icons/lucide/menu';
 	import X from '~icons/lucide/x';

--- a/src/docs/components/preview.svelte
+++ b/src/docs/components/preview.svelte
@@ -25,7 +25,7 @@
 	import { cn } from '$docs/utils';
 	import type { SelectOptionProps } from '$lib';
 	import { usingPreprocessor } from '$routes/store';
-	import { isBrowser } from '@melt-ui/svelte/internal/helpers';
+	import { isBrowser } from '$lib/internal/helpers';
 	import { writable } from 'svelte/store';
 	import CodeBlock from './code-block.svelte';
 	import PreviewWrapper from './preview-wrapper.svelte';

--- a/src/docs/components/ui/button.svelte
+++ b/src/docs/components/ui/button.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { cn } from '$docs/utils';
-	import { noop } from '@melt-ui/svelte/internal/helpers';
+	import { noop } from '$lib/internal/helpers';
 	import type { Action } from 'svelte/action';
 	import type { HTMLAnchorAttributes, HTMLButtonAttributes } from 'svelte/elements';
 	import type { VariantProps } from 'tailwind-variants';

--- a/src/docs/data/builders/pin-input.ts
+++ b/src/docs/data/builders/pin-input.ts
@@ -1,5 +1,5 @@
 import type { APISchema, KeyboardSchema } from '$docs/types';
-import { isMac } from '@melt-ui/svelte/internal/helpers';
+import { isMac } from '$lib/internal/helpers';
 import { ATTRS, DESCRIPTIONS, KBD } from '$docs/constants';
 import type { BuilderData } from '.';
 

--- a/src/docs/previews/accordion/disabled/css.svelte
+++ b/src/docs/previews/accordion/disabled/css.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createAccordion } from '@melt-ui/svelte';
+	import { createAccordion } from '$lib';
 	import { slide } from 'svelte/transition';
 
 	const { content, item, trigger, isSelected, root } = createAccordion();

--- a/src/docs/previews/accordion/disabled/tailwind.svelte
+++ b/src/docs/previews/accordion/disabled/tailwind.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createAccordion } from '@melt-ui/svelte';
+	import { createAccordion } from '$lib';
 	import { slide } from 'svelte/transition';
 
 	const { content, item, trigger, isSelected, root } = createAccordion();

--- a/src/docs/previews/accordion/main/css.svelte
+++ b/src/docs/previews/accordion/main/css.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createAccordion } from '@melt-ui/svelte';
+	import { createAccordion } from '$lib';
 	import { slide } from 'svelte/transition';
 
 	const { content, item, trigger, isSelected, root } = createAccordion();

--- a/src/docs/previews/accordion/main/tailwind.svelte
+++ b/src/docs/previews/accordion/main/tailwind.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createAccordion } from '@melt-ui/svelte';
+	import { createAccordion } from '$lib';
 	import { slide } from 'svelte/transition';
 
 	const { content, item, trigger, isSelected, root } = createAccordion();

--- a/src/docs/previews/accordion/multiple/css.svelte
+++ b/src/docs/previews/accordion/multiple/css.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createAccordion } from '@melt-ui/svelte';
+	import { createAccordion } from '$lib';
 	import { slide } from 'svelte/transition';
 
 	const { content, item, trigger, isSelected, root } = createAccordion({

--- a/src/docs/previews/accordion/multiple/tailwind.svelte
+++ b/src/docs/previews/accordion/multiple/tailwind.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createAccordion } from '@melt-ui/svelte';
+	import { createAccordion } from '$lib';
 	import { slide } from 'svelte/transition';
 
 	const { content, item, trigger, isSelected, root } = createAccordion({

--- a/src/docs/previews/avatar/main/css.svelte
+++ b/src/docs/previews/avatar/main/css.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createAvatar } from '@melt-ui/svelte';
+	import { createAvatar } from '$lib';
 
 	const { image, fallback } = createAvatar({
 		src: 'https://avatars.githubusercontent.com/u/1162160?v=4',

--- a/src/docs/previews/avatar/main/tailwind.svelte
+++ b/src/docs/previews/avatar/main/tailwind.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createAvatar } from '@melt-ui/svelte';
+	import { createAvatar } from '$lib';
 
 	const { image, fallback } = createAvatar({
 		src: 'https://avatars.githubusercontent.com/u/1162160?v=4',

--- a/src/docs/previews/collapsible/main/css.svelte
+++ b/src/docs/previews/collapsible/main/css.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createCollapsible } from '$lib/builders/collapsible';
+	import { createCollapsible } from '$lib';
 	import { slide } from 'svelte/transition';
 	import ChevronsUpDown from '~icons/lucide/chevrons-up-down';
 	import X from '~icons/lucide/x';

--- a/src/docs/previews/collapsible/main/tailwind.svelte
+++ b/src/docs/previews/collapsible/main/tailwind.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createCollapsible } from '$lib/builders/collapsible';
+	import { createCollapsible } from '$lib';
 	import { slide } from 'svelte/transition';
 	import ChevronsUpDown from '~icons/lucide/chevrons-up-down';
 	import X from '~icons/lucide/x';

--- a/src/docs/previews/combobox/main/css.svelte
+++ b/src/docs/previews/combobox/main/css.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createCombobox } from '@melt-ui/svelte';
+	import { createCombobox } from '$lib';
 	import Check from '~icons/lucide/check';
 	import ChevronDown from '~icons/lucide/chevron-down';
 	import ChevronUp from '~icons/lucide/chevron-up';

--- a/src/docs/previews/combobox/main/tailwind.svelte
+++ b/src/docs/previews/combobox/main/tailwind.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createCombobox } from '@melt-ui/svelte';
+	import { createCombobox } from '$lib';
 	import Check from '~icons/lucide/check';
 	import ChevronDown from '~icons/lucide/chevron-down';
 	import ChevronUp from '~icons/lucide/chevron-up';

--- a/src/docs/previews/dialog/alert/css.svelte
+++ b/src/docs/previews/dialog/alert/css.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createDialog } from '@melt-ui/svelte';
+	import { createDialog } from '$lib';
 	/** Internal helpers */
 	import { flyAndScale } from '$docs/utils';
 	import X from '~icons/lucide/x';

--- a/src/docs/previews/dialog/alert/tailwind.svelte
+++ b/src/docs/previews/dialog/alert/tailwind.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createDialog } from '@melt-ui/svelte';
+	import { createDialog } from '$lib';
 	/** Internal helpers */
 	import { flyAndScale } from '$docs/utils';
 	import X from '~icons/lucide/x';

--- a/src/docs/previews/dialog/drawer/css.svelte
+++ b/src/docs/previews/dialog/drawer/css.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createDialog } from '$lib/builders/dialog';
+	import { createDialog } from '$lib';
 	import { fade, fly } from 'svelte/transition';
 	// Internal helpers
 	import X from '~icons/lucide/x';

--- a/src/docs/previews/dialog/drawer/tailwind.svelte
+++ b/src/docs/previews/dialog/drawer/tailwind.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createDialog } from '$lib/builders/dialog';
+	import { createDialog } from '$lib';
 	import { fade, fly } from 'svelte/transition';
 	// Internal helpers
 	import X from '~icons/lucide/x';

--- a/src/docs/previews/dialog/main/css.svelte
+++ b/src/docs/previews/dialog/main/css.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createDialog } from '@melt-ui/svelte';
+	import { createDialog } from '$lib';
 	/** Internal helpers */
 	import { flyAndScale } from '$docs/utils';
 	import X from '~icons/lucide/x';

--- a/src/docs/previews/dialog/main/tailwind.svelte
+++ b/src/docs/previews/dialog/main/tailwind.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createDialog } from '@melt-ui/svelte';
+	import { createDialog } from '$lib';
 	/** Internal helpers */
 	import { flyAndScale } from '$docs/utils';
 	import X from '~icons/lucide/x';

--- a/src/docs/previews/dialog/nested/tailwind.svelte
+++ b/src/docs/previews/dialog/nested/tailwind.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createDialog } from '@melt-ui/svelte';
+	import { createDialog } from '$lib';
 	/** Internal helpers */
 	import { flyAndScale } from '$docs/utils';
 	import X from '~icons/lucide/x';

--- a/src/docs/previews/hover-card/main/tailwind.svelte
+++ b/src/docs/previews/hover-card/main/tailwind.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createHoverCard } from '@melt-ui/svelte';
+	import { createHoverCard } from '$lib';
 	import { fade } from 'svelte/transition';
 
 	const { trigger, content, open, arrow } = createHoverCard();

--- a/src/docs/previews/label/main/tailwind.svelte
+++ b/src/docs/previews/label/main/tailwind.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createLabel } from '@melt-ui/svelte';
+	import { createLabel } from '$lib';
 
 	const root = createLabel();
 </script>

--- a/src/docs/previews/menubar/main/tailwind.svelte
+++ b/src/docs/previews/menubar/main/tailwind.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createMenubar } from '@melt-ui/svelte';
+	import { createMenubar } from '$lib';
 	import { writable } from 'svelte/store';
 	import ChevronRight from '~icons/lucide/chevron-right';
 	import Check from '~icons/lucide/check';

--- a/src/docs/previews/pagination/main/css.svelte
+++ b/src/docs/previews/pagination/main/css.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createPagination } from '@melt-ui/svelte';
+	import { createPagination } from '$lib';
 	import ChevronLeft from '~icons/lucide/chevron-left';
 	import ChevronRight from '~icons/lucide/chevron-right';
 

--- a/src/docs/previews/pagination/main/tailwind.svelte
+++ b/src/docs/previews/pagination/main/tailwind.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createPagination } from '@melt-ui/svelte';
+	import { createPagination } from '$lib';
 	import ChevronLeft from '~icons/lucide/chevron-left';
 	import ChevronRight from '~icons/lucide/chevron-right';
 

--- a/src/docs/previews/pin-input/main/tailwind.svelte
+++ b/src/docs/previews/pin-input/main/tailwind.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createPinInput } from '@melt-ui/svelte';
+	import { createPinInput } from '$lib';
 
 	const { root, input } = createPinInput();
 </script>

--- a/src/docs/previews/popover/main/tailwind.svelte
+++ b/src/docs/previews/popover/main/tailwind.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createPopover } from '@melt-ui/svelte';
+	import { createPopover } from '$lib';
 	import { fade } from 'svelte/transition';
 	import Settings2 from '~icons/lucide/settings2';
 	import X from '~icons/lucide/x';

--- a/src/docs/previews/progress/main/tailwind.svelte
+++ b/src/docs/previews/progress/main/tailwind.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createProgress } from '@melt-ui/svelte';
+	import { createProgress } from '$lib';
 
 	const { progress, value, max } = createProgress({
 		value: 30,

--- a/src/docs/previews/radio-group/main/tailwind.svelte
+++ b/src/docs/previews/radio-group/main/tailwind.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createRadioGroup } from '@melt-ui/svelte';
+	import { createRadioGroup } from '$lib';
 
 	const { root, item, isChecked } = createRadioGroup({
 		value: 'default',

--- a/src/docs/previews/select/main/tailwind.svelte
+++ b/src/docs/previews/select/main/tailwind.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createSelect } from '@melt-ui/svelte';
+	import { createSelect } from '$lib';
 	import Check from '~icons/lucide/check';
 	import ChevronDown from '~icons/lucide/chevron-down';
 

--- a/src/docs/previews/separator/main/css.svelte
+++ b/src/docs/previews/separator/main/css.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createSeparator, type CreateSeparatorProps } from '@melt-ui/svelte';
+	import { createSeparator, type CreateSeparatorProps } from '$lib';
 
 	export let orientation: CreateSeparatorProps['orientation'] = 'vertical';
 

--- a/src/docs/previews/separator/main/tailwind.svelte
+++ b/src/docs/previews/separator/main/tailwind.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createSeparator, type CreateSeparatorProps } from '@melt-ui/svelte';
+	import { createSeparator, type CreateSeparatorProps } from '$lib';
 
 	export let orientation: CreateSeparatorProps['orientation'] = 'vertical';
 

--- a/src/docs/previews/slider/main/tailwind.svelte
+++ b/src/docs/previews/slider/main/tailwind.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createSlider } from '@melt-ui/svelte';
+	import { createSlider } from '$lib';
 
 	const { slider, range, thumb } = createSlider({
 		value: [30],

--- a/src/docs/previews/slider/range/tailwind.svelte
+++ b/src/docs/previews/slider/range/tailwind.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createSlider } from '@melt-ui/svelte';
+	import { createSlider } from '$lib';
 
 	const { slider, range, thumb, value } = createSlider({
 		value: [20, 80],

--- a/src/docs/previews/slider/vertical/tailwind.svelte
+++ b/src/docs/previews/slider/vertical/tailwind.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createSlider } from '@melt-ui/svelte';
+	import { createSlider } from '$lib';
 
 	const { slider, range, thumb } = createSlider({
 		value: [30],

--- a/src/docs/previews/switch/main/tailwind.svelte
+++ b/src/docs/previews/switch/main/tailwind.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createSwitch } from '@melt-ui/svelte';
+	import { createSwitch } from '$lib';
 
 	const { root, input, isChecked } = createSwitch();
 </script>

--- a/src/docs/previews/tabs/main/tailwind.svelte
+++ b/src/docs/previews/tabs/main/tailwind.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createTabs } from '@melt-ui/svelte';
+	import { createTabs } from '$lib';
 
 	const { root, list, content, trigger } = createTabs({
 		value: 'tab1',

--- a/src/docs/previews/tags-input/main/tailwind.svelte
+++ b/src/docs/previews/tags-input/main/tailwind.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createTagsInput } from '@melt-ui/svelte';
+	import { createTagsInput } from '$lib';
 	import X from '~icons/lucide/x';
 
 	const { root, input, tags, tag, deleteTrigger, edit } = createTagsInput({

--- a/src/docs/previews/toast/main/tailwind.svelte
+++ b/src/docs/previews/toast/main/tailwind.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createToaster } from '@melt-ui/svelte';
+	import { createToaster } from '$lib';
 	import { flip } from 'svelte/animate';
 	import { fly } from 'svelte/transition';
 	import X from '~icons/lucide/x';

--- a/src/docs/previews/toggle-group/main/tailwind.svelte
+++ b/src/docs/previews/toggle-group/main/tailwind.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createToggleGroup } from '@melt-ui/svelte';
+	import { createToggleGroup } from '$lib';
 	import AlignCenter from '~icons/lucide/align-center';
 	import AlignLeft from '~icons/lucide/align-left';
 	import AlignRight from '~icons/lucide/align-right';

--- a/src/docs/previews/toggle/main/tailwind.svelte
+++ b/src/docs/previews/toggle/main/tailwind.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createToggle } from '@melt-ui/svelte';
+	import { createToggle } from '$lib';
 	import Italic from '~icons/lucide/italic';
 
 	const { toggle } = createToggle();

--- a/src/docs/previews/toolbar/main/tailwind.svelte
+++ b/src/docs/previews/toolbar/main/tailwind.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createToolbar } from '@melt-ui/svelte';
+	import { createToolbar } from '$lib';
 
 	import Bold from '~icons/lucide/bold';
 	import Italic from '~icons/lucide/italic';

--- a/src/docs/previews/tooltip/main/tailwind.svelte
+++ b/src/docs/previews/tooltip/main/tailwind.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createTooltip } from '@melt-ui/svelte';
+	import { createTooltip } from '$lib';
 	import { fade } from 'svelte/transition';
 	import Plus from '~icons/lucide/plus';
 

--- a/src/docs/utils/preview.ts
+++ b/src/docs/utils/preview.ts
@@ -130,6 +130,14 @@ type GetAllPreviewSnippetsArgs = {
 	fetcher?: typeof fetch;
 };
 
+const replaceLibEntriesRegex = /import (.*) from ["|'](?:\$lib.*)["|']/;
+
+function replaceLibEntries(code: string) {
+	// avoid executing the regex if it doesn't have $lib in the code for performance
+	if (!code.includes('$lib')) return code;
+	return code.replace(replaceLibEntriesRegex, "import $1 from '@melt-ui/svelte'");
+}
+
 export async function getAllPreviewSnippets({ slug, fetcher }: GetAllPreviewSnippetsArgs) {
 	const previewsCode = import.meta.glob(`/src/docs/previews/**/*.svelte`, {
 		as: 'raw',
@@ -140,7 +148,7 @@ export async function getAllPreviewSnippets({ slug, fetcher }: GetAllPreviewSnip
 	for (const [path, resolver] of Object.entries(previewsCode)) {
 		const isMatch = previewPathMatcher(path, slug);
 		if (isMatch) {
-			const prev = { path, content: resolver };
+			const prev = { path, content: replaceLibEntries(resolver) };
 			previewCodeMatches.push(prev);
 		}
 	}

--- a/src/docs/utils/transition.ts
+++ b/src/docs/utils/transition.ts
@@ -1,4 +1,4 @@
-import { styleToString } from '@melt-ui/svelte/internal/helpers';
+import { styleToString } from '$lib/internal/helpers';
 import { cubicOut } from 'svelte/easing';
 import type { TransitionConfig } from 'svelte/transition';
 

--- a/src/lib/builders/accordion/tests/Accordion.spec.ts
+++ b/src/lib/builders/accordion/tests/Accordion.spec.ts
@@ -1,4 +1,4 @@
-import { kbd } from '@melt-ui/svelte/internal/helpers/keyboard';
+import { kbd } from '$lib/internal/helpers/keyboard';
 import { render } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';

--- a/src/lib/builders/accordion/tests/AccordionTest.svelte
+++ b/src/lib/builders/accordion/tests/AccordionTest.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createAccordion, type CreateAccordionProps } from '@melt-ui/svelte';
+	import { createAccordion, type CreateAccordionProps } from '$lib';
 
 	export let type: CreateAccordionProps['type'] = 'single';
 	export let disabled: CreateAccordionProps['disabled'];

--- a/src/lib/builders/dialog/tests/DialogTest.svelte
+++ b/src/lib/builders/dialog/tests/DialogTest.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createDialog } from '@melt-ui/svelte';
+	import { createDialog } from '$lib';
 
 	const { trigger, portal, overlay, content, title, description, close } = createDialog();
 </script>

--- a/src/lib/builders/pagination/tests/cmp.spec.ts
+++ b/src/lib/builders/pagination/tests/cmp.spec.ts
@@ -2,7 +2,7 @@ import { render } from '@testing-library/svelte';
 import { axe } from 'jest-axe';
 import { describe } from 'vitest';
 import cmp from './cmp.svelte';
-import { isHTMLElement } from '@melt-ui/svelte/internal/helpers';
+import { isHTMLElement } from '$lib/internal/helpers';
 
 function getValue(el: HTMLElement) {
 	return el.querySelector('[data-selected]')?.getAttribute('data-value');

--- a/src/lib/builders/pagination/tests/cmp.svelte
+++ b/src/lib/builders/pagination/tests/cmp.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createPagination } from '@melt-ui/svelte';
+	import { createPagination } from '$lib';
 	import ChevronLeft from '~icons/lucide/chevron-left';
 	import ChevronRight from '~icons/lucide/chevron-right';
 

--- a/src/lib/builders/pin-input/create.ts
+++ b/src/lib/builders/pin-input/create.ts
@@ -11,7 +11,7 @@ import {
 	prev,
 	styleToString,
 } from '$lib/internal/helpers';
-import type { Defaults } from '@melt-ui/svelte/internal/types';
+import type { Defaults } from '$lib/internal/types';
 import { tick } from 'svelte';
 import { derived, get, writable } from 'svelte/store';
 import type { CreatePinInputProps } from './types';

--- a/src/lib/builders/progress/create.ts
+++ b/src/lib/builders/progress/create.ts
@@ -1,5 +1,5 @@
 import type { Defaults } from '$lib/internal/types';
-import { builder, createElHelpers } from '@melt-ui/svelte/internal/helpers';
+import { builder, createElHelpers } from '$lib/internal/helpers';
 import { writable } from 'svelte/store';
 import type { CreateProgressProps } from './types';
 

--- a/src/lib/builders/select/create.ts
+++ b/src/lib/builders/select/create.ts
@@ -35,7 +35,7 @@ import { onMount, tick } from 'svelte';
 import { derived, get, writable } from 'svelte/store';
 import { createSeparator } from '../separator';
 import type { CreateSelectProps, SelectOptionProps } from './types';
-import { usePortal } from '@melt-ui/svelte/internal/actions';
+import { usePortal } from '$lib/internal/actions';
 import { createLabel } from '../label';
 
 const defaults = {

--- a/src/lib/builders/toast/create.ts
+++ b/src/lib/builders/toast/create.ts
@@ -9,7 +9,7 @@ import {
 	noop,
 } from '../../internal/helpers';
 import type { AddToastProps, Toast } from './types';
-import { usePortal } from '@melt-ui/svelte/internal/actions';
+import { usePortal } from '$lib/internal/actions';
 
 type ToastParts = 'content' | 'title' | 'description' | 'close';
 const { name } = createElHelpers<ToastParts>('toast');

--- a/src/stories/Dialog/BaseDialog.svelte
+++ b/src/stories/Dialog/BaseDialog.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import type { CreateDialogReturn } from '@melt-ui/svelte';
-	import { styleToString } from '@melt-ui/svelte/internal/helpers';
+	import type { CreateDialogReturn } from '$lib';
+	import { styleToString } from '$lib/internal/helpers';
 	import { cubicOut } from 'svelte/easing';
 	import type { TransitionConfig } from 'svelte/transition';
 

--- a/src/stories/Dialog/Dialog.svelte
+++ b/src/stories/Dialog/Dialog.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createDialog } from '@melt-ui/svelte';
+	import { createDialog } from '$lib';
 	/** Internal helpers */
 	import { PreviewWrapper } from '$docs/components';
 	import BaseDialog from './BaseDialog.svelte';

--- a/src/stories/Dialog/NestedDialog.svelte
+++ b/src/stories/Dialog/NestedDialog.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createDialog } from '@melt-ui/svelte';
+	import { createDialog } from '$lib';
 	/** Internal helpers */
 	import { PreviewWrapper } from '$docs/components';
 	import BaseDialog from './BaseDialog.svelte';

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -28,7 +28,6 @@ const config = {
 			'$routes/*': 'src/routes/*',
 			'$test-helpers': 'src/test-helpers',
 			$constants: 'src/constants',
-			'@melt-ui/svelte': 'src/lib',
 			$docs: 'src/docs',
 			'$docs/*': 'src/docs/*',
 			$components: 'src/docs/components',


### PR DESCRIPTION
This PR removes `@melt-ui/svelte` alias in favor of `$lib` while at the same time adding a regex to replace `$lib` with `@melt-ui/svelte` in the docs.

I've also replaced some imports from deeper in the tree (importing directly from a builder folder) with a more short and better `$lib`.

A couple of noted:

1. The regex replace every import that starts with `$lib` with `@melt-ui/svelte` (only in the preview code obviosuly) so even occurrencies of "$lib/builders/builderName" will be substituted.
2. Could enforce or at least warn of imports deeper in the tree in the previews folder make sense? It might be an easy enaugh custom eslint rule.
3. I've talked about this with @TGlide and that's why i'm making this PR, it's not out of the blue 😆 