### PR TITLE
fix: bug in dialog where `handleClose` was called twice on clickoutside

### DIFF
--- a/.changeset/khaki-schools-hunt.md
+++ b/.changeset/khaki-schools-hunt.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+fix: bug where dialog would call `handleClose` twice on click outside events


### PR DESCRIPTION
Moves the click outside handling logic from the `allowOutsideClick` handler in the focus trap action to its own action to align with the other builders with `clickOutside` logic.