### PR TITLE
[Select] Prevent trigger refocus when using mouse

### DIFF
--- a/.changeset/soft-files-fetch.md
+++ b/.changeset/soft-files-fetch.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+[Select] Prevent trigger refocus when using mouse

--- a/src/lib/builders/select/create.ts
+++ b/src/lib/builders/select/create.ts
@@ -483,7 +483,9 @@ export function createSelect<
 				};
 				optionsList.push(optProps);
 
-				const isSelected = Array.isArray($value) ? $value.includes(props?.value) : $value === props?.value;
+				const isSelected = Array.isArray($value)
+					? $value.includes(props?.value)
+					: $value === props?.value;
 
 				return {
 					role: 'option',
@@ -614,7 +616,7 @@ export function createSelect<
 			} else if (menuEl && $open) {
 				// focus on the menu element
 				handleRovingFocus(menuEl);
-			} else if ($activeTrigger && constantMounted) {
+			} else if ($activeTrigger && constantMounted && get(isUsingKeyboard)) {
 				// Hacky way to prevent the keydown event from triggering on the trigger
 				handleRovingFocus($activeTrigger);
 			}

--- a/src/tests/select/Select.spec.ts
+++ b/src/tests/select/Select.spec.ts
@@ -123,8 +123,8 @@ describe('Select (Default)', () => {
 		if (!firstItem) throw new Error('No option found');
 		await user.click(firstItem);
 
-		await expect(firstItem).toHaveAttribute('data-selected')
-		await expect(firstItem).toHaveAttribute('aria-selected', "true")
+		await expect(firstItem).toHaveAttribute('data-selected');
+		await expect(firstItem).toHaveAttribute('aria-selected', 'true');
 
 		await expect(menu).not.toBeVisible();
 		await expect(trigger).toHaveTextContent('Caramel');
@@ -136,8 +136,8 @@ describe('Select (Default)', () => {
 		if (!secondItem) throw new Error('No option found');
 		await user.click(secondItem);
 
-		await expect(secondItem).toHaveAttribute('data-selected')
-		await expect(secondItem).toHaveAttribute('aria-selected', "true")
+		await expect(secondItem).toHaveAttribute('data-selected');
+		await expect(secondItem).toHaveAttribute('aria-selected', 'true');
 
 		await expect(menu).not.toBeVisible();
 		await expect(trigger).toHaveTextContent('Caramel, Chocolate');


### PR DESCRIPTION
Currently, even when using the mouse to select an item, the trigger is refocused after selection. This can cause unexpected effects like screen jumps, etc.

This PR prevents the trigger from automatically being refocused when a selection is made using the pointer/mouse.

If this feels wrong, an option to `disableRefocusTriggerWhenUsingPointer` or something of that sort could also be used instead. I think an option to disable trigger refocus altogether is the solution, just when using a mouse.