### PR TITLE
feat(#389) after selecting, check multiple is false before closing select menu

### DIFF
--- a/.changeset/funny-lizards-grow.md
+++ b/.changeset/funny-lizards-grow.md
@@ -1,0 +1,6 @@
+---
+"@melt-ui/svelte": patch
+---
+
+Keep Select menu open on select when `multiple` prop is `true`
+

--- a/src/lib/builders/select/create.ts
+++ b/src/lib/builders/select/create.ts
@@ -514,7 +514,8 @@ export function createSelect<
 					handleRovingFocus(itemElement);
 
 					setValue(props.value);
-					open.set(false);
+					const $multiple = get(multiple);
+					if (!$multiple) open.set(false);
 				}),
 
 				addMeltEventListener(node, 'keydown', (e) => {
@@ -530,7 +531,8 @@ export function createSelect<
 						node.setAttribute('data-selected', '');
 
 						setValue(props.value);
-						open.set(false);
+						const $multiple = get(multiple);
+						if (!$multiple) open.set(false);
 					}
 				}),
 				addMeltEventListener(node, 'pointermove', (e) => {

--- a/src/tests/select/Select.spec.ts
+++ b/src/tests/select/Select.spec.ts
@@ -126,11 +126,8 @@ describe('Select (Default)', () => {
 		await expect(firstItem).toHaveAttribute('data-selected');
 		await expect(firstItem).toHaveAttribute('aria-selected', 'true');
 
-		await expect(menu).not.toBeVisible();
-		await expect(trigger).toHaveTextContent('Caramel');
-
-		await user.click(trigger);
 		await expect(menu).toBeVisible();
+		await expect(trigger).toHaveTextContent('Caramel');
 
 		const secondItem = menu.querySelectorAll('[data-melt-select-option]')[1];
 		if (!secondItem) throw new Error('No option found');
@@ -139,8 +136,11 @@ describe('Select (Default)', () => {
 		await expect(secondItem).toHaveAttribute('data-selected');
 		await expect(secondItem).toHaveAttribute('aria-selected', 'true');
 
-		await expect(menu).not.toBeVisible();
+		await expect(menu).toBeVisible();
 		await expect(trigger).toHaveTextContent('Caramel, Chocolate');
+
+		await user.keyboard(`{${kbd.ESCAPE}}`);
+		await expect(menu).not.toBeVisible();
 	});
 
 	test('Shows correct label when defaultValue is provided', async () => {


### PR DESCRIPTION
Updated related test accordingly.

Since this is an expected behaviour I did not changed the docs. 

Side note: I tested the Esc Key to close the Select menu, that may not be necessary or a separate test