### PR TITLE
[Types] Expose ComponentEvent types

### DIFF
--- a/.changeset/nervous-toys-sing.md
+++ b/.changeset/nervous-toys-sing.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+[Types] Expose ComponentEvent types

--- a/src/lib/builders/accordion/events.ts
+++ b/src/lib/builders/accordion/events.ts
@@ -1,7 +1,8 @@
-import type { GroupedEvents } from '$lib/internal/types.js';
+import type { GroupedEvents, MeltComponentEvents } from '$lib/internal/types.js';
 
 export const accordionEvents = {
 	trigger: ['keydown', 'click'] as const,
 };
 
 export type AccordionEvents = GroupedEvents<typeof accordionEvents>;
+export type AccordionComponentEvents = MeltComponentEvents<AccordionEvents>;

--- a/src/lib/builders/accordion/types.ts
+++ b/src/lib/builders/accordion/types.ts
@@ -2,7 +2,7 @@ import type { BuilderReturn } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
 import type { createAccordion } from './create.js';
 import type { ChangeFn } from '$lib/internal/helpers/index.js';
-
+export type { AccordionComponentEvents } from './events.js';
 export type CreateAccordionProps<Multiple extends boolean = false> = {
 	/**
 	 * If `true`, multiple accordion items can be open at the same time.

--- a/src/lib/builders/checkbox/events.ts
+++ b/src/lib/builders/checkbox/events.ts
@@ -1,7 +1,8 @@
-import type { GroupedEvents } from '$lib/internal/types.js';
+import type { GroupedEvents, MeltComponentEvents } from '$lib/internal/types.js';
 
 export const checkboxEvents = {
 	root: ['keydown', 'click'] as const,
 };
 
 export type CheckboxEvents = GroupedEvents<typeof checkboxEvents>;
+export type CheckboxComponentEvents = MeltComponentEvents<CheckboxEvents>;

--- a/src/lib/builders/checkbox/types.ts
+++ b/src/lib/builders/checkbox/types.ts
@@ -2,6 +2,7 @@ import type { createCheckbox } from './create.js';
 import type { BuilderReturn } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
 import type { ChangeFn } from '$lib/internal/helpers/index.js';
+export type { CheckboxComponentEvents } from './events.js';
 
 export type CreateCheckboxProps = {
 	/**

--- a/src/lib/builders/collapsible/events.ts
+++ b/src/lib/builders/collapsible/events.ts
@@ -1,7 +1,8 @@
-import type { GroupedEvents } from '$lib/internal/types.js';
+import type { GroupedEvents, MeltComponentEvents } from '$lib/internal/types.js';
 
 export const collapsibleEvents = {
 	trigger: ['click'] as const,
 };
 
 export type CollapsibleEvents = GroupedEvents<typeof collapsibleEvents>;
+export type CollapsibleComponentEvents = MeltComponentEvents<CollapsibleEvents>;

--- a/src/lib/builders/collapsible/types.ts
+++ b/src/lib/builders/collapsible/types.ts
@@ -2,6 +2,7 @@ import type { createCollapsible } from './create.js';
 import type { BuilderReturn } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
 import type { ChangeFn } from '$lib/internal/helpers/index.js';
+export type { CollapsibleComponentEvents } from './events.js';
 
 export type CreateCollapsibleProps = {
 	/**

--- a/src/lib/builders/combobox/events.ts
+++ b/src/lib/builders/combobox/events.ts
@@ -1,4 +1,4 @@
-import type { GroupedEvents } from '$lib/internal/types.js';
+import type { GroupedEvents, MeltComponentEvents } from '$lib/internal/types.js';
 
 export const comboboxEvents = {
 	input: ['click', 'keydown', 'input'] as const,
@@ -7,3 +7,4 @@ export const comboboxEvents = {
 };
 
 export type ComboboxEvents = GroupedEvents<typeof comboboxEvents>;
+export type ComboboxComponentEvents = MeltComponentEvents<ComboboxEvents>;

--- a/src/lib/builders/combobox/types.ts
+++ b/src/lib/builders/combobox/types.ts
@@ -3,6 +3,7 @@ import type { ChangeFn } from '$lib/internal/helpers/index.js';
 import type { Writable } from 'svelte/store';
 import type { createCombobox } from './create.js';
 import type { FloatingConfig } from '$lib/internal/actions/index.js';
+export type { ComboboxComponentEvents } from './events.js';
 
 export type CreateComboboxProps<Item> = {
 	/**

--- a/src/lib/builders/context-menu/events.ts
+++ b/src/lib/builders/context-menu/events.ts
@@ -1,4 +1,4 @@
-import type { GroupedEvents } from '$lib/internal/types.js';
+import type { GroupedEvents, MeltComponentEvents } from '$lib/internal/types.js';
 import { menuEvents } from '../menu/events.js';
 
 export const contextMenuEvents = {
@@ -8,3 +8,4 @@ export const contextMenuEvents = {
 };
 
 export type ContextMenuEvents = GroupedEvents<typeof contextMenuEvents>;
+export type ContextMenuComponentEvents = MeltComponentEvents<ContextMenuEvents>;

--- a/src/lib/builders/context-menu/types.ts
+++ b/src/lib/builders/context-menu/types.ts
@@ -1,6 +1,7 @@
 import type { BuilderReturn } from '$lib/internal/types.js';
 import type { _Menu } from '../menu/index.js';
 import type { createContextMenu } from './create.js';
+export type { ContextMenuComponentEvents } from './events.js';
 
 // Props
 export type CreateContextMenuProps = _Menu['builder'];

--- a/src/lib/builders/dialog/events.ts
+++ b/src/lib/builders/dialog/events.ts
@@ -1,7 +1,8 @@
-import type { GroupedEvents } from '$lib/internal/types.js';
+import type { GroupedEvents, MeltComponentEvents } from '$lib/internal/types.js';
 export const dialogEvents = {
 	trigger: ['click', 'keydown'] as const,
 	close: ['click', 'keydown'] as const,
 };
 
 export type DialogEvents = GroupedEvents<typeof dialogEvents>;
+export type DialogComponentEvents = MeltComponentEvents<DialogEvents>;

--- a/src/lib/builders/dialog/types.ts
+++ b/src/lib/builders/dialog/types.ts
@@ -2,7 +2,7 @@ import type { BuilderReturn } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
 import type { createDialog } from './create.js';
 import type { ChangeFn } from '$lib/internal/helpers/index.js';
-
+export type { DialogComponentEvents } from './events.js';
 export type CreateDialogProps = {
 	preventScroll?: boolean;
 	closeOnEscape?: boolean;

--- a/src/lib/builders/dropdown-menu/events.ts
+++ b/src/lib/builders/dropdown-menu/events.ts
@@ -1,4 +1,6 @@
+import type { MeltComponentEvents } from '$lib/internal/types.js';
 import { menuEvents, type MenuEvents } from '../menu/events.js';
 
 export const dropdownMenuEvents = menuEvents;
 export type DropdownMenuEvents = MenuEvents;
+export type DropdownMenuComponentEvents = MeltComponentEvents<DropdownMenuEvents>;

--- a/src/lib/builders/dropdown-menu/types.ts
+++ b/src/lib/builders/dropdown-menu/types.ts
@@ -1,7 +1,7 @@
 import type { BuilderReturn } from '$lib/internal/types.js';
 import type { _Menu } from '../menu/index.js';
 import type { createDropdownMenu } from './create.js';
-
+export type { DropdownMenuComponentEvents } from './events.js';
 // Props
 export type CreateDropdownMenuProps = _Menu['builder'];
 export type CreateDropdownSubmenuProps = _Menu['submenu'];

--- a/src/lib/builders/hover-card/events.ts
+++ b/src/lib/builders/hover-card/events.ts
@@ -1,4 +1,4 @@
-import type { GroupedEvents } from '$lib/internal/types.js';
+import type { GroupedEvents, MeltComponentEvents } from '$lib/internal/types.js';
 
 export const hoverCardEvents = {
 	trigger: ['pointerenter', 'pointerleave', 'focus', 'blur', 'touchstart'] as const,
@@ -6,3 +6,4 @@ export const hoverCardEvents = {
 };
 
 export type HoverCardEvents = GroupedEvents<typeof hoverCardEvents>;
+export type HoverCardComponentEvents = MeltComponentEvents<HoverCardEvents>;

--- a/src/lib/builders/hover-card/types.ts
+++ b/src/lib/builders/hover-card/types.ts
@@ -3,7 +3,7 @@ import type { BuilderReturn } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
 import type { createHoverCard } from './create.js';
 import type { ChangeFn } from '$lib/internal/helpers/index.js';
-
+export type { HoverCardComponentEvents } from './events.js';
 export type CreateHoverCardProps = {
 	/**
 	 * Options for positioning the popover menu.

--- a/src/lib/builders/label/events.ts
+++ b/src/lib/builders/label/events.ts
@@ -1,7 +1,8 @@
-import type { GroupedEvents } from '$lib/internal/types.js';
+import type { GroupedEvents, MeltComponentEvents } from '$lib/internal/types.js';
 
 export const labelEvents = {
 	root: ['mousedown'] as const,
 };
 
 export type LabelEvents = GroupedEvents<typeof labelEvents>;
+export type LabelComponentEvents = MeltComponentEvents<LabelEvents>;

--- a/src/lib/builders/label/types.ts
+++ b/src/lib/builders/label/types.ts
@@ -1,5 +1,6 @@
 import type { BuilderReturn } from '$lib/internal/types.js';
 import type { createLabel } from './create.js';
+export type { LabelComponentEvents } from './events.js';
 
 export type Label = BuilderReturn<typeof createLabel>;
 export type LabelElements = Label['elements'];

--- a/src/lib/builders/menubar/events.ts
+++ b/src/lib/builders/menubar/events.ts
@@ -1,4 +1,4 @@
-import type { GroupedEvents } from '$lib/internal/types.js';
+import type { GroupedEvents, MeltComponentEvents } from '$lib/internal/types.js';
 import { menuEvents } from '../menu/events.js';
 
 export const menubarEvents = {
@@ -8,3 +8,4 @@ export const menubarEvents = {
 };
 
 export type MenubarEvents = GroupedEvents<typeof menubarEvents>;
+export type MenubarComponentEvents = MeltComponentEvents<MenubarEvents>;

--- a/src/lib/builders/menubar/types.ts
+++ b/src/lib/builders/menubar/types.ts
@@ -1,7 +1,7 @@
 import type { BuilderReturn } from '$lib/internal/types.js';
 import type { _Menu } from '../menu/index.js';
 import type { createMenubar } from './create.js';
-
+export type { MenubarComponentEvents } from './events.js';
 // Props
 export type CreateMenubarProps = {
 	/**

--- a/src/lib/builders/pagination/events.ts
+++ b/src/lib/builders/pagination/events.ts
@@ -1,4 +1,4 @@
-import type { GroupedEvents } from '$lib/internal/types.js';
+import type { GroupedEvents, MeltComponentEvents } from '$lib/internal/types.js';
 
 export const paginationEvents = {
 	pageTrigger: ['click', 'keydown'] as const,
@@ -7,3 +7,4 @@ export const paginationEvents = {
 };
 
 export type PaginationEvents = GroupedEvents<typeof paginationEvents>;
+export type PaginationComponentEvents = MeltComponentEvents<PaginationEvents>;

--- a/src/lib/builders/pagination/types.ts
+++ b/src/lib/builders/pagination/types.ts
@@ -2,7 +2,7 @@ import type { BuilderReturn } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
 import type { createPagination } from './create.js';
 import type { ChangeFn } from '$lib/internal/helpers/index.js';
-
+export type { PaginationComponentEvents } from './events.js';
 export type CreatePaginationProps = {
 	/**
 	 * The total number of items to be paginated.

--- a/src/lib/builders/pin-input/events.ts
+++ b/src/lib/builders/pin-input/events.ts
@@ -1,7 +1,8 @@
-import type { GroupedEvents } from '$lib/internal/types.js';
+import type { GroupedEvents, MeltComponentEvents } from '$lib/internal/types.js';
 
 export const pinInputEvents = {
 	input: ['keydown', 'input', 'paste', 'change', 'focus', 'blur'] as const,
 };
 
 export type PinInputEvents = GroupedEvents<typeof pinInputEvents>;
+export type PinInputComponentEvents = MeltComponentEvents<PinInputEvents>;

--- a/src/lib/builders/pin-input/types.ts
+++ b/src/lib/builders/pin-input/types.ts
@@ -2,6 +2,7 @@ import type { ChangeFn } from '$lib/internal/helpers/index.js';
 import type { BuilderReturn } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
 import type { createPinInput } from './create.js';
+export type { PinInputComponentEvents } from './events.js';
 
 export type CreatePinInputProps = {
 	/**

--- a/src/lib/builders/popover/events.ts
+++ b/src/lib/builders/popover/events.ts
@@ -1,4 +1,4 @@
-import type { GroupedEvents } from '$lib/internal/types.js';
+import type { GroupedEvents, MeltComponentEvents } from '$lib/internal/types.js';
 
 export const popoverEvents = {
 	trigger: ['click', 'keydown'] as const,
@@ -6,3 +6,4 @@ export const popoverEvents = {
 };
 
 export type PopoverEvents = GroupedEvents<typeof popoverEvents>;
+export type PopoverComponentEvents = MeltComponentEvents<PopoverEvents>;

--- a/src/lib/builders/popover/types.ts
+++ b/src/lib/builders/popover/types.ts
@@ -3,6 +3,7 @@ import type { ChangeFn } from '$lib/internal/helpers/index.js';
 import type { Writable } from 'svelte/store';
 import type { createPopover } from './create.js';
 import type { BuilderReturn } from '$lib/internal/types.js';
+export type { PopoverComponentEvents } from './events.js';
 
 export type CreatePopoverProps = {
 	/**

--- a/src/lib/builders/radio-group/events.ts
+++ b/src/lib/builders/radio-group/events.ts
@@ -1,7 +1,8 @@
-import type { GroupedEvents } from '$lib/internal/types.js';
+import type { GroupedEvents, MeltComponentEvents } from '$lib/internal/types.js';
 
 export const radioGroupEvents = {
 	item: ['click', 'focus', 'keydown'] as const,
 };
 
 export type RadioGroupEvents = GroupedEvents<typeof radioGroupEvents>;
+export type RadioGroupComponentEvents = MeltComponentEvents<RadioGroupEvents>;

--- a/src/lib/builders/radio-group/types.ts
+++ b/src/lib/builders/radio-group/types.ts
@@ -2,6 +2,7 @@ import type { BuilderReturn, Orientation } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
 import type { createRadioGroup } from './create.js';
 import type { ChangeFn } from '$lib/internal/helpers/index.js';
+export type { RadioGroupComponentEvents } from './events.js';
 
 export type CreateRadioGroupProps = {
 	/**

--- a/src/lib/builders/select/events.ts
+++ b/src/lib/builders/select/events.ts
@@ -1,4 +1,4 @@
-import type { GroupedEvents } from '$lib/internal/types.js';
+import type { GroupedEvents, MeltComponentEvents } from '$lib/internal/types.js';
 
 export const selectEvents = {
 	menu: ['keydown'] as const,
@@ -8,3 +8,4 @@ export const selectEvents = {
 };
 
 export type SelectEvents = GroupedEvents<typeof selectEvents>;
+export type SelectComponentEvents = MeltComponentEvents<SelectEvents>;

--- a/src/lib/builders/select/types.ts
+++ b/src/lib/builders/select/types.ts
@@ -3,7 +3,7 @@ import type { BuilderReturn } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
 import type { createSelect } from './create.js';
 import type { ChangeFn } from '$lib/internal/helpers/index.js';
-
+export type { SelectComponentEvents } from './events.js';
 export type CreateSelectProps<
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	Item extends Multiple extends true ? Array<unknown> : unknown = any,

--- a/src/lib/builders/slider/events.ts
+++ b/src/lib/builders/slider/events.ts
@@ -1,7 +1,8 @@
-import type { GroupedEvents } from '$lib/internal/types.js';
+import type { GroupedEvents, MeltComponentEvents } from '$lib/internal/types.js';
 
 export const sliderEvents = {
 	thumb: ['keydown'] as const,
 };
 
 export type SliderEvents = GroupedEvents<typeof sliderEvents>;
+export type SliderComponentEvents = MeltComponentEvents<SliderEvents>;

--- a/src/lib/builders/slider/types.ts
+++ b/src/lib/builders/slider/types.ts
@@ -2,7 +2,7 @@ import type { BuilderReturn } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
 import type { createSlider } from './create.js';
 import type { ChangeFn } from '$lib/internal/helpers/index.js';
-
+export type { SliderComponentEvents } from './events.js';
 export type CreateSliderProps = {
 	/**
 	 * The uncontrolled default value of the slider.

--- a/src/lib/builders/switch/events.ts
+++ b/src/lib/builders/switch/events.ts
@@ -1,7 +1,8 @@
-import type { GroupedEvents } from '$lib/internal/types.js';
+import type { GroupedEvents, MeltComponentEvents } from '$lib/internal/types.js';
 
 export const switchEvents = {
 	root: ['click', 'keydown'] as const,
 };
 
 export type SwitchEvents = GroupedEvents<typeof switchEvents>;
+export type SwitchComponentEvents = MeltComponentEvents<SwitchEvents>;

--- a/src/lib/builders/switch/types.ts
+++ b/src/lib/builders/switch/types.ts
@@ -2,7 +2,7 @@ import type { BuilderReturn } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
 import type { createSwitch } from './create.js';
 import type { ChangeFn } from '$lib/internal/helpers/index.js';
-
+export type { SwitchComponentEvents } from './events.js';
 export type CreateSwitchProps = {
 	/**
 	 * The uncontrolled default checked status of the switch.

--- a/src/lib/builders/tabs/events.ts
+++ b/src/lib/builders/tabs/events.ts
@@ -1,7 +1,8 @@
-import type { GroupedEvents } from '$lib/internal/types.js';
+import type { GroupedEvents, MeltComponentEvents } from '$lib/internal/types.js';
 
 export const tabsEvents = {
 	trigger: ['focus', 'click', 'keydown'] as const,
 };
 
 export type TabsEvents = GroupedEvents<typeof tabsEvents>;
+export type TabsComponentEvents = MeltComponentEvents<TabsEvents>;

--- a/src/lib/builders/tabs/types.ts
+++ b/src/lib/builders/tabs/types.ts
@@ -2,6 +2,7 @@ import type { BuilderReturn, Orientation } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
 import type { createTabs } from './create.js';
 import type { ChangeFn } from '$lib/internal/helpers/index.js';
+export type { TabsComponentEvents } from './events.js';
 
 export type CreateTabsProps = {
 	/**

--- a/src/lib/builders/tags-input/events.ts
+++ b/src/lib/builders/tags-input/events.ts
@@ -1,4 +1,4 @@
-import type { GroupedEvents } from '$lib/internal/types.js';
+import type { GroupedEvents, MeltComponentEvents } from '$lib/internal/types.js';
 
 export const tagsInputEvents = {
 	root: ['mousedown'] as const,
@@ -9,3 +9,4 @@ export const tagsInputEvents = {
 };
 
 export type TagsInputEvents = GroupedEvents<typeof tagsInputEvents>;
+export type TagsInputComponentEvents = MeltComponentEvents<TagsInputEvents>;

--- a/src/lib/builders/tags-input/types.ts
+++ b/src/lib/builders/tags-input/types.ts
@@ -2,7 +2,7 @@ import type { BuilderReturn } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
 import type { createTagsInput } from './create.js';
 import type { ChangeFn } from '$lib/internal/helpers/index.js';
-
+export type { TagsInputComponentEvents } from './events.js';
 export type CreateTagsInputProps = {
 	placeholder?: string;
 	disabled?: boolean;

--- a/src/lib/builders/toast/events.ts
+++ b/src/lib/builders/toast/events.ts
@@ -1,4 +1,4 @@
-import type { GroupedEvents } from '$lib/internal/types.js';
+import type { GroupedEvents, MeltComponentEvents } from '$lib/internal/types.js';
 
 export const toastEvents = {
 	content: ['pointerenter', 'pointerleave', 'focusout'] as const,
@@ -6,3 +6,4 @@ export const toastEvents = {
 };
 
 export type ToastEvents = GroupedEvents<typeof toastEvents>;
+export type ToastComponentEvents = MeltComponentEvents<ToastEvents>;

--- a/src/lib/builders/toast/types.ts
+++ b/src/lib/builders/toast/types.ts
@@ -1,6 +1,6 @@
 import type { BuilderReturn } from '$lib/internal/types.js';
 import type { createToaster } from './create.js';
-
+export type { ToastComponentEvents } from './events.js';
 export type EmptyType = Record<never, never>;
 
 export type CreateToasterProps = {

--- a/src/lib/builders/toggle-group/events.ts
+++ b/src/lib/builders/toggle-group/events.ts
@@ -1,7 +1,8 @@
-import type { GroupedEvents } from '$lib/internal/types.js';
+import type { GroupedEvents, MeltComponentEvents } from '$lib/internal/types.js';
 
 export const toggleGroupEvents = {
 	item: ['click', 'keydown'] as const,
 };
 
 export type ToggleGroupEvents = GroupedEvents<typeof toggleGroupEvents>;
+export type ToggleGroupComponentEvents = MeltComponentEvents<ToggleGroupEvents>;

--- a/src/lib/builders/toggle-group/types.ts
+++ b/src/lib/builders/toggle-group/types.ts
@@ -2,7 +2,7 @@ import type { BuilderReturn, Orientation } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
 import type { createToggleGroup } from './create.js';
 import type { ChangeFn } from '$lib/internal/helpers/index.js';
-
+export type { ToggleGroupComponentEvents } from './events.js';
 export type ToggleGroupType = 'single' | 'multiple';
 
 export type CreateToggleGroupProps<T extends ToggleGroupType = 'single'> = {

--- a/src/lib/builders/toggle/events.ts
+++ b/src/lib/builders/toggle/events.ts
@@ -1,6 +1,7 @@
-import type { GroupedEvents } from '$lib/internal/types.js';
+import type { GroupedEvents, MeltComponentEvents } from '$lib/internal/types.js';
 
 export const toggleEvents = {
 	root: ['click', 'keydown'] as const,
 };
 export type ToggleEvents = GroupedEvents<typeof toggleEvents>;
+export type ToggleComponentEvents = MeltComponentEvents<ToggleEvents>;

--- a/src/lib/builders/toggle/types.ts
+++ b/src/lib/builders/toggle/types.ts
@@ -2,7 +2,7 @@ import type { BuilderReturn } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
 import type { createToggle } from './create.js';
 import type { ChangeFn } from '$lib/internal/helpers/index.js';
-
+export type { ToggleComponentEvents } from './events.js';
 export type CreateToggleProps = {
 	disabled?: boolean;
 	defaultPressed?: boolean;

--- a/src/lib/builders/toolbar/events.ts
+++ b/src/lib/builders/toolbar/events.ts
@@ -1,4 +1,4 @@
-import type { GroupedEvents } from '$lib/internal/types.js';
+import type { GroupedEvents, MeltComponentEvents } from '$lib/internal/types.js';
 
 export const toolbarEvents = {
 	button: ['keydown'] as const,
@@ -7,3 +7,4 @@ export const toolbarEvents = {
 };
 
 export type ToolbarEvents = GroupedEvents<typeof toolbarEvents>;
+export type ToolbarComponentEvents = MeltComponentEvents<ToolbarEvents>;

--- a/src/lib/builders/toolbar/types.ts
+++ b/src/lib/builders/toolbar/types.ts
@@ -2,7 +2,7 @@ import type { BuilderReturn, Orientation } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
 import type { createToolbar } from './create.js';
 import type { ChangeFn } from '$lib/internal/helpers/index.js';
-
+export type { ToolbarComponentEvents } from './events.js';
 export type ToolbarGroupType = 'single' | 'multiple';
 
 export type CreateToolbarProps = {

--- a/src/lib/builders/tooltip/events.ts
+++ b/src/lib/builders/tooltip/events.ts
@@ -1,7 +1,8 @@
-import type { GroupedEvents } from '$lib/internal/types.js';
+import type { GroupedEvents, MeltComponentEvents } from '$lib/internal/types.js';
 
 export const tooltipEvents = {
 	trigger: ['pointerdown', 'pointerenter', 'pointerleave', 'focus', 'blur', 'keydown'] as const,
 	content: ['pointerenter', 'pointerdown'] as const,
 };
 export type TooltipEvents = GroupedEvents<typeof tooltipEvents>;
+export type TooltipComponentEvents = MeltComponentEvents<TooltipEvents>;

--- a/src/lib/builders/tooltip/types.ts
+++ b/src/lib/builders/tooltip/types.ts
@@ -3,7 +3,7 @@ import type { BuilderReturn } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
 import type { createTooltip } from './create.js';
 import type { ChangeFn } from '$lib/internal/helpers/index.js';
-
+export type { TooltipComponentEvents } from './events.js';
 export type CreateTooltipProps = {
 	positioning?: FloatingConfig;
 	arrowSize?: number;

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,3 +1,2 @@
 export * from './builders/index.js';
 export { melt } from './internal/actions/index.js';
-export type { StoreValue, StoreValueObj } from './internal/types.js';

--- a/src/lib/internal/types.ts
+++ b/src/lib/internal/types.ts
@@ -74,8 +74,24 @@ export type MeltActionReturn<Events extends keyof HTMLElementEventMap> = ActionR
 	}
 >;
 
+export type CustomMeltEvents<Events extends keyof HTMLElementEventMap> = {
+	[K in Events as `on:m-${string & K}`]?: K extends keyof HTMLElementEventMap
+		? MeltEventHandler<HTMLElementEventMap[K]>
+		: never;
+};
+
+type CustomMeltComponentEvents<Events extends keyof HTMLElementEventMap> = {
+	[K in Events as `m-${string & K}`]?: K extends keyof HTMLElementEventMap
+		? MeltEventHandler<HTMLElementEventMap[K]>
+		: never;
+};
+
 type ElementEvents<T> = T extends ReadonlyArray<infer U> ? U : never;
 
 export type GroupedEvents<T> = {
 	[K in keyof T]: ElementEvents<T[K]>;
+};
+
+export type MeltComponentEvents<T> = {
+	[K in keyof T]: T[K] extends keyof HTMLElementEventMap ? CustomMeltComponentEvents<T[K]> : never;
 };

--- a/src/lib/internal/types.ts
+++ b/src/lib/internal/types.ts
@@ -74,12 +74,6 @@ export type MeltActionReturn<Events extends keyof HTMLElementEventMap> = ActionR
 	}
 >;
 
-export type CustomMeltEvents<Events extends keyof HTMLElementEventMap> = {
-	[K in Events as `on:m-${string & K}`]?: K extends keyof HTMLElementEventMap
-		? MeltEventHandler<HTMLElementEventMap[K]>
-		: never;
-};
-
 type CustomMeltComponentEvents<Events extends keyof HTMLElementEventMap> = {
 	[K in Events as `m-${string & K}`]?: K extends keyof HTMLElementEventMap
 		? MeltEventHandler<HTMLElementEventMap[K]>


### PR DESCRIPTION
This PR exports/exposes `ComponentEvent` types for the various builders which can be used to properly type components with our custom `m-` events that we dispatch.

### The problem
When you apply Melt's builders to regular elements, the attributes are properly typed to provide type safety & autocomplete for the custom events we dispatch, such as `m-click`, `m-keydown`, and so on.

Here's an example of a type that our actions infer & set the proper element attributes for:

```ts
type TriggerEvents = {
	'on:m-click'?: MeltEventHandler<MouseEvent>
}
```

However, events forwarded/dispatched from _components_ are typed a bit differently. More specifically, we don't include the `on:` portion, so the same example above, but typed for a component, would look something like this:

```svelte
<!-- AccordionTrigger.svelte (example) -->
<script lang="ts">
	type $$Events = {
		'm-click':  MeltEventHandler<MouseEvent>
	};
</script>

<button on:m-click>Forwarding an m-click event</button>
```

then it would be used and have autocomplete, properly typed event, ability to cancel, etc. like so:
```svelte
<script lang="ts">
	import { AccordionTrigger } from './AccordionTrigger.svelte'
</script>

<AccordionTrigger on:m-click={(e) => console.log(e)} />
```

Currently, this isn't possible because we don't export the `MeltEventHandler` type, as we shouldn't because it's really for internal use only. Nor would we want to, as this should be as simple as possible for the users to consume.

## The solution
I added some new internal type helpers to construct a `ComponentEvents` type for each of the builders.

At a high level, they look something like this:

```ts
type AccordionComponentEvents = {
	trigger: {
		'm-click': MeltEventHandler<MouseEvent>;
        'm-keydown': MeltEventHandler<KeyboardEvent>;
	},
   // ...any other elements that have events from the accordion builder 
}
```

They can then be used in the previous component example like so:

```svelte
<!-- AccordionTrigger.svelte (example) -->
<script lang="ts">
	import type { AccordionComponentEvents } from '@melt-ui/svelte';
	type $$Events = AccordionComponentEvents["trigger"];
</script>

<button on:m-click>Forwarding an m-click event</button>
```

This has 0 impact/implications for the existing event types we are using elsewhere, this is just in addition to.
