### PR TITLE
refactor: menu types

### DIFF
--- a/.changeset/late-birds-beg.md
+++ b/.changeset/late-birds-beg.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+refactor: menu types

--- a/src/lib/builders/context-menu/types.ts
+++ b/src/lib/builders/context-menu/types.ts
@@ -6,8 +6,8 @@ import type { createContextMenu } from './create';
 export type CreateContextMenuProps = _Menu['builder'];
 export type CreateContextSubmenuProps = _Menu['submenu'];
 export type ContextMenuItemProps = _Menu['item'];
-export type ContextMenuCheckboxItemProps = _Menu['checkboxItem'];
 export type CreateContextMenuRadioGroupProps = _Menu['radioGroup'];
+export type CreateContextMenuCheckboxItemProps = _Menu['checkboxItem'];
 export type ContextMenuRadioItemProps = _Menu['radioItem'];
 export type ContextMenuRadioItemActionProps = _Menu['radioItemAction'];
 

--- a/src/lib/builders/dropdown-menu/types.ts
+++ b/src/lib/builders/dropdown-menu/types.ts
@@ -6,8 +6,8 @@ import type { createDropdownMenu } from './create';
 export type CreateDropdownMenuProps = _Menu['builder'];
 export type CreateDropdownSubmenuProps = _Menu['submenu'];
 export type DropdownMenuItemProps = _Menu['item'];
-export type DropdownMenuCheckboxItemProps = _Menu['checkboxItem'];
 export type CreateDropdownMenuRadioGroupProps = _Menu['radioGroup'];
+export type CreateDropdownMenuCheckboxItemProps = _Menu['checkboxItem'];
 export type DropdownMenuRadioItemProps = _Menu['radioItem'];
 export type DropdownMenuRadioItemActionProps = _Menu['radioItemAction'];
 


### PR DESCRIPTION
Since we're using a builder for checkbox items, renamed the type to align with the other "builder" prop types.