### PR TITLE
Fix portalling issues

### DIFF
--- a/.changeset/soft-buses-flow.md
+++ b/.changeset/soft-buses-flow.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+Fix portalling issues

--- a/src/docs/previews/combobox/main/tailwind.svelte
+++ b/src/docs/previews/combobox/main/tailwind.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { createCombobox, type ComboboxFilterFunction, melt } from '$lib';
 	import { Check, ChevronDown, ChevronUp } from 'lucide-svelte';
-	import { writable } from 'svelte/store';
 	import { slide } from 'svelte/transition';
 
 	interface Book {

--- a/src/lib/builders/combobox/create.ts
+++ b/src/lib/builders/combobox/create.ts
@@ -26,9 +26,9 @@ import {
 	removeHighlight,
 	omit,
 	getOptions,
-	getPortalParent,
 	derivedVisible,
 	addMeltEventListener,
+	getPortalDestination,
 } from '$lib/internal/helpers';
 import { onMount, tick } from 'svelte';
 import { derived, get, readonly, writable, type Writable } from 'svelte/store';
@@ -51,8 +51,8 @@ const defaults = {
 	closeOnOutsideClick: true,
 	preventScroll: true,
 	closeOnEscape: true,
-	portal: 'body',
 	forceVisible: false,
+	portal: undefined,
 	itemToString: (item: unknown) => `${item}`,
 } satisfies Defaults<CreateComboboxProps<unknown>>;
 
@@ -417,12 +417,6 @@ export function createCombobox<Item>(props: CreateComboboxProps<Item>) {
 			} as const;
 		},
 		action: (node: HTMLElement): MeltActionReturn<ComboboxEvents['menu']> => {
-			/**
-			 * We need to get the parent portal before the menu is opened,
-			 * otherwise the parent will have been moved to the body, and
-			 * will no longer be an ancestor of this node.
-			 */
-			const portalParent = getPortalParent(node);
 			let unsubPopper = noop;
 			let unsubScroll = noop;
 			const unsubscribe = executeCallbacks(
@@ -469,7 +463,7 @@ export function createCombobox<Item>(props: CreateComboboxProps<Item>) {
 												},
 										  }
 										: null,
-									portal: $portal ? (portalParent === $portal ? portalParent : $portal) : null,
+									portal: getPortalDestination(node, $portal),
 								},
 							});
 							if (popper && popper.destroy) {

--- a/src/lib/builders/context-menu/create.ts
+++ b/src/lib/builders/context-menu/create.ts
@@ -8,7 +8,7 @@ import {
 	effect,
 	executeCallbacks,
 	getNextFocusable,
-	getPortalParent,
+	getPortalDestination,
 	getPreviousFocusable,
 	isHTMLElement,
 	isLeftClick,
@@ -44,7 +44,7 @@ const defaults = {
 	preventScroll: true,
 	closeOnEscape: true,
 	closeOnOutsideClick: true,
-	portal: 'body',
+	portal: undefined,
 	loop: false,
 	dir: 'ltr',
 	defaultOpen: false,
@@ -134,7 +134,6 @@ export function createContextMenu(props?: CreateContextMenuProps) {
 			} as const;
 		},
 		action: (node: HTMLElement): MeltActionReturn<ContextMenuEvents['menu']> => {
-			const portalParent = getPortalParent(node);
 			let unsubPopper = noop;
 
 			const unsubDerived = effect(
@@ -155,7 +154,7 @@ export function createContextMenu(props?: CreateContextMenuProps) {
 											handler: handleClickOutside,
 									  }
 									: null,
-								portal: $portal ? (portalParent === document.body ? null : portalParent) : null,
+								portal: getPortalDestination(node, $portal),
 							},
 						});
 						if (!popper || !popper.destroy) return;

--- a/src/lib/builders/dialog/create.ts
+++ b/src/lib/builders/dialog/create.ts
@@ -3,7 +3,6 @@ import {
 	addMeltEventListener,
 	builder,
 	createElHelpers,
-	derivedVisible,
 	effect,
 	executeCallbacks,
 	generateId,

--- a/src/lib/builders/dialog/types.ts
+++ b/src/lib/builders/dialog/types.ts
@@ -16,7 +16,7 @@ export type CreateDialogProps = {
 	 *
 	 * @default 'body'
 	 */
-	portal?: HTMLElement | string;
+	portal?: HTMLElement | string | null;
 
 	forceVisible?: boolean;
 };

--- a/src/lib/builders/dropdown-menu/create.ts
+++ b/src/lib/builders/dropdown-menu/create.ts
@@ -11,7 +11,7 @@ const defaults = {
 	preventScroll: true,
 	closeOnEscape: true,
 	closeOnOutsideClick: true,
-	portal: 'body',
+	portal: undefined,
 	loop: false,
 	dir: 'ltr',
 	defaultOpen: false,

--- a/src/lib/builders/menu/create.ts
+++ b/src/lib/builders/menu/create.ts
@@ -15,7 +15,7 @@ import {
 	executeCallbacks,
 	generateId,
 	getNextFocusable,
-	getPortalParent,
+	getPortalDestination,
 	getPreviousFocusable,
 	handleRovingFocus,
 	isBrowser,
@@ -157,7 +157,6 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 			} as const;
 		},
 		action: (node: HTMLElement): MeltActionReturn<MenuEvents['menu']> => {
-			const portalParent = getPortalParent(node);
 			let unsubPopper = noop;
 
 			const unsubDerived = effect(
@@ -180,7 +179,7 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 							options: {
 								floating: $positioning,
 								clickOutside: $closeOnOutsideClick ? undefined : null,
-								portal: $portal ? (portalParent === $portal ? portalParent : $portal) : null,
+								portal: getPortalDestination(node, $portal),
 								escapeKeydown: $closeOnEscape ? undefined : null,
 							},
 						});

--- a/src/lib/builders/menu/types.ts
+++ b/src/lib/builders/menu/types.ts
@@ -44,7 +44,7 @@ export type _CreateMenuProps = {
 	 *
 	 * @default 'body'
 	 */
-	portal?: HTMLElement | string;
+	portal?: HTMLElement | string | null;
 
 	/**
 	 * Whether or not to close the menu when a click occurs outside of it.
@@ -143,7 +143,7 @@ export type _MenuBuilderOptions = {
 		dir: Writable<TextDirection>;
 		closeOnEscape: Writable<boolean>;
 		closeOnOutsideClick: Writable<boolean>;
-		portal: Writable<string | HTMLElement | undefined>;
+		portal: Writable<string | HTMLElement | undefined | null>;
 		forceVisible: Writable<boolean>;
 	};
 	disableTriggerRefocus?: boolean;

--- a/src/lib/builders/menubar/create.ts
+++ b/src/lib/builders/menubar/create.ts
@@ -27,9 +27,9 @@ import {
 	toWritableStores,
 	removeHighlight,
 	addHighlight,
-	getPortalParent,
 	derivedVisible,
 	addMeltEventListener,
+	getPortalDestination,
 } from '$lib/internal/helpers';
 import { onMount, tick } from 'svelte';
 import { usePopper } from '$lib/internal/actions';
@@ -96,7 +96,7 @@ export function createMenubar(props?: CreateMenubarProps) {
 		loop: false,
 		closeOnEscape: true,
 		closeOnOutsideClick: true,
-		portal: 'body',
+		portal: undefined,
 		forceVisible: false,
 		defaultOpen: false,
 	} satisfies CreateMenubarMenuProps;
@@ -145,13 +145,6 @@ export function createMenubar(props?: CreateMenubarProps) {
 				} as const;
 			},
 			action: (node: HTMLElement): MeltActionReturn<MenubarEvents['menu']> => {
-				/**
-				 * We need to get the parent portal before the menu is opened,
-				 * otherwise the parent will have been moved to the body, and
-				 * will no longer be an ancestor of this node.
-				 */
-				const portalParent = getPortalParent(node);
-
 				let unsubPopper = noop;
 
 				const unsubDerived = effect(
@@ -166,7 +159,7 @@ export function createMenubar(props?: CreateMenubarProps) {
 								open: rootOpen,
 								options: {
 									floating: $positioning,
-									portal: $portal ? (portalParent === $portal ? portalParent : $portal) : null,
+									portal: getPortalDestination(node, $portal),
 								},
 							});
 

--- a/src/lib/builders/popover/create.ts
+++ b/src/lib/builders/popover/create.ts
@@ -5,7 +5,7 @@ import {
 	derivedVisible,
 	effect,
 	generateId,
-	getPortalParent,
+	getPortalDestination,
 	isBrowser,
 	isHTMLElement,
 	kbd,
@@ -36,7 +36,7 @@ const defaults = {
 	preventScroll: false,
 	onOpenChange: undefined,
 	closeOnOutsideClick: true,
-	portal: 'body',
+	portal: undefined,
 	forceVisible: false,
 } satisfies Defaults<CreatePopoverProps>;
 
@@ -104,7 +104,6 @@ export function createPopover(args?: CreatePopoverProps) {
 			 * otherwise the parent will have been moved to the body, and
 			 * will no longer be an ancestor of this node.
 			 */
-			const portalParent = getPortalParent(node);
 			let unsubPopper = noop;
 
 			const unsubDerived = effect(
@@ -152,7 +151,7 @@ export function createPopover(args?: CreatePopoverProps) {
 											},
 									  }
 									: null,
-								portal: $portal ? (portalParent === $portal ? portalParent : $portal) : null,
+								portal: getPortalDestination(node, $portal),
 							},
 						});
 

--- a/src/lib/builders/popover/types.ts
+++ b/src/lib/builders/popover/types.ts
@@ -71,7 +71,7 @@ export type CreatePopoverProps = {
 	 *
 	 * @default 'body'
 	 */
-	portal?: HTMLElement | string;
+	portal?: HTMLElement | string | null;
 
 	/**
 	 * Whether the menu content should be displayed even if it is not open.

--- a/src/lib/builders/select/create.ts
+++ b/src/lib/builders/select/create.ts
@@ -18,7 +18,7 @@ import {
 	getFirstOption,
 	getNextFocusable,
 	getOptions,
-	getPortalParent,
+	getPortalDestination,
 	getPreviousFocusable,
 	handleRovingFocus,
 	isBrowser,
@@ -57,7 +57,7 @@ const defaults = {
 	name: undefined,
 	defaultOpen: false,
 	forceVisible: false,
-	portal: 'body',
+	portal: undefined,
 	closeOnEscape: true,
 	closeOnOutsideClick: true,
 } satisfies CreateSelectProps;
@@ -75,6 +75,7 @@ type SelectParts =
 const { name } = createElHelpers<SelectParts>('select');
 
 export function createSelect<
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	Item extends Multiple extends true ? Array<unknown> : unknown = any,
 	Multiple extends boolean = false
 >(props?: CreateSelectProps<Item, Multiple>) {
@@ -187,12 +188,6 @@ export function createSelect<
 			};
 		},
 		action: (node: HTMLElement): MeltActionReturn<SelectEvents['menu']> => {
-			/**
-			 * We need to get the parent portal before the menu is opened,
-			 * otherwise the parent will have been moved to the body, and
-			 * will no longer be an ancestor of this node.
-			 */
-			const portalParent = getPortalParent(node);
 			let unsubPopper = noop;
 			let unsubScroll = noop;
 
@@ -228,7 +223,7 @@ export function createSelect<
 											},
 									  }
 									: null,
-								portal: $portal ? (portalParent === $portal ? portalParent : $portal) : null,
+								portal: getPortalDestination(node, $portal),
 							},
 						});
 

--- a/src/lib/builders/select/types.ts
+++ b/src/lib/builders/select/types.ts
@@ -5,6 +5,7 @@ import type { createSelect } from './create';
 import type { ChangeFn } from '$lib/internal/helpers';
 
 export type CreateSelectProps<
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	Item extends Multiple extends true ? Array<unknown> : unknown = any,
 	Multiple extends boolean = false
 > = {
@@ -102,7 +103,7 @@ export type CreateSelectProps<
 	 *
 	 * @default 'body'
 	 */
-	portal?: HTMLElement | string;
+	portal?: HTMLElement | string | null;
 
 	/**
 	 * Whether the menu content should be displayed even if it is not open.

--- a/src/lib/internal/helpers/elements.ts
+++ b/src/lib/internal/helpers/elements.ts
@@ -14,10 +14,10 @@ export function getPortalParent(node: HTMLElement) {
 
 export function getPortalDestination(
 	node: HTMLElement,
-	portalProp: string | HTMLElement | undefined
+	portalProp: string | HTMLElement | undefined | null
 ) {
 	const portalParent = getPortalParent(node);
-	if (portalProp) return portalProp;
+	if (portalProp !== undefined) return portalProp;
 	if (portalParent === 'body') return document.body;
 	return null;
 }

--- a/src/lib/internal/helpers/elements.ts
+++ b/src/lib/internal/helpers/elements.ts
@@ -11,3 +11,13 @@ export function getPortalParent(node: HTMLElement) {
 	}
 	return parent || 'body';
 }
+
+export function getPortalDestination(
+	node: HTMLElement,
+	portalProp: string | HTMLElement | undefined
+) {
+	const portalParent = getPortalParent(node);
+	if (portalProp) return portalProp;
+	if (portalParent === 'body') return document.body;
+	return null;
+}


### PR DESCRIPTION
This PR corrects some incorrect portal handling within our builders that portal. The logic became messy when we introduced the ability to pass a custom portal destination prop, which we weren't properly handling along with detecting if the element is already a descendant of a portal.

I'm gonna say portal about 300 times but here's a breakdown of the behavior to expect moving forward:

### Passing a custom `HTMLElement` or selector to the `portal` prop

If you pass an `HTMLElement` or selector as the `portal` prop to any of the builders that support portals, your prop will take 100% priority. Meaning even if it's a `Menu` that's nested inside a dialog, but you pass in `"body"` as the `portal` prop to the menu, it's going to completely ignore the fact that it's already a descendent of a portal, and instead go straight to the body and become the dialog's sibling. So it's now a sibling, even though it may _appear_ to be inside the dialog, which means any clicks within that `Menu` would be considered an "outside click" of the dialog, thus triggering the dialog to close.

### Passing `null` as the `portal` prop
By passing `null`, you're overriding any default portal behavior we would have taken, and are saying **DO NOT PORTAL THIS ELEMENT**. You know what comes with great power...

### Leaving the portal decisions up to us (recommended)
If you don't pass a `portal` prop (leave it undefined), Melt does its best to make the right portal decisions on your behalf. If it's an element that would benefit from portalling, we'll portal it. If it's a portalling element but has an ancestor that is already being portalled, we won't portal it to prevent any of the issues mentioned in the first behavior.

I tested the various menu-like elements within a dialog to make sure this behaves as expected, and it looks good, but I'd appreciate an additional set of eyes/experiments.