### PR TITLE
stop touching hover card button from immediately clicking the button

### DIFF
--- a/.changeset/healthy-lizards-sparkle.md
+++ b/.changeset/healthy-lizards-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+Remove focus trigger on hover cards

--- a/src/lib/builders/hover-card/create.ts
+++ b/src/lib/builders/hover-card/create.ts
@@ -123,16 +123,6 @@ export function createHoverCard(props: CreateHoverCardProps = {}) {
 				addMeltEventListener(node, 'pointerleave', (e) => {
 					if (isTouch(e)) return;
 					get(handleClose)();
-				}),
-				addMeltEventListener(node, 'focus', () => get(handleOpen)()),
-
-				addMeltEventListener(node, 'blur', () => get(handleClose)()),
-				addMeltEventListener(node, 'touchstart', (e) => {
-					// prevent focus on touch devices
-					e.preventDefault();
-					const currentTarget = e.currentTarget;
-					if (!isHTMLElement(currentTarget)) return;
-					currentTarget.click();
 				})
 			);
 


### PR DESCRIPTION
fixes #398 

So... I appreciate this might not be the way you want to fix this bug, but referring to the documentation:
<img width="821" alt="CleanShot 2023-08-17 at 16 15 08@2x" src="https://github.com/melt-ui/melt-ui/assets/3743418/22909154-edeb-400c-8cfa-1a5cdd15cdb2">

Reading this, I'm not totally sure opening the card on focus is actually appropriate, given that it is specifically designed to only open with a pointing device, calling out keyboard as something that isn't supported.
Also if we take github's hover card as an example (e.g. hovering an issue link) they do not trigger on focus

So this PR removes the focus handling, and therefore is able to remove the hack attempts to prevent focus on mobile via touch, therefore fixing the bug!