### PR TITLE
fix: Select & Combobox `forceVisible` transition bug

### DIFF
--- a/.changeset/angry-parents-grab.md
+++ b/.changeset/angry-parents-grab.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+fix: bug `Combobox` requiring transition when `forcevisible`

--- a/.changeset/stupid-rivers-act.md
+++ b/.changeset/stupid-rivers-act.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+fix: Bug where `Select` required a transition when using `forceVisible` to work properly

--- a/src/lib/builders/combobox/create.ts
+++ b/src/lib/builders/combobox/create.ts
@@ -608,7 +608,15 @@ export function createCombobox<ItemValue>(props?: CreateComboboxProps<ItemValue>
 	/** ------------------- */
 
 	onMount(() => {
-		open.set(withDefaults.defaultOpen);
+		const $forceVisible = get(forceVisible);
+
+		if ($forceVisible) {
+			tick().then(() => {
+				open.set(withDefaults.defaultOpen);
+			});
+		} else {
+			open.set(withDefaults.defaultOpen);
+		}
 
 		if (!isBrowser) return;
 		const menuEl = document.getElementById(ids.menu);

--- a/src/lib/builders/select/create.ts
+++ b/src/lib/builders/select/create.ts
@@ -150,11 +150,16 @@ export function createSelect<
 
 	onMount(() => {
 		// Run after all initial effects
+		const $forceVisible = get(forceVisible);
 		tick().then(() => {
 			mounted = true;
+			if ($forceVisible) {
+				open.set(withDefaults.defaultOpen);
+			}
 		});
-
-		open.set(withDefaults.defaultOpen);
+		if (!$forceVisible) {
+			open.set(withDefaults.defaultOpen);
+		}
 
 		if (!isBrowser) return;
 		const menuEl = document.getElementById(ids.menu);


### PR DESCRIPTION
Conditionally modifying when the `open.set()` is called `onMount` depending on if `forceVisible` is true or not.

Without this, when using forceVisible without a transition, the select breaks and does not allow the selection of items.