### PR TITLE
[RadioGroup] - Fix input `required` & `disabled` & add `name` prop to builder

### DIFF
--- a/.changeset/tough-insects-sip.md
+++ b/.changeset/tough-insects-sip.md
@@ -1,0 +1,6 @@
+---
+"@melt-ui/svelte": patch
+---
+
+- Properly apply `required` and `disabled` attributes on `itemInput`
+- Add `name` prop to `createRadioGroup` builder to apply to `itemInput`s 

--- a/src/docs/data/builders/radio-group.ts
+++ b/src/docs/data/builders/radio-group.ts
@@ -17,6 +17,11 @@ const OPTION_PROPS = [
 		default: '"vertical"',
 		description: 'The orientation of the radio group.',
 	},
+	{
+		name: 'name',
+		type: 'string',
+		description: 'The name of the radio group input that is submitted with form data.',
+	},
 ];
 const BUILDER_NAME = 'radio group';
 

--- a/src/lib/builders/radio-group/types.ts
+++ b/src/lib/builders/radio-group/types.ts
@@ -6,7 +6,8 @@ export type { RadioGroupComponentEvents } from './events.js';
 
 export type CreateRadioGroupProps = {
 	/**
-	 * When `true`, prevents the user from interacting with the radio group.
+	 * When `true`, prevents the user from interacting with the radio group in its entirety.
+	 * To disable individual radio items, use the `disabled` prop on the `item` builder instead.
 	 *
 	 * @default false
 	 */
@@ -19,6 +20,13 @@ export type CreateRadioGroupProps = {
 	 * @default false
 	 */
 	required?: boolean;
+
+	/**
+	 * The name of the radio group input that is submitted with form data.
+	 *
+	 * @default undefined
+	 */
+	name?: string;
 
 	/**
 	 * Whether or not the radio group should loop around when the end


### PR DESCRIPTION
Fixes: #434
Closes: #394 

Applying the `required` and `disabled` attributes in the return object of the store like we do other attributes does not work properly.

The fix I came up with is setting `data-disabled` & `data-required` attributes on the input on SSR, and then when the action runs, checking for those attributes to properly set the `node.disabled` and `node.required`. Additionally, using an `effect` we're watching to see if the `disabled` or `required` option stores are updated and then updates the input accordingly.

This is likely the case with the other builder inputs, so I will adjust those in #439 which I've already started to handle the `disabled` attributes.

Additionally, added a `name` option to the radio group builder to apply to the inputs for form submission.