### PR TITLE
Clarified the warning in introduction.md

### DIFF
--- a/src/docs/content/introduction.md
+++ b/src/docs/content/introduction.md
@@ -14,7 +14,7 @@ focus on accessibility, limitless customization options, and an overall delightf
 experience, Melt UI strives to be the de-facto headless UI library for Svelte.
 
 <Construction>
-    Melt UI is in its early stages. Expect breaking changes! And lots of new stuff! 🚀
+    Melt UI is in its early stages. Expect breaking changes in minor releases until 1.0 is ready! And lots of new stuff! 🚀
 </Construction>
 
 ## Features


### PR DESCRIPTION
Updated the under construction warning in the introduction based on this info: https://discord.com/channels/1116682155809067049/1140452054888873994

> Once version 1.0 is released, semantic versioning will be followed,  (limiting breaking changes to major releases). Until then, breaking changes might happen on non-major releases.

> ^ this - we're prerelease. We do bump minor/patch versions. So right now, minor could consist of a breaking change where patch changes should not.

This makes it a lot clearer where breaking changes might happens and what the next goalpost is.
