### PR TITLE
chore: add eslint rule to prevent imports from lib/builders

### DIFF
--- a/.changeset/green-apes-explode.md
+++ b/.changeset/green-apes-explode.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+chore: add eslint rule to prevent imports from lib/builders

--- a/.changeset/green-apes-explode.md
+++ b/.changeset/green-apes-explode.md
@@ -1,5 +1,0 @@
----
-"@melt-ui/svelte": patch
----
-
-chore: add eslint rule to prevent imports from lib/builders

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -29,6 +29,21 @@ module.exports = {
 	},
 	rules: {
 		'no-console': 'warn',
+		'no-restricted-imports': [
+			'error',
+			{
+				patterns: [
+					{
+						group: ['**/lib/builders/*'],
+						message: 'If you need to import a builder do it from the root `$lib`',
+					},
+					{
+						group: ['$lib/builders/*'],
+						message: 'If you need to import a builder do it from the root `$lib`',
+					},
+				],
+			},
+		],
 	},
 	globals: {
 		NodeJS: true,

--- a/src/lib/builders/hover-card/create.ts
+++ b/src/lib/builders/hover-card/create.ts
@@ -107,9 +107,9 @@ export function createHoverCard(props: CreateHoverCardProps = {}) {
 				addEventListener(node, 'touchstart', (e) => {
 					// prevent focus on touch devices
 					e.preventDefault();
-                    const currentTarget = e.currentTarget
-                    if (!isHTMLElement(currentTarget)) return
-                    currentTarget.click()
+					const currentTarget = e.currentTarget;
+					if (!isHTMLElement(currentTarget)) return;
+					currentTarget.click();
 				})
 			);
 

--- a/src/stories/Collapsible/Collapsible.svelte
+++ b/src/stories/Collapsible/Collapsible.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createCollapsible } from '$lib/builders/collapsible';
+	import { createCollapsible } from '$lib';
 	import { PreviewWrapper } from '$docs/components';
 	import { slide } from 'svelte/transition';
 	import X from '~icons/lucide/x';


### PR DESCRIPTION
This rule prevent accidentally importing from `$lib/builders/*` given that the preferred way should be importing from `$lib` directly.

I've also fixed one occurence of this lint rule.