### PR TITLE
Add a more complete explanation for global usage of the toast builder

### DIFF
--- a/src/docs/content/builders/toast.md
+++ b/src/docs/content/builders/toast.md
@@ -24,20 +24,19 @@ you call the builder function `createToaster` inside the lib directory. This wil
 accessible to all components in your application.
 
 ```typescript
-// lib/toast.ts
 import { createToaster } from '@melt-ui/svelte'
 
 export type ToastData = {
-  title: string
-  description: string
-  color: string
+	title: string
+	description: string
+	color: string
 }
 
 export const {
-  elements: { content, title, description, close },
-  helpers: { addToast },
-  states: { toasts },
-  actions: { portal }
+	elements: { content, title, description, close },
+	helpers: { addToast },
+	states: { toasts },
+	actions: { portal }
 } = createToaster<ToastData>()
 ```
 
@@ -45,42 +44,41 @@ The second step is to create a `Toast` component that will be used to render toa
 
 ```svelte
 <script lang="ts">
-  // lib/Toast.svelte
-  import { flip } from 'svelte/animate'
-  import { fly } from 'svelte/transition'
-  import { melt } from '@melt-ui/svelte'
-  import X from '~icons/lucide/x'
-  import { toasts, content, portal, title, description, close } from './toast'
+	import { flip } from 'svelte/animate'
+	import { fly } from 'svelte/transition'
+	import { melt } from '@melt-ui/svelte'
+	import X from '~icons/lucide/x'
+	import { toasts, content, portal, title, description, close } from './toast'
 </script>
 
 <div class="fixed bottom-0 right-0 z-50 m-4 flex flex-col items-end gap-2" use:portal>
-  {#each $toasts as { id, data } (id)}
-    <div
-      use:melt={$content(id)}
-      animate:flip={{ duration: 500 }}
-      in:fly={{ duration: 150, x: '100%' }}
-      out:fly={{ duration: 150, x: '100%' }}
-      class="rounded-lg bg-neutral-700 text-white shadow-md">
-      <div
-        class="relative flex w-[24rem] max-w-[calc(100vw-2rem)] items-center justify-between gap-4 p-5">
-        <div>
-          <h3 use:melt={$title(id)} class="flex items-center gap-2 font-semibold">
-            {data.title}
-            <span class="rounded-full square-1.5 {data.color}" />
-          </h3>
-          <div use:melt={$description(id)}>
-            {data.description}
-          </div>
-        </div>
-        <button
-          use:melt={$close(id)}
-          class="absolute right-4 top-4 grid place-items-center rounded-full text-magnum-500 square-6
+	{#each $toasts as { id, data } (id)}
+		<div
+			use:melt={$content(id)}
+			animate:flip={{ duration: 500 }}
+			in:fly={{ duration: 150, x: '100%' }}
+			out:fly={{ duration: 150, x: '100%' }}
+			class="rounded-lg bg-neutral-700 text-white shadow-md">
+			<div
+				class="relative flex w-[24rem] max-w-[calc(100vw-2rem)] items-center justify-between gap-4 p-5">
+				<div>
+					<h3 use:melt={$title(id)} class="flex items-center gap-2 font-semibold">
+						{data.title}
+						<span class="rounded-full square-1.5 {data.color}" />
+					</h3>
+					<div use:melt={$description(id)}>
+						{data.description}
+					</div>
+				</div>
+				<button
+					use:melt={$close(id)}
+					class="absolute right-4 top-4 grid place-items-center rounded-full text-magnum-500 square-6
           hover:bg-magnum-900/50">
-          <X />
-        </button>
-      </div>
-    </div>
-  {/each}
+					<X />
+				</button>
+			</div>
+		</div>
+	{/each}
 </div>
 ```
 
@@ -88,8 +86,7 @@ This component should be added to your root `+layout.svelte` or `App.svelte` com
 
 ```svelte
 <script>
-  // routes/+layout.svelte
-  import Toast from '$lib/Toast.svelte'
+	import Toast from '$lib/Toast.svelte'
 </script>
 
 <Toast />
@@ -102,24 +99,24 @@ application.
 
 ```svelte
 <script lang="ts">
-  import { addToast } from '$lib/toast'
+	import { addToast } from '$lib/toast'
 
-  function create() {
-    addToast({
-      data: {
-        title: 'Success',
-        description: 'The resource was created!',
-        color: 'bg-green-500'
-      }
-    })
-  }
+	function create() {
+		addToast({
+			data: {
+				title: 'Success',
+				description: 'The resource was created!',
+				color: 'bg-green-500'
+			}
+		})
+	}
 </script>
 
 <button
-  class="inline-flex items-center justify-center rounded-md bg-white px-4 py-2 font-medium leading-none
+	class="inline-flex items-center justify-center rounded-md bg-white px-4 py-2 font-medium leading-none
   text-magnum-700 shadow-lg hover:opacity-75"
-  on:click={create}>
-  Create
+	on:click={create}>
+	Create
 </button>
 ```
 

--- a/src/docs/content/builders/toast.md
+++ b/src/docs/content/builders/toast.md
@@ -23,32 +23,35 @@ that can be accessed from anywhere in your application. To accomplish this, it i
 you call the builder function `createToaster` inside the lib directory. This will make the function
 accessible to all components in your application.
 
-```typescript
-import { createToaster } from '@melt-ui/svelte'
-
-export type ToastData = {
-	title: string
-	description: string
-	color: string
-}
-
-export const {
-	elements: { content, title, description, close },
-	helpers: { addToast },
-	states: { toasts },
-	actions: { portal }
-} = createToaster<ToastData>()
-```
-
-The second step is to create a `Toast` component that will be used to render toast notifications.
+The first step is to create a `Toast` component that will be used to render toast notifications. We
+can take advantage of
+[Svelte context module](https://svelte.dev/docs/svelte-components#script-context-module) to create
+the template for the toast notifications and expose the helper function so it can be used in other
+components.
 
 ```svelte
+<script lang="ts" context="module">
+	export type ToastData = {
+		title: string
+		description: string
+		color: string
+	}
+
+	const {
+		elements: { content, title, description, close },
+		helpers,
+		states: { toasts },
+		actions: { portal }
+	} = createToaster<ToastData>()
+
+	export const addToast = helpers.addToast
+</script>
+
 <script lang="ts">
+	import { createToaster, melt } from '@melt-ui/svelte'
 	import { flip } from 'svelte/animate'
 	import { fly } from 'svelte/transition'
-	import { melt } from '@melt-ui/svelte'
-	import X from '~icons/lucide/x'
-	import { toasts, content, portal, title, description, close } from './toast'
+	import { X } from 'lucide-svelte'
 </script>
 
 <div class="fixed bottom-0 right-0 z-50 m-4 flex flex-col items-end gap-2" use:portal>
@@ -74,7 +77,7 @@ The second step is to create a `Toast` component that will be used to render toa
 					use:melt={$close(id)}
 					class="absolute right-4 top-4 grid place-items-center rounded-full text-magnum-500 square-6
           hover:bg-magnum-900/50">
-					<X />
+					<X class="square-4" />
 				</button>
 			</div>
 		</div>
@@ -94,12 +97,12 @@ This component should be added to your root `+layout.svelte` or `App.svelte` com
 <slot />
 ```
 
-Finally, you can use the exported `addToast` function to add a toast from any component of the
-application.
+Finally, you can use the exported `addToast` helper function to add a toast from any component of
+the application.
 
 ```svelte
 <script lang="ts">
-	import { addToast } from '$lib/toast'
+	import { addToast } from '$lib/Toast.svelte'
 
 	function create() {
 		addToast({

--- a/src/docs/content/builders/toast.md
+++ b/src/docs/content/builders/toast.md
@@ -18,8 +18,109 @@ description: A succinct message that is displayed temporarily.
 
 ## Usage
 
-To create a toast, use the `createToast` builder function. You can then reference the anatomy or
+Unlike most builders, the toast is not component-based. Instead, it provides a global functionality
+that can be accessed from anywhere in your application. To accomplish this, it is recommended that
+you call the builder function inside the lib directory. This will make the function accessible to
+all components in your application.
+
+To create a toast, use the `createToaster` builder function. You can then reference the anatomy or
 example above to create your toast.
+
+```typescript
+// lib/toast.ts
+import { createToaster } from '@melt-ui/svelte'
+
+export type ToastData = {
+  title: string
+  description: string
+  color: string
+}
+
+export const { toasts, addToast, content, title, description, close, portal } =
+  createToaster<ToastData>({})
+```
+
+The second step is to create a `Toast` component that will be used to render toast notifications.
+
+```svelte
+<script lang="ts">
+  // lib/Toast.svelte
+  import { flip } from 'svelte/animate'
+  import { fly } from 'svelte/transition'
+  import X from '~icons/lucide/x'
+  import { toasts, content, portal, description, title, close } from './toast'
+</script>
+
+<div class="fixed bottom-0 right-0 z-50 m-4 flex flex-col items-end gap-2" use:portal>
+  {#each $toasts as { id, data } (id)}
+    <div
+      melt={$content(id)}
+      animate:flip={{ duration: 500 }}
+      in:fly={{ duration: 150, x: '100%' }}
+      out:fly={{ duration: 150, x: '100%' }}
+      class="rounded-lg bg-neutral-700 text-white shadow-md">
+      <div
+        class="relative flex w-[24rem] max-w-[calc(100vw-2rem)] items-center justify-between gap-4 p-5">
+        <div>
+          <h3 melt={$title(id)} class="flex items-center gap-2 font-semibold">
+            {data.title}
+            <span class="rounded-full square-1.5 {data.color}" />
+          </h3>
+          <div melt={$description(id)}>
+            {data.description}
+          </div>
+        </div>
+        <button
+          melt={$close(id)}
+          class="absolute right-4 top-4 grid place-items-center rounded-full text-magnum-500 square-6
+          hover:bg-magnum-900/50">
+          <X />
+        </button>
+      </div>
+    </div>
+  {/each}
+</div>
+```
+
+This component should be placed in your root `+layout.svelte` or `App.svelte` component.
+
+```svelte
+<script>
+  // routes/+layout.svelte
+  import Toast from '$lib/toast/Toast.svelte'
+</script>
+
+<Toast />
+
+<slot />
+```
+
+Finally, you can use the exported `addToast` function to add a toast from any component of the
+application.
+
+```svelte
+<script lang="ts">
+  import { addToast } from '$lib/toast'
+
+  function create() {
+    // ...
+    addToast({
+      data: {
+        title: 'Success',
+        description: 'The resource was created!',
+        color: 'bg-green-500'
+      }
+    })
+  }
+</script>
+
+<button
+  class="inline-flex items-center justify-center rounded-md bg-white px-4 py-2 font-medium leading-none
+  text-magnum-700 shadow-lg hover:opacity-75"
+  on:click={create}>
+  Create
+</button>
+```
 
 ## API Reference
 

--- a/src/docs/content/builders/toast.md
+++ b/src/docs/content/builders/toast.md
@@ -20,11 +20,10 @@ description: A succinct message that is displayed temporarily.
 
 Unlike most builders, the toast is not component-based. Instead, it provides a global functionality
 that can be accessed from anywhere in your application. To accomplish this, it is recommended that
-you call the builder function `createToaster` inside the lib directory. This will make the function
-accessible to all components in your application.
+you create a global component that is called on the root of your application.
 
-The first step is to create a `Toast` component that will be used to render toast notifications. We
-can take advantage of
+The first step is to create a `Toaster` component that will be used to render toast notifications.
+We can take advantage of
 [Svelte context module](https://svelte.dev/docs/svelte-components#script-context-module) to create
 the template for the toast notifications and expose the helper function so it can be used in other
 components.
@@ -89,10 +88,10 @@ This component should be added to your root `+layout.svelte` or `App.svelte` com
 
 ```svelte
 <script>
-	import Toast from '$lib/Toast.svelte'
+	import Toaster from '$lib/Toaster.svelte'
 </script>
 
-<Toast />
+<Toaster />
 
 <slot />
 ```
@@ -102,7 +101,7 @@ the application.
 
 ```svelte
 <script lang="ts">
-	import { addToast } from '$lib/Toast.svelte'
+	import { addToast } from '$lib/Toaster.svelte'
 
 	function create() {
 		addToast({

--- a/src/docs/content/builders/toast.md
+++ b/src/docs/content/builders/toast.md
@@ -20,11 +20,8 @@ description: A succinct message that is displayed temporarily.
 
 Unlike most builders, the toast is not component-based. Instead, it provides a global functionality
 that can be accessed from anywhere in your application. To accomplish this, it is recommended that
-you call the builder function inside the lib directory. This will make the function accessible to
-all components in your application.
-
-To create a toast, use the `createToaster` builder function. You can then reference the anatomy or
-example above to create your toast.
+you call the builder function `createToaster` inside the lib directory. This will make the function
+accessible to all components in your application.
 
 ```typescript
 // lib/toast.ts
@@ -36,8 +33,12 @@ export type ToastData = {
   color: string
 }
 
-export const { toasts, addToast, content, title, description, close, portal } =
-  createToaster<ToastData>({})
+export const {
+  elements: { content, title, description, close },
+  helpers: { addToast },
+  states: { toasts },
+  actions: { portal }
+} = createToaster<ToastData>()
 ```
 
 The second step is to create a `Toast` component that will be used to render toast notifications.
@@ -47,14 +48,15 @@ The second step is to create a `Toast` component that will be used to render toa
   // lib/Toast.svelte
   import { flip } from 'svelte/animate'
   import { fly } from 'svelte/transition'
+  import { melt } from '@melt-ui/svelte'
   import X from '~icons/lucide/x'
-  import { toasts, content, portal, description, title, close } from './toast'
+  import { toasts, content, portal, title, description, close } from './toast'
 </script>
 
 <div class="fixed bottom-0 right-0 z-50 m-4 flex flex-col items-end gap-2" use:portal>
   {#each $toasts as { id, data } (id)}
     <div
-      melt={$content(id)}
+      use:melt={$content(id)}
       animate:flip={{ duration: 500 }}
       in:fly={{ duration: 150, x: '100%' }}
       out:fly={{ duration: 150, x: '100%' }}
@@ -62,16 +64,16 @@ The second step is to create a `Toast` component that will be used to render toa
       <div
         class="relative flex w-[24rem] max-w-[calc(100vw-2rem)] items-center justify-between gap-4 p-5">
         <div>
-          <h3 melt={$title(id)} class="flex items-center gap-2 font-semibold">
+          <h3 use:melt={$title(id)} class="flex items-center gap-2 font-semibold">
             {data.title}
             <span class="rounded-full square-1.5 {data.color}" />
           </h3>
-          <div melt={$description(id)}>
+          <div use:melt={$description(id)}>
             {data.description}
           </div>
         </div>
         <button
-          melt={$close(id)}
+          use:melt={$close(id)}
           class="absolute right-4 top-4 grid place-items-center rounded-full text-magnum-500 square-6
           hover:bg-magnum-900/50">
           <X />
@@ -82,12 +84,12 @@ The second step is to create a `Toast` component that will be used to render toa
 </div>
 ```
 
-This component should be placed in your root `+layout.svelte` or `App.svelte` component.
+This component should be added to your root `+layout.svelte` or `App.svelte` component.
 
 ```svelte
 <script>
   // routes/+layout.svelte
-  import Toast from '$lib/toast/Toast.svelte'
+  import Toast from '$lib/Toast.svelte'
 </script>
 
 <Toast />
@@ -103,7 +105,6 @@ application.
   import { addToast } from '$lib/toast'
 
   function create() {
-    // ...
     addToast({
       data: {
         title: 'Success',


### PR DESCRIPTION
This is the first approach to improve the docs of the toast builder, which will help users understand how to use the toast as global functionality.

After some testing, I found that it was better to introduce this in the "Usage" section, so that the first example remains a unit. Another alternative is to introduce this as an additional example. Let me know what you think!

PD: The formatter wouldn't allow me to place the `// ...path/to/file` comments at the top of each snippet.