### PR TITLE
Cleanup disabled attributes

### DIFF
--- a/.changeset/dull-balloons-teach.md
+++ b/.changeset/dull-balloons-teach.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+Standardize `disabled` and `data-disabled` attributes.

--- a/src/lib/builders/accordion/create.ts
+++ b/src/lib/builders/accordion/create.ts
@@ -100,23 +100,27 @@ export const createAccordion = <Multiple extends boolean = false>(
 				// generate the content ID here so that we can grab it in the content
 				// builder action to ensure the values match.
 				const isDisabled = $disabled || disabled;
-				const disabledVal = isDisabled ? '' : undefined;
 				const isItemSelected = isSelected(itemValue, $value);
 				return {
-					disabled: disabledVal,
 					'aria-expanded': isItemSelected ? true : false,
 					'aria-disabled': disabled ? true : false,
-					'data-disabled': disabledVal,
+					'data-disabled': isDisabled ? '' : undefined,
 					'data-value': itemValue,
 					'data-state': isItemSelected ? 'open' : 'closed',
 				};
 			};
 		},
 		action: (node: HTMLElement): MeltActionReturn<AccordionEvents['trigger']> => {
+			function getTriggerProps() {
+				return {
+					disabled: node.hasAttribute('data-disabled'),
+					itemValue: node.dataset.value,
+				};
+			}
+
 			const unsub = executeCallbacks(
 				addMeltEventListener(node, 'click', () => {
-					const disabled = node.hasAttribute('data-disabled');
-					const itemValue = node.dataset.value;
+					const { disabled, itemValue } = getTriggerProps();
 					if (disabled || !itemValue) {
 						return;
 					}
@@ -130,8 +134,7 @@ export const createAccordion = <Multiple extends boolean = false>(
 					e.preventDefault();
 
 					if (e.key === kbd.SPACE || e.key === kbd.ENTER) {
-						const disabled = node.hasAttribute('data-disabled');
-						const itemValue = node.dataset.value;
+						const { disabled, itemValue } = getTriggerProps();
 						if (disabled || !itemValue) return;
 						handleValueUpdate(itemValue);
 						return;

--- a/src/lib/builders/accordion/create.ts
+++ b/src/lib/builders/accordion/create.ts
@@ -26,6 +26,7 @@ const defaults = {
 	multiple: false,
 	disabled: false,
 	forceVisible: false,
+	orientation: 'horizontal',
 } satisfies CreateAccordionProps;
 
 export const createAccordion = <Multiple extends boolean = false>(
@@ -33,7 +34,7 @@ export const createAccordion = <Multiple extends boolean = false>(
 ) => {
 	const withDefaults = { ...defaults, ...props };
 	const options = toWritableStores(omit(withDefaults, 'value', 'onValueChange', 'defaultValue'));
-	const { disabled, forceVisible } = options;
+	const { disabled, forceVisible, orientation } = options;
 
 	const valueWritable = withDefaults.value ?? writable(withDefaults.defaultValue);
 
@@ -79,22 +80,23 @@ export const createAccordion = <Multiple extends boolean = false>(
 	};
 
 	const item = builder(name('item'), {
-		stores: [value, disabled],
-		returned: ([$value, $disabled]) => {
+		stores: [value, disabled, orientation],
+		returned: ([$value, $disabled, $orientation]) => {
 			return (props: AccordionItemProps) => {
 				const { value: itemValue, disabled } = parseItemProps(props);
 				const isDisabled = $disabled || disabled;
 				return {
 					'data-state': isSelected(itemValue, $value) ? 'open' : 'closed',
 					'data-disabled': isDisabled ? '' : undefined,
+					'data-orientation': $orientation,
 				};
 			};
 		},
 	});
 
 	const trigger = builder(name('trigger'), {
-		stores: [value, disabled],
-		returned: ([$value, $disabled]) => {
+		stores: [value, disabled, orientation],
+		returned: ([$value, $disabled, $orientation]) => {
 			return (props: AccordionItemProps) => {
 				const { value: itemValue, disabled } = parseItemProps(props);
 				// generate the content ID here so that we can grab it in the content
@@ -107,6 +109,7 @@ export const createAccordion = <Multiple extends boolean = false>(
 					'data-disabled': isDisabled ? '' : undefined,
 					'data-value': itemValue,
 					'data-state': isItemSelected ? 'open' : 'closed',
+					'data-orientation': $orientation,
 				};
 			};
 		},
@@ -175,8 +178,8 @@ export const createAccordion = <Multiple extends boolean = false>(
 	});
 
 	const content = builder(name('content'), {
-		stores: [value, disabled, forceVisible],
-		returned: ([$value, $disabled, $forceVisible]) => {
+		stores: [value, disabled, orientation, forceVisible],
+		returned: ([$value, $disabled, $orientation, $forceVisible]) => {
 			return (props: AccordionItemProps) => {
 				const { value: itemValue, disabled } = parseItemProps(props);
 				const isVisible = isSelected(itemValue, $value) || $forceVisible;
@@ -189,6 +192,7 @@ export const createAccordion = <Multiple extends boolean = false>(
 					style: styleToString({
 						display: isVisible ? undefined : 'none',
 					}),
+					'data-orientation': $orientation,
 				};
 			};
 		},
@@ -210,13 +214,16 @@ export const createAccordion = <Multiple extends boolean = false>(
 	});
 
 	const heading = builder(name('heading'), {
-		returned: () => {
+		stores: [orientation, disabled],
+		returned: ([$orientation, $disabled]) => {
 			return (props: AccordionHeadingProps) => {
 				const { level } = parseHeadingProps(props);
 				return {
 					role: 'heading',
 					'aria-level': level,
 					'data-heading-level': level,
+					'data-orientation': $orientation,
+					'data-disabled': $disabled ? '' : undefined,
 				};
 			};
 		},

--- a/src/lib/builders/accordion/types.ts
+++ b/src/lib/builders/accordion/types.ts
@@ -29,6 +29,13 @@ export type CreateAccordionProps<Multiple extends boolean = false> = {
 	forceVisible?: boolean;
 
 	/**
+	 * The orientation of the accordion.
+	 *
+	 * @default 'horizontal'
+	 */
+	orientation?: 'horizontal' | 'vertical';
+
+	/**
 	 * The uncontrolled default value of the accordion.
 	 */
 	defaultValue?: Multiple extends false ? string : string[];

--- a/src/lib/builders/checkbox/create.ts
+++ b/src/lib/builders/checkbox/create.ts
@@ -1,6 +1,7 @@
 import {
 	addMeltEventListener,
 	builder,
+	effect,
 	executeCallbacks,
 	kbd,
 	omit,
@@ -43,6 +44,7 @@ export function createCheckbox(props?: CreateCheckboxProps) {
 				role: 'checkbox',
 				'aria-checked': isIndeterminate ? 'mixed' : $checked,
 				'aria-required': $required,
+				'aria-disabled': $disabled,
 			} as const;
 		},
 		action: (node: HTMLElement): MeltActionReturn<CheckboxEvents['root']> => {
@@ -78,16 +80,25 @@ export function createCheckbox(props?: CreateCheckboxProps) {
 				name: $name,
 				value: $value,
 				checked: $checked === 'indeterminate' ? false : $checked,
-				required: $required,
-				disabled: $disabled ? '' : undefined,
+				'data-required': $required ? '' : undefined,
+				'data-disabled': $disabled ? '' : undefined,
 				style: styleToString({
-					position: 'absolute',
-					opacity: 0,
-					'pointer-events': 'none',
-					margin: 0,
-					transform: 'translateX(-100%)',
+					display: 'none',
 				}),
 			} as const;
+		},
+		action: (node: HTMLInputElement) => {
+			node.disabled = node.hasAttribute('data-disabled');
+			node.required = node.hasAttribute('data-required');
+
+			const unsub = effect([disabled, required], ([$disabled, $required]) => {
+				node.disabled = $disabled;
+				node.required = $required;
+			});
+
+			return {
+				destroy: unsub,
+			};
 		},
 	});
 

--- a/src/lib/builders/checkbox/create.ts
+++ b/src/lib/builders/checkbox/create.ts
@@ -34,13 +34,14 @@ export function createCheckbox(props?: CreateCheckboxProps) {
 	const root = builder('checkbox', {
 		stores: [checked, disabled, required],
 		returned: ([$checked, $disabled, $required]) => {
+			const isIndeterminate = $checked === 'indeterminate';
+
 			return {
-				'data-disabled': $disabled,
-				'data-state':
-					$checked === 'indeterminate' ? 'indeterminate' : $checked ? 'checked' : 'unchecked',
+				'data-disabled': $disabled ? '' : undefined,
+				'data-state': isIndeterminate ? 'indeterminate' : $checked ? 'checked' : 'unchecked',
 				type: 'button',
 				role: 'checkbox',
-				'aria-checked': $checked === 'indeterminate' ? 'mixed' : $checked,
+				'aria-checked': isIndeterminate ? 'mixed' : $checked,
 				'aria-required': $required,
 			} as const;
 		},
@@ -78,7 +79,7 @@ export function createCheckbox(props?: CreateCheckboxProps) {
 				value: $value,
 				checked: $checked === 'indeterminate' ? false : $checked,
 				required: $required,
-				disabled: $disabled,
+				disabled: $disabled ? '' : undefined,
 				style: styleToString({
 					position: 'absolute',
 					opacity: 0,

--- a/src/lib/builders/collapsible/create.ts
+++ b/src/lib/builders/collapsible/create.ts
@@ -39,15 +39,17 @@ export function createCollapsible(props?: CreateCollapsibleProps) {
 
 	const trigger = builder(name('trigger'), {
 		stores: [open, disabled],
-		returned: ([$open, $disabled]) =>
-			({
+		returned: ([$open, $disabled]) => {
+			const disabledVal = $disabled ? '' : undefined;
+			return {
 				'data-state': $open ? 'open' : 'closed',
-				'data-disabled': $disabled ? '' : undefined,
-				disabled: $disabled,
-			} as const),
+				'data-disabled': disabledVal,
+				disabled: disabledVal,
+			} as const;
+		},
 		action: (node: HTMLElement): MeltActionReturn<CollapsibleEvents['trigger']> => {
 			const unsub = addMeltEventListener(node, 'click', () => {
-				const disabled = node.dataset.disabled !== undefined;
+				const disabled = node.hasAttribute('data-disabled');
 				if (disabled) return;
 				open.update(($open) => !$open);
 			});
@@ -65,14 +67,16 @@ export function createCollapsible(props?: CreateCollapsibleProps) {
 
 	const content = builder(name('content'), {
 		stores: [isVisible, disabled],
-		returned: ([$isVisible, $disabled]) => ({
-			'data-state': $isVisible ? 'open' : 'closed',
-			'data-disabled': $disabled ? '' : undefined,
-			hidden: $isVisible ? undefined : true,
-			style: styleToString({
-				display: $isVisible ? undefined : 'none',
-			}),
-		}),
+		returned: ([$isVisible, $disabled]) => {
+			return {
+				'data-state': $isVisible ? 'open' : 'closed',
+				'data-disabled': $disabled ? '' : undefined,
+				hidden: $isVisible ? undefined : true,
+				style: styleToString({
+					display: $isVisible ? undefined : 'none',
+				}),
+			};
+		},
 	});
 
 	return {

--- a/src/lib/builders/collapsible/create.ts
+++ b/src/lib/builders/collapsible/create.ts
@@ -34,17 +34,16 @@ export function createCollapsible(props?: CreateCollapsibleProps) {
 		returned: ([$open, $disabled]) => ({
 			'data-state': $open ? 'open' : 'closed',
 			'data-disabled': $disabled ? '' : 'undefined',
+			'aria-disabled': $disabled,
 		}),
 	});
 
 	const trigger = builder(name('trigger'), {
 		stores: [open, disabled],
 		returned: ([$open, $disabled]) => {
-			const disabledVal = $disabled ? '' : undefined;
 			return {
 				'data-state': $open ? 'open' : 'closed',
-				'data-disabled': disabledVal,
-				disabled: disabledVal,
+				'data-disabled': $disabled ? '' : undefined,
 			} as const;
 		},
 		action: (node: HTMLElement): MeltActionReturn<CollapsibleEvents['trigger']> => {

--- a/src/lib/builders/combobox/types.ts
+++ b/src/lib/builders/combobox/types.ts
@@ -133,6 +133,27 @@ export type CreateComboboxProps<ItemValue> = {
 	 * The delay in milliseconds for the filterFunction to be called after the input value changes.
 	 */
 	debounce?: number;
+
+	/**
+	 * The name of the combobox input element which is used for form submission.
+	 *
+	 * @default undefined
+	 */
+	name?: string;
+
+	/**
+	 * Whether the combobox input is disabled or not.
+	 *
+	 * @default false
+	 */
+	disabled?: boolean;
+
+	/**
+	 * Whether the combobox input is required or not.
+	 *
+	 * @default false
+	 */
+	required?: boolean;
 };
 
 type ComboboxFilterFunctionArgs<T> = {

--- a/src/lib/builders/dialog/types.ts
+++ b/src/lib/builders/dialog/types.ts
@@ -4,12 +4,50 @@ import type { createDialog } from './create.js';
 import type { ChangeFn } from '$lib/internal/helpers/index.js';
 export type { DialogComponentEvents } from './events.js';
 export type CreateDialogProps = {
+	/**
+	 * Whether to prevent scrolling the body while the dialog is open.
+	 *
+	 * @default true
+	 */
 	preventScroll?: boolean;
+
+	/**
+	 * Whether to close the dialog when the escape key is pressed.
+	 *
+	 * @default true
+	 */
 	closeOnEscape?: boolean;
+
+	/**
+	 * Whether to close the dialog when the user clicks outside of the dialog.
+	 *
+	 * @default true
+	 */
 	closeOnOutsideClick?: boolean;
+
+	/**
+	 * The role of the dialog.
+	 *
+	 * @default 'dialog'
+	 */
 	role?: 'dialog' | 'alertdialog';
+
+	/**
+	 * The default open state of the dialog.
+	 *
+	 * @default false
+	 */
 	defaultOpen?: boolean;
+
+	/**
+	 * The controlled open state of the dialog.
+	 *
+	 */
 	open?: Writable<boolean>;
+
+	/**
+	 * A change handler called when the open state of the dialog would normally change.
+	 */
 	onOpenChange?: ChangeFn<boolean>;
 	/**
 	 * If not undefined, the dialog content will be rendered within the provided element or selector.

--- a/src/lib/builders/menu/create.ts
+++ b/src/lib/builders/menu/create.ts
@@ -504,7 +504,7 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 					const checked = $value === itemValue;
 
 					return {
-						disabled,
+						disabled: disabled ? '' : undefined,
 						role: 'menuitemradio',
 						'data-state': checked ? 'checked' : 'unchecked',
 						'aria-checked': checked,

--- a/src/lib/builders/pagination/create.ts
+++ b/src/lib/builders/pagination/create.ts
@@ -122,7 +122,7 @@ export function createPagination(props: CreatePaginationProps) {
 		returned: ($page) => {
 			return {
 				'aria-label': 'Previous',
-				disabled: $page <= 1,
+				disabled: $page <= 1 ? '' : undefined,
 			} as const;
 		},
 		action: (node: HTMLElement): MeltActionReturn<PaginationEvents['prevButton']> => {
@@ -142,9 +142,11 @@ export function createPagination(props: CreatePaginationProps) {
 	const nextButton = builder(name('next'), {
 		stores: [page, totalPages],
 		returned: ([$page, $totalPages]) => {
+			const disabledVal = $page >= $totalPages ? '' : undefined;
 			return {
 				'aria-label': 'Next',
-				disabled: $page >= $totalPages,
+				disabled: disabledVal,
+				'data-disabled': disabledVal,
 			} as const;
 		},
 		action: (node: HTMLElement): MeltActionReturn<PaginationEvents['nextButton']> => {

--- a/src/lib/builders/pin-input/create.ts
+++ b/src/lib/builders/pin-input/create.ts
@@ -88,11 +88,12 @@ export function createPinInput(props?: CreatePinInputProps) {
 				const currIndex = index % totalItems;
 				index = (index + 1) % totalItems;
 				const currValue = $value[currIndex] ?? '';
-
+				const disabledVal = $disabled ? '' : undefined;
 				return {
 					'data-complete': $value.length && $value.every((v) => v.length > 0) ? '' : undefined,
 					placeholder: $placeholder,
-					disabled: $disabled,
+					disabled: disabledVal,
+					'data-disabled': disabledVal,
 					type: $type,
 					value: currValue,
 				};

--- a/src/lib/builders/radio-group/create.ts
+++ b/src/lib/builders/radio-group/create.ts
@@ -11,6 +11,7 @@ import {
 	kbd,
 	omit,
 	overridable,
+	styleToString,
 	toWritableStores,
 } from '$lib/internal/helpers/index.js';
 import type { Defaults, MeltActionReturn } from '$lib/internal/types.js';
@@ -25,6 +26,7 @@ const defaults = {
 	disabled: false,
 	required: false,
 	defaultValue: undefined,
+	name: undefined,
 } satisfies Defaults<CreateRadioGroupProps>;
 
 type RadioGroupParts = 'item' | 'item-input';
@@ -35,7 +37,7 @@ export function createRadioGroup(props?: CreateRadioGroupProps) {
 
 	// options
 	const options = toWritableStores(omit(withDefaults, 'value'));
-	const { disabled, required, loop, orientation } = options;
+	const { disabled, required, loop, orientation, name: inputName } = options;
 
 	const valueWritable = withDefaults.value ?? writable(withDefaults.defaultValue);
 	const value = overridable(valueWritable, withDefaults?.onValueChange);
@@ -173,21 +175,40 @@ export function createRadioGroup(props?: CreateRadioGroupProps) {
 	});
 
 	const itemInput = builder(name('item-input'), {
-		stores: [disabled, value],
-		returned: ([$disabled, $value]) => {
+		stores: [disabled, required, value, inputName],
+		returned: ([$disabled, $required, $value, $inputName]) => {
 			return (props: RadioGroupItemProps) => {
 				const itemValue = typeof props === 'string' ? props : props.value;
 				const argDisabled = typeof props === 'string' ? false : !!props.disabled;
+
 				const disabled = $disabled || argDisabled;
 
 				return {
-					type: 'hidden',
-					'aria-hidden': true,
+					type: 'radio',
+					name: $inputName,
 					tabindex: -1,
 					value: itemValue,
 					checked: $value === itemValue,
-					disabled: disabled ? '' : undefined,
+					'aria-hidden': true,
+					'data-disabled': disabled ? '' : undefined,
+					'data-required': $required ? '' : undefined,
+					style: styleToString({
+						display: 'none',
+					}),
 				};
+			};
+		},
+		action: (node: HTMLInputElement) => {
+			node.disabled = node.hasAttribute('data-disabled');
+			node.required = node.hasAttribute('data-required');
+
+			const unsub = effect([disabled, required], ([$disabled, $required]) => {
+				node.disabled = $disabled || node.hasAttribute('data-disabled');
+				node.required = $required || node.hasAttribute('data-required');
+			});
+
+			return {
+				destroy: unsub,
 			};
 		},
 	});

--- a/src/lib/builders/radio-group/create.ts
+++ b/src/lib/builders/radio-group/create.ts
@@ -101,14 +101,13 @@ export function createRadioGroup(props?: CreateRadioGroupProps) {
 
 				const tabindex = !hasActiveTabIndex ? 0 : checked ? 0 : -1;
 				hasActiveTabIndex = true;
-				const disabledVal = disabled ? '' : undefined;
 				return {
-					disabled: disabledVal,
 					'data-value': itemValue,
 					'data-orientation': $orientation,
-					'data-disabled': disabledVal,
+					'data-disabled': disabled ? '' : undefined,
 					'data-state': checked ? 'checked' : 'unchecked',
 					'aria-checked': checked,
+					'aria-disabled': disabled,
 					type: 'button',
 					role: 'radio',
 					tabindex,

--- a/src/lib/builders/radio-group/create.ts
+++ b/src/lib/builders/radio-group/create.ts
@@ -69,7 +69,7 @@ export function createRadioGroup(props?: CreateRadioGroupProps) {
 
 	/* Helpers */
 	const selectItem = (item: HTMLElement) => {
-		const disabled = item.dataset.disabled === 'true';
+		const disabled = item.hasAttribute('data-disabled');
 		const itemValue = item.dataset.value;
 		if (disabled || itemValue === undefined) return;
 		value.set(itemValue);
@@ -99,12 +99,12 @@ export function createRadioGroup(props?: CreateRadioGroupProps) {
 
 				const tabindex = !hasActiveTabIndex ? 0 : checked ? 0 : -1;
 				hasActiveTabIndex = true;
-
+				const disabledVal = disabled ? '' : undefined;
 				return {
-					disabled,
+					disabled: disabledVal,
 					'data-value': itemValue,
 					'data-orientation': $orientation,
-					'data-disabled': disabled ? true : undefined,
+					'data-disabled': disabledVal,
 					'data-state': checked ? 'checked' : 'unchecked',
 					'aria-checked': checked,
 					type: 'button',
@@ -186,7 +186,7 @@ export function createRadioGroup(props?: CreateRadioGroupProps) {
 					tabindex: -1,
 					value: itemValue,
 					checked: $value === itemValue,
-					disabled,
+					disabled: disabled ? '' : undefined,
 				};
 			};
 		},

--- a/src/lib/builders/radio-group/types.ts
+++ b/src/lib/builders/radio-group/types.ts
@@ -6,7 +6,8 @@ export type { RadioGroupComponentEvents } from './events.js';
 
 export type CreateRadioGroupProps = {
 	/**
-	 * When `true`, prevents the user from interacting with the radio group.
+	 * When `true`, prevents the user from interacting with the radio group in its entirety.
+	 * To disable individual radio items, use the `disabled` prop on the `item` builder instead.
 	 *
 	 * @default false
 	 */
@@ -19,6 +20,13 @@ export type CreateRadioGroupProps = {
 	 * @default false
 	 */
 	required?: boolean;
+
+	/**
+	 * The name of the radio group input that is submitted with form data.
+	 *
+	 * @default undefined
+	 */
+	name?: string;
 
 	/**
 	 * Whether or not the radio group should loop around when the end

--- a/src/lib/builders/select/create.ts
+++ b/src/lib/builders/select/create.ts
@@ -286,6 +286,7 @@ export function createSelect<
 	const trigger = builder(name('trigger'), {
 		stores: [open, disabled, required],
 		returned: ([$open, $disabled, $required]) => {
+			const disabledVal = $disabled ? '' : undefined;
 			return {
 				role: 'combobox',
 				'aria-autocomplete': 'none',
@@ -294,9 +295,9 @@ export function createSelect<
 				'aria-expanded': $open,
 				'aria-required': $required,
 				'data-state': $open ? 'open' : 'closed',
-				'data-disabled': $disabled ? true : undefined,
+				'data-disabled': disabledVal,
 				'aria-labelledby': ids.label,
-				disabled: $disabled,
+				disabled: disabledVal,
 				id: ids.trigger,
 				tabindex: 0,
 			} as const;
@@ -669,7 +670,7 @@ export function createSelect<
 				hidden: true,
 				tabIndex: -1,
 				required: $required,
-				disabled: $disabled,
+				disabled: $disabled ? '' : undefined,
 				style: styleToString({
 					position: 'absolute',
 					opacity: 0,

--- a/src/lib/builders/slider/create.ts
+++ b/src/lib/builders/slider/create.ts
@@ -52,8 +52,10 @@ export const createSlider = (props?: CreateSliderProps) => {
 	const root = builder(name(), {
 		stores: [disabled, orientation],
 		returned: ([$disabled, $orientation]) => {
+			const disabledVal = $disabled ? '' : undefined;
 			return {
-				disabled: $disabled,
+				disabled: disabledVal,
+				'data-disabled': disabledVal,
 				'data-orientation': $orientation,
 				style: $disabled ? undefined : 'touch-action: none;',
 				'data-melt-id': ids.root,
@@ -148,6 +150,8 @@ export const createSlider = (props?: CreateSliderProps) => {
 					'aria-valuemax': $max,
 					'aria-valuenow': $value[index],
 					'data-melt-part': 'thumb',
+					'aria-disabled': $disabled,
+					'data-disabled': $disabled ? '' : undefined,
 					style: styleToString({
 						position: 'absolute',
 						...($orientation === 'horizontal'

--- a/src/lib/builders/switch/create.ts
+++ b/src/lib/builders/switch/create.ts
@@ -41,14 +41,17 @@ export function createSwitch(props?: CreateSwitchProps) {
 	const root = builder(name(), {
 		stores: [checked, disabled, required],
 		returned: ([$checked, $disabled, $required]) => {
+			const disabledVal = $disabled ? '' : undefined;
+
 			return {
-				'data-disabled': $disabled,
-				disabled: $disabled,
+				'data-disabled': disabledVal,
+				disabled: disabledVal,
 				'data-state': $checked ? 'checked' : 'unchecked',
 				type: 'button',
 				role: 'switch',
 				'aria-checked': $checked,
 				'aria-required': $required,
+				'aria-disabled': $disabled,
 			} as const;
 		},
 		action(node: HTMLElement): MeltActionReturn<SwitchEvents['root']> {
@@ -81,7 +84,7 @@ export function createSwitch(props?: CreateSwitchProps) {
 				value: $value,
 				checked: $checked,
 				required: $required,
-				disabled: $disabled,
+				disabled: $disabled ? '' : undefined,
 				style: styleToString({
 					position: 'absolute',
 					opacity: 0,

--- a/src/lib/builders/tabs/create.ts
+++ b/src/lib/builders/tabs/create.ts
@@ -87,7 +87,7 @@ export function createTabs(props?: CreateTabsProps) {
 
 				const sourceOfTruth = isBrowser ? $value : ssrValue;
 				const isActive = sourceOfTruth === tabValue;
-
+				const disabledVal = disabled ? '' : undefined;
 				return {
 					type: 'button',
 					role: 'tab',
@@ -95,15 +95,15 @@ export function createTabs(props?: CreateTabsProps) {
 					tabindex: isActive ? 0 : -1,
 					'data-value': tabValue,
 					'data-orientation': $orientation,
-					'data-disabled': disabled ? true : undefined,
-					disabled,
+					'data-disabled': disabledVal,
+					disabled: disabledVal,
 				};
 			};
 		},
 		action: (node: HTMLElement): MeltActionReturn<TabsEvents['trigger']> => {
 			const unsub = executeCallbacks(
 				addMeltEventListener(node, 'focus', () => {
-					const disabled = node.dataset.disabled === 'true';
+					const disabled = node.hasAttribute('data-disabled');
 					const tabValue = node.dataset.value;
 
 					if (get(activateOnFocus) && !disabled && tabValue !== undefined) {
@@ -116,7 +116,7 @@ export function createTabs(props?: CreateTabsProps) {
 
 					e.preventDefault();
 
-					const disabled = node.dataset.disabled === 'true';
+					const disabled = node.hasAttribute('data-disabled');
 					if (disabled) return;
 
 					const tabValue = node.dataset.value;

--- a/src/lib/builders/tags-input/create.ts
+++ b/src/lib/builders/tags-input/create.ts
@@ -233,7 +233,7 @@ export function createTagsInput(props?: CreateTagsInputProps) {
 			return {
 				'data-melt-id': ids.root,
 				'data-disabled': $disabled ? true : undefined,
-				disabled: $disabled,
+				disabled: $disabled ? '' : undefined,
 			} as const;
 		},
 		action: (node: HTMLElement): MeltActionReturn<TagsInputEvents['root']> => {
@@ -261,7 +261,7 @@ export function createTagsInput(props?: CreateTagsInputProps) {
 			return {
 				'data-melt-id': ids.input,
 				'data-disabled': $disabled ? '' : undefined,
-				disabled: $disabled,
+				disabled: $disabled ? '' : undefined,
 				placeholder: $placeholder,
 			};
 		},
@@ -488,7 +488,7 @@ export function createTagsInput(props?: CreateTagsInputProps) {
 					'data-editable': editable ? '' : undefined,
 					'data-editing': editing ? '' : undefined,
 					'data-disabled': disabled ? '' : undefined,
-					disabled: disabled,
+					disabled: disabled ? '' : undefined,
 					hidden: editing,
 					tabindex: -1,
 					style: editing
@@ -576,14 +576,15 @@ export function createTagsInput(props?: CreateTagsInputProps) {
 				const selected = disabled ? undefined : $selected?.id === tag?.id;
 				const editing = editable ? $editing?.id === tag?.id : undefined;
 
+				const disabledVal = disabled ? '' : undefined;
 				return {
 					'aria-selected': selected,
 					'data-tag-id': tag.id,
 					'data-tag-value': tag.value,
 					'data-selected': selected ? '' : undefined,
 					'data-editing': editing ? '' : undefined,
-					'data-disabled': disabled ? '' : undefined,
-					disabled: disabled,
+					'data-disabled': disabledVal,
+					disabled: disabledVal,
 					tabindex: -1,
 				};
 			};

--- a/src/lib/builders/toggle-group/create.ts
+++ b/src/lib/builders/toggle-group/create.ts
@@ -64,14 +64,16 @@ export const createToggleGroup = <T extends ToggleGroupType = 'single'>(
 				const argDisabled = typeof props === 'string' ? false : !!props.disabled;
 				const disabled = $disabled || argDisabled;
 				const pressed = Array.isArray($value) ? $value.includes(itemValue) : $value === itemValue;
+				const disabledVal = disabled ? '' : undefined;
 				return {
-					disabled,
+					disabled: disabledVal,
 					pressed,
 					'data-orientation': $orientation,
-					'data-disabled': disabled ? true : undefined,
+					'data-disabled': disabledVal,
 					'data-state': pressed ? 'on' : 'off',
 					'data-value': itemValue,
 					'aria-pressed': pressed,
+					'aria-disabled': disabled,
 					type: 'button',
 					role: $type === 'single' ? 'radio' : undefined,
 					tabindex: pressed ? 0 : -1,
@@ -94,7 +96,7 @@ export const createToggleGroup = <T extends ToggleGroupType = 'single'>(
 
 			function getNodeProps() {
 				const itemValue = node.dataset.value;
-				const disabled = node.dataset.disabled === 'true';
+				const disabled = node.hasAttribute('data-disabled');
 
 				return { value: itemValue, disabled };
 			}

--- a/src/lib/builders/toggle/create.ts
+++ b/src/lib/builders/toggle/create.ts
@@ -35,9 +35,11 @@ export function createToggle(props?: CreateToggleProps) {
 	const root = builder('toggle', {
 		stores: [pressed, disabled],
 		returned: ([$pressed, $disabled]) => {
+			const disabledVal = $disabled ? '' : undefined;
 			return {
-				'data-disabled': $disabled ? true : undefined,
-				disabled: $disabled,
+				'data-disabled': disabledVal,
+				'aria-disabled': $disabled,
+				disabled: disabledVal,
 				'data-state': $pressed ? 'on' : 'off',
 				'aria-pressed': $pressed,
 				type: 'button',

--- a/src/lib/builders/toolbar/create.ts
+++ b/src/lib/builders/toolbar/create.ts
@@ -129,11 +129,12 @@ export const createToolbar = (props?: CreateToolbarProps) => {
 					const disabled = $disabled || argDisabled;
 
 					const pressed = Array.isArray($value) ? $value.includes(itemValue) : $value === itemValue;
+					const disabledVal = disabled ? '' : undefined;
 					return {
-						disabled,
+						disabled: disabledVal,
 						pressed,
 						'data-orientation': $orientation,
-						'data-disabled': disabled ? true : undefined,
+						'data-disabled': disabledVal,
 						'data-value': itemValue,
 						'data-state': pressed ? 'on' : 'off',
 						'aria-pressed': pressed,
@@ -146,7 +147,7 @@ export const createToolbar = (props?: CreateToolbarProps) => {
 			action: (node: HTMLElement): MeltActionReturn<ToolbarEvents['item']> => {
 				function getNodeProps() {
 					const itemValue = node.dataset.value;
-					const disabled = node.dataset.disabled === 'true';
+					const disabled = node.hasAttribute('data-disabled');
 
 					return { value: itemValue, disabled };
 				}


### PR DESCRIPTION
Closes: #390

Standardizes the way we apply `data-disabled` properties to various builder elements. Right now we have a mix of `[data-disabled]` `[data-disabled="true"]` `[data-disabled="false"]`.

Made them all consistent where `[data-disabled]` is only applied if the element is in fact disabled.

Additionally, only apply the `disabled` attribute if the element is disabled, otherwise, it's undefined.