### PR TITLE
feature: Add trim option to input-tags

### DIFF
--- a/.changeset/fuzzy-lamps-fail.md
+++ b/.changeset/fuzzy-lamps-fail.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+feature: Add trim option to input-tags

--- a/src/docs/data/builders/tags-input.ts
+++ b/src/docs/data/builders/tags-input.ts
@@ -38,6 +38,12 @@ const OPTION_PROPS = [
 		description: 'Whether or not the tags input should only allow unique tags.',
 	},
 	{
+		name: 'trim',
+		type: 'boolean',
+		default: 'true',
+		description: 'Whether or not whitespace from both ends of input string should be removed when a tag is added.'
+	},
+	{
 		name: 'blur',
 		type: 'boolean',
 		description: 'Whether or not the input should blur when a tag is added.',

--- a/src/lib/builders/tags-input/create.ts
+++ b/src/lib/builders/tags-input/create.ts
@@ -27,6 +27,7 @@ const defaults = {
 	editable: true,
 	defaultTags: [],
 	unique: false,
+	trim: true,
 	blur: 'nothing',
 	addOnPaste: false,
 	maxTags: undefined,
@@ -35,6 +36,7 @@ const defaults = {
 	add: undefined,
 	remove: undefined,
 	update: undefined,
+
 } satisfies Defaults<CreateTagsInputProps>;
 
 type TagsInputParts = '' | 'tag' | 'delete-trigger' | 'edit' | 'input';
@@ -55,6 +57,7 @@ export function createTagsInput(props?: CreateTagsInputProps) {
 		disabled,
 		editable,
 		unique,
+		trim,
 		blur,
 		addOnPaste,
 		allowed,
@@ -105,7 +108,11 @@ export function createTagsInput(props?: CreateTagsInputProps) {
 		const $allowed = get(allowed);
 		const $denied = get(denied);
 		const $maxTags = get(maxTags);
-		// Tag uniqueness
+
+		// Trim the validation value before validations
+		if (get(trim)) v = v.trim();
+
+		// Tag uniqueness		
 		if (get(unique) && $editing?.value !== v) {
 			const index = $tags.findIndex((tag) => tag.value === v);
 			if (index >= 0) return false;
@@ -143,6 +150,10 @@ export function createTagsInput(props?: CreateTagsInputProps) {
 			workingTag.id = generateId();
 		}
 
+		// Trim the value, only after the user defined add function
+		if (get(trim)) workingTag.value = workingTag.value.trim();
+
+
 		tags.update((current) => {
 			current.push(workingTag);
 			return current;
@@ -170,6 +181,9 @@ export function createTagsInput(props?: CreateTagsInputProps) {
 				return false;
 			}
 		}
+
+		// Trim the value, only after the user defined update function
+		if (get(trim)) workingTag.value = workingTag.value.trim();
 
 		// Update the tag matching the old id
 		tags.update(($tags) => {
@@ -475,11 +489,11 @@ export function createTagsInput(props?: CreateTagsInputProps) {
 					tabindex: -1,
 					style: editing
 						? styleToString({
-								position: 'absolute',
-								opacity: 0,
-								'pointer-events': 'none',
-								margin: 0,
-						  })
+							position: 'absolute',
+							opacity: 0,
+							'pointer-events': 'none',
+							margin: 0,
+						})
 						: undefined,
 				};
 			};
@@ -616,11 +630,11 @@ export function createTagsInput(props?: CreateTagsInputProps) {
 					tabindex: -1,
 					style: !editing
 						? styleToString({
-								position: 'absolute',
-								opacity: 0,
-								'pointer-events': 'none',
-								margin: 0,
-						  })
+							position: 'absolute',
+							opacity: 0,
+							'pointer-events': 'none',
+							margin: 0,
+						})
 						: undefined,
 				};
 			};

--- a/src/lib/builders/tags-input/types.ts
+++ b/src/lib/builders/tags-input/types.ts
@@ -12,6 +12,7 @@ export type CreateTagsInputProps = {
 	tags?: Writable<Tag[]>;
 	onTagsChange?: ChangeFn<Tag[]>;
 	unique?: boolean;
+	trim?: boolean;
 	blur?: Blur;
 	addOnPaste?: boolean;
 	maxTags?: number;


### PR DESCRIPTION
Added `trim` option to the `input-tags` with default value to `true`.