### PR TITLE
[Docs] Fix code escaping issues

### DIFF
--- a/mdsvex.config.js
+++ b/mdsvex.config.js
@@ -85,7 +85,7 @@ export const mdsvexOptions = {
 		backticks: false,
 		dashes: false,
 	},
-	remarkPlugins: [remarkGfm, codeImport],
+	remarkPlugins: [remarkGfm, remarkEscapeSvelte, codeImport],
 	rehypePlugins: [
 		[rehypeRewrite, rehypeRewriteOptions],
 		rehypeComponentPreToPre,
@@ -105,6 +105,25 @@ function rehypeComponentPreToPre() {
 				node.tagName = 'pre';
 			}
 		});
+	};
+}
+
+const entities = [
+	[/</g, '&lt;'],
+	[/>/g, '&gt;'],
+	[/{/g, '&#123;'],
+	[/}/g, '&#125;'],
+];
+
+function remarkEscapeSvelte() {
+	return async (tree) => {
+		visit(tree, 'inlineCode', escape);
+
+		function escape(node) {
+			for (let i = 0; i < entities.length; i += 1) {
+				node.value = node.value.replace(entities[i][0], entities[i][1]);
+			}
+		}
 	};
 }
 


### PR DESCRIPTION
Right now, we aren't able to do an inline code snippet like "`<div />`" or "`{#each}`" due to manipulations required to get mdsvex to cooperate.

This PR addresses that and now permits those entities to be used as normal :)