### PR TITLE
refactor: internal menu types

### DIFF
--- a/.changeset/calm-flowers-watch.md
+++ b/.changeset/calm-flowers-watch.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': minor
+---
+
+convert controllable returned states from readables to writables

--- a/.changeset/real-brooms-rescue.md
+++ b/.changeset/real-brooms-rescue.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+refactor: internal menu types

--- a/src/docs/data/builders/accordion.ts
+++ b/src/docs/data/builders/accordion.ts
@@ -166,6 +166,10 @@ const trigger = elementSchema('trigger', {
 			value: 'The value of the associated item.',
 		},
 		{
+			name: 'data-state',
+			value: ATTRS.OPEN_CLOSED,
+		},
+		{
 			name: 'data-melt-accordion-trigger',
 			value: ATTRS.MELT('accordion trigger'),
 		},

--- a/src/lib/builders/accordion/create.ts
+++ b/src/lib/builders/accordion/create.ts
@@ -104,6 +104,7 @@ export const createAccordion = <Multiple extends boolean = false>(
 					'aria-disabled': disabled ? true : false,
 					'data-disabled': disabled ? true : undefined,
 					'data-value': itemValue,
+					'data-state': isSelected(itemValue, $value) ? 'open' : 'closed',
 				};
 			};
 		},

--- a/src/lib/builders/context-menu/create.ts
+++ b/src/lib/builders/context-menu/create.ts
@@ -30,7 +30,7 @@ import {
 	handleMenuNavigation,
 	handleTabNavigation,
 	setMeltMenuAttribute,
-	type MenuParts,
+	type _MenuParts,
 	type Point,
 } from '../menu';
 import type { ContextMenuEvents } from './events';
@@ -51,7 +51,7 @@ const defaults = {
 	forceVisible: false,
 } satisfies CreateContextMenuProps;
 
-const { name, selector } = createElHelpers<MenuParts>('context-menu');
+const { name, selector } = createElHelpers<_MenuParts>('context-menu');
 
 export function createContextMenu(props?: CreateContextMenuProps) {
 	const withDefaults = { ...defaults, ...props } satisfies CreateContextMenuProps;

--- a/src/lib/builders/context-menu/types.ts
+++ b/src/lib/builders/context-menu/types.ts
@@ -1,15 +1,15 @@
 import type { BuilderReturn } from '$lib/internal/types';
-import type { Menu } from '../menu';
+import type { _Menu } from '../menu';
 import type { createContextMenu } from './create';
 
 // Props
-export type CreateContextMenuProps = Menu['builder'];
-export type CreateContextSubmenuProps = Menu['submenu'];
-export type ContextMenuItemProps = Menu['item'];
-export type ContextMenuCheckboxItemProps = Menu['checkboxItem'];
-export type CreateContextMenuRadioGroupProps = Menu['radioGroup'];
-export type ContextMenuRadioItemProps = Menu['radioItem'];
-export type ContextMenuRadioItemActionProps = Menu['radioItemAction'];
+export type CreateContextMenuProps = _Menu['builder'];
+export type CreateContextSubmenuProps = _Menu['submenu'];
+export type ContextMenuItemProps = _Menu['item'];
+export type ContextMenuCheckboxItemProps = _Menu['checkboxItem'];
+export type CreateContextMenuRadioGroupProps = _Menu['radioGroup'];
+export type ContextMenuRadioItemProps = _Menu['radioItem'];
+export type ContextMenuRadioItemActionProps = _Menu['radioItemAction'];
 
 // Returns
 export type ContextMenu = BuilderReturn<typeof createContextMenu>;

--- a/src/lib/builders/dropdown-menu/types.ts
+++ b/src/lib/builders/dropdown-menu/types.ts
@@ -1,15 +1,15 @@
 import type { BuilderReturn } from '$lib/internal/types';
-import type { Menu } from '../menu';
+import type { _Menu } from '../menu';
 import type { createDropdownMenu } from './create';
 
 // Props
-export type CreateDropdownMenuProps = Menu['builder'];
-export type CreateDropdownSubmenuProps = Menu['submenu'];
-export type DropdownMenuItemProps = Menu['item'];
-export type DropdownMenuCheckboxItemProps = Menu['checkboxItem'];
-export type CreateDropdownMenuRadioGroupProps = Menu['radioGroup'];
-export type DropdownMenuRadioItemProps = Menu['radioItem'];
-export type DropdownMenuRadioItemActionProps = Menu['radioItemAction'];
+export type CreateDropdownMenuProps = _Menu['builder'];
+export type CreateDropdownSubmenuProps = _Menu['submenu'];
+export type DropdownMenuItemProps = _Menu['item'];
+export type DropdownMenuCheckboxItemProps = _Menu['checkboxItem'];
+export type CreateDropdownMenuRadioGroupProps = _Menu['radioGroup'];
+export type DropdownMenuRadioItemProps = _Menu['radioItem'];
+export type DropdownMenuRadioItemActionProps = _Menu['radioItemAction'];
 
 // Returns
 export type DropdownMenu = BuilderReturn<typeof createDropdownMenu>;

--- a/src/lib/builders/menu/create.ts
+++ b/src/lib/builders/menu/create.ts
@@ -36,13 +36,13 @@ import { derived, get, writable, type Writable } from 'svelte/store';
 
 import type { MenuEvents } from './events';
 import type {
-	CheckboxItemProps,
-	CreateMenuProps,
-	CreateRadioGroupProps,
-	CreateSubmenuProps,
-	MenuBuilderOptions,
-	MenuParts,
-	RadioItemProps,
+	_CheckboxItemProps,
+	_CreateMenuProps,
+	_CreateRadioGroupProps,
+	_CreateSubmenuProps,
+	_MenuBuilderOptions,
+	_MenuParts,
+	_RadioItemProps,
 	Selector,
 } from './types';
 
@@ -67,10 +67,10 @@ const defaults = {
 	loop: false,
 	dir: 'ltr',
 	defaultOpen: false,
-} satisfies Defaults<CreateMenuProps>;
+} satisfies Defaults<_CreateMenuProps>;
 
-export function createMenuBuilder(opts: MenuBuilderOptions) {
-	const { name, selector } = createElHelpers<MenuParts>(opts.selector);
+export function createMenuBuilder(opts: _MenuBuilderOptions) {
+	const { name, selector } = createElHelpers<_MenuParts>(opts.selector);
 
 	const {
 		preventScroll,
@@ -363,8 +363,8 @@ export function createMenuBuilder(opts: MenuBuilderOptions) {
 		disabled: false,
 	};
 
-	const createCheckboxItem = (props?: CheckboxItemProps) => {
-		const withDefaults = { ...checkboxItemDefaults, ...props } satisfies CheckboxItemProps;
+	const createCheckboxItem = (props?: _CheckboxItemProps) => {
+		const withDefaults = { ...checkboxItemDefaults, ...props } satisfies _CheckboxItemProps;
 		const checkedWritable = withDefaults.checked ?? writable(withDefaults.defaultChecked ?? null);
 		const checked = overridable(checkedWritable, withDefaults.onCheckedChange);
 		const disabled = writable(withDefaults.disabled);
@@ -463,7 +463,7 @@ export function createMenuBuilder(opts: MenuBuilderOptions) {
 		};
 	};
 
-	const createMenuRadioGroup = (args: CreateRadioGroupProps = {}) => {
+	const createMenuRadioGroup = (args: _CreateRadioGroupProps = {}) => {
 		const valueWritable = args.value ?? writable(args.defaultValue ?? null);
 		const value = overridable(valueWritable, args.onValueChange);
 
@@ -480,7 +480,7 @@ export function createMenuBuilder(opts: MenuBuilderOptions) {
 		const radioItem = builder(name('radio-item'), {
 			stores: [value],
 			returned: ([$value]) => {
-				return (itemProps: RadioItemProps) => {
+				return (itemProps: _RadioItemProps) => {
 					const { value: itemValue, disabled } = { ...radioItemDefaults, ...itemProps };
 					const checked = $value === itemValue;
 
@@ -609,10 +609,10 @@ export function createMenuBuilder(opts: MenuBuilderOptions) {
 			placement: 'right-start',
 			gutter: 8,
 		},
-	} satisfies Defaults<CreateSubmenuProps>;
+	} satisfies Defaults<_CreateSubmenuProps>;
 
-	const createSubmenu = (args?: CreateSubmenuProps) => {
-		const withDefaults = { ...subMenuDefaults, ...args } satisfies CreateSubmenuProps;
+	const createSubmenu = (args?: _CreateSubmenuProps) => {
+		const withDefaults = { ...subMenuDefaults, ...args } satisfies _CreateSubmenuProps;
 
 		const subOpen = writable(false);
 

--- a/src/lib/builders/menu/types.ts
+++ b/src/lib/builders/menu/types.ts
@@ -4,7 +4,7 @@ import type { ChangeFn } from '$lib/internal/helpers';
 import type { Writable } from 'svelte/store';
 import type { createMenuBuilder } from './create';
 
-export type CreateMenuProps = {
+export type _CreateMenuProps = {
 	/**
 	 * Options for positioning the popover menu.
 	 *
@@ -95,44 +95,44 @@ export type CreateMenuProps = {
 	forceVisible?: boolean;
 };
 
-export type CreateSubmenuProps = Pick<CreateMenuProps, 'arrowSize' | 'positioning'> & {
+export type _CreateSubmenuProps = Pick<_CreateMenuProps, 'arrowSize' | 'positioning'> & {
 	disabled?: boolean;
 };
 
-export type CreateRadioGroupProps = {
+export type _CreateRadioGroupProps = {
 	defaultValue?: string;
 	value?: Writable<string>;
 	onValueChange?: ChangeFn<string | null>;
 };
 
-export type ItemProps = {
+export type _ItemProps = {
 	disabled?: boolean;
 };
 
-export type CheckboxItemProps = ItemProps & {
+export type _CheckboxItemProps = _ItemProps & {
 	defaultChecked?: boolean | 'indeterminate';
 	checked?: Writable<boolean | 'indeterminate'>;
 	onCheckedChange?: ChangeFn<boolean | 'indeterminate'>;
 };
 
-export type RadioItemProps = {
+export type _RadioItemProps = {
 	value: string;
 	disabled?: boolean;
 };
 
-export type RadioItemActionProps = ItemProps;
+export type _RadioItemActionProps = _ItemProps;
 
-export type Menu = {
-	builder: CreateMenuProps;
-	submenu: CreateSubmenuProps;
-	radioGroup: CreateRadioGroupProps;
-	item: ItemProps;
-	checkboxItem: CheckboxItemProps;
-	radioItem: RadioItemProps;
-	radioItemAction: RadioItemActionProps;
+export type _Menu = {
+	builder: _CreateMenuProps;
+	submenu: _CreateSubmenuProps;
+	radioGroup: _CreateRadioGroupProps;
+	item: _ItemProps;
+	checkboxItem: _CheckboxItemProps;
+	radioItem: _RadioItemProps;
+	radioItemAction: _RadioItemActionProps;
 };
 
-export type MenuBuilderOptions = {
+export type _MenuBuilderOptions = {
 	rootOpen: Writable<boolean>;
 	rootActiveTrigger: Writable<HTMLElement | null>;
 	rootOptions: {
@@ -153,7 +153,7 @@ export type MenuBuilderOptions = {
 	selector: string;
 };
 
-export type MenuParts =
+export type _MenuParts =
 	| 'trigger'
 	| 'arrow'
 	| 'checkbox-item'
@@ -164,6 +164,6 @@ export type MenuParts =
 	| 'subtrigger'
 	| 'subarrow';
 
-export type Selector = (part?: MenuParts | undefined) => string;
+export type Selector = (part?: _MenuParts | undefined) => string;
 
-export type CreateMenuReturn = ReturnType<typeof createMenuBuilder>;
+export type _CreateMenuReturn = ReturnType<typeof createMenuBuilder>;

--- a/src/lib/builders/menubar/create.ts
+++ b/src/lib/builders/menubar/create.ts
@@ -5,7 +5,7 @@ import {
 	getMenuItems,
 	handleMenuNavigation,
 	handleTabNavigation,
-	type MenuParts,
+	type _MenuParts,
 } from '../menu';
 import {
 	executeCallbacks,
@@ -39,7 +39,7 @@ import type { MenubarEvents } from './events';
 
 const MENUBAR_NAV_KEYS = [kbd.ARROW_LEFT, kbd.ARROW_RIGHT, kbd.HOME, kbd.END];
 
-const { name } = createElHelpers<MenuParts | 'menu'>('menubar');
+const { name } = createElHelpers<_MenuParts | 'menu'>('menubar');
 
 const defaults = {
 	loop: true,

--- a/src/lib/builders/menubar/types.ts
+++ b/src/lib/builders/menubar/types.ts
@@ -1,5 +1,5 @@
 import type { BuilderReturn } from '$lib/internal/types';
-import type { Menu } from '../menu';
+import type { _Menu } from '../menu';
 import type { createMenubar } from './create';
 
 // Props
@@ -17,13 +17,13 @@ export type CreateMenubarProps = {
 	 */
 	closeOnEscape?: boolean;
 };
-export type CreateMenubarMenuProps = Menu['builder'];
-export type CreateMenubarSubmenuProps = Menu['submenu'];
-export type MenubarMenuItemProps = Menu['item'];
-export type MenubarCheckboxItemProps = Menu['checkboxItem'];
-export type CreateMenuRadioGroupProps = Menu['radioGroup'];
-export type MenubarRadioItemProps = Menu['radioItem'];
-export type MenubarRadioItemActionProps = Menu['radioItemAction'];
+export type CreateMenubarMenuProps = _Menu['builder'];
+export type CreateMenubarSubmenuProps = _Menu['submenu'];
+export type MenubarMenuItemProps = _Menu['item'];
+export type MenubarCheckboxItemProps = _Menu['checkboxItem'];
+export type CreateMenuRadioGroupProps = _Menu['radioGroup'];
+export type MenubarRadioItemProps = _Menu['radioItem'];
+export type MenubarRadioItemActionProps = _Menu['radioItemAction'];
 
 // Returns
 export type Menubar = BuilderReturn<typeof createMenubar>;


### PR DESCRIPTION
Prevent accidental imports of similar internal menu types by prefixing them with `_`