### PR TITLE
refactor: migrate from `eslint-plugin-svelte3` to `eslint-plugin-svelte`

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,34 +1,60 @@
+/** @type {import('eslint').Linter.Config} */
 module.exports = {
 	root: true,
 	parser: '@typescript-eslint/parser',
 	extends: [
 		'eslint:recommended',
 		'plugin:@typescript-eslint/recommended',
+		'plugin:svelte/recommended',
 		'plugin:storybook/recommended',
 		'prettier',
 	],
-	plugins: ['svelte3', '@typescript-eslint'],
-	ignorePatterns: ['*.cjs'],
+	plugins: ['@typescript-eslint'],
 	overrides: [
 		{
 			files: ['*.svelte'],
-			processor: 'svelte3/svelte3',
+			parser: 'svelte-eslint-parser',
+			parserOptions: {
+				parser: '@typescript-eslint/parser',
+			},
 		},
 	],
-	settings: {
-		'svelte3/typescript': () => require('typescript'),
-	},
 	parserOptions: {
 		sourceType: 'module',
-		ecmaVersion: 2020,
+		ecmaVersion: 'latest',
+		extraFileExtensions: ['.svelte'],
 	},
 	env: {
 		browser: true,
-		es2017: true,
+		es2024: true,
 		node: true,
 	},
 	rules: {
+		// eslint
 		'no-console': 'warn',
+
+		// @typescript-eslint
+		'@typescript-eslint/no-unused-vars': [
+			'warn',
+			{
+				argsIgnorePattern: '^_',
+				varsIgnorePattern: '^_',
+			},
+		],
+
+		// eslint-plugin-svelte
+		'svelte/no-target-blank': 'error',
+		'svelte/no-immutable-reactive-statements': 'error',
+		'svelte/no-trailing-spaces': 'error',
+		'svelte/prefer-style-directive': 'error',
+		'svelte/no-reactive-literals': 'error',
+		'svelte/no-useless-mustaches': 'error',
+		// TODO: opt in to these at a later stage
+		'svelte/button-has-type': 'off',
+		'svelte/require-each-key': 'off',
+		'svelte/no-at-html-tags': 'off',
+		'svelte/no-unused-svelte-ignore': 'off',
+		'svelte/require-stores-init': 'off',
 	},
 	globals: {
 		NodeJS: true,

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
 		"eslint": "^8.45.0",
 		"eslint-config-prettier": "^8.9.0",
 		"eslint-plugin-storybook": "^0.6.13",
-		"eslint-plugin-svelte3": "^4.0.0",
+		"eslint-plugin-svelte": "^2.33.0",
 		"glob": "^9.3.2",
 		"happy-dom": "^10.5.2",
 		"hast-util-to-html": "^8.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,9 +130,9 @@ devDependencies:
   eslint-plugin-storybook:
     specifier: ^0.6.13
     version: 0.6.13(eslint@8.45.0)(typescript@5.1.6)
-  eslint-plugin-svelte3:
-    specifier: ^4.0.0
-    version: 4.0.0(eslint@8.45.0)(svelte@4.0.0)
+  eslint-plugin-svelte:
+    specifier: ^2.33.0
+    version: 2.33.0(eslint@8.45.0)(svelte@4.0.0)
   glob:
     specifier: ^9.3.2
     version: 9.3.4
@@ -6702,14 +6702,32 @@ packages:
       - typescript
     dev: true
 
-  /eslint-plugin-svelte3@4.0.0(eslint@8.45.0)(svelte@4.0.0):
-    resolution: {integrity: sha512-OIx9lgaNzD02+MDFNLw0GEUbuovNcglg+wnd/UY0fbZmlQSz7GlQiQ1f+yX0XvC07XPcDOnFcichqI3xCwp71g==}
+  /eslint-plugin-svelte@2.33.0(eslint@8.45.0)(svelte@4.0.0):
+    resolution: {integrity: sha512-kk7Z4BfxVjFYJseFcOpS8kiKNio7KnAnhFagmM89h1wNSKlM7tIn+uguNQppKM9leYW+S+Us0Rjg2Qg3zsEcvg==}
+    engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: '>=8.0.0'
-      svelte: ^3.2.0
+      eslint: ^7.0.0 || ^8.0.0-0
+      svelte: ^3.37.0 || ^4.0.0
+    peerDependenciesMeta:
+      svelte:
+        optional: true
     dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.45.0)
+      '@jridgewell/sourcemap-codec': 1.4.15
+      debug: 4.3.4
       eslint: 8.45.0
+      esutils: 2.0.3
+      known-css-properties: 0.28.0
+      postcss: 8.4.27
+      postcss-load-config: 3.1.4(postcss@8.4.27)
+      postcss-safe-parser: 6.0.0(postcss@8.4.27)
+      postcss-selector-parser: 6.0.11
+      semver: 7.5.4
       svelte: 4.0.0
+      svelte-eslint-parser: 0.33.0(svelte@4.0.0)
+    transitivePeerDependencies:
+      - supports-color
+      - ts-node
     dev: true
 
   /eslint-scope@5.1.1:
@@ -8540,6 +8558,10 @@ packages:
     engines: {node: '>= 8'}
     dev: true
 
+  /known-css-properties@0.28.0:
+    resolution: {integrity: sha512-9pSL5XB4J+ifHP0e0jmmC98OGC1nL8/JjS+fi6mnTlIf//yt/MfVLtKg7S6nCtj/8KTcWX7nRlY0XywoYY1ISQ==}
+    dev: true
+
   /lazy-universal-dotenv@4.0.0:
     resolution: {integrity: sha512-aXpZJRnTkpK6gQ/z4nk+ZBLd/Qdp118cvPruLSIQzQNRhKwEcdXCOzXuF55VDqIiuAaY3UGZ10DJtvZzDcvsxg==}
     engines: {node: '>=14.0.0'}
@@ -9975,6 +9997,23 @@ packages:
       postcss: 8.4.27
     dev: true
 
+  /postcss-load-config@3.1.4(postcss@8.4.27):
+    resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
+    engines: {node: '>= 10'}
+    peerDependencies:
+      postcss: '>=8.0.9'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      postcss:
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      lilconfig: 2.1.0
+      postcss: 8.4.27
+      yaml: 1.10.2
+    dev: true
+
   /postcss-load-config@4.0.1(postcss@8.4.27):
     resolution: {integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==}
     engines: {node: '>= 14'}
@@ -10058,6 +10097,24 @@ packages:
       postcss-selector-parser: 6.0.11
     dev: true
 
+  /postcss-safe-parser@6.0.0(postcss@8.4.27):
+    resolution: {integrity: sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.3.3
+    dependencies:
+      postcss: 8.4.27
+    dev: true
+
+  /postcss-scss@4.0.7(postcss@8.4.28):
+    resolution: {integrity: sha512-xPv2GseoyXPa58Nro7M73ZntttusuCmZdeOojUFR5PZDz2BR62vfYx1w9TyOnp1+nYFowgOMipsCBhxzVkAEPw==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.4.19
+    dependencies:
+      postcss: 8.4.28
+    dev: true
+
   /postcss-selector-parser@6.0.10:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
     engines: {node: '>=4'}
@@ -10080,6 +10137,15 @@ packages:
 
   /postcss@8.4.27:
     resolution: {integrity: sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.6
+      picocolors: 1.0.0
+      source-map-js: 1.0.2
+    dev: true
+
+  /postcss@8.4.28:
+    resolution: {integrity: sha512-Z7V5j0cq8oEKyejIKfpD8b4eBy9cwW2JWPk0+fB1HOAMsfHbnAXLLS+PfVWlzMSLQaWttKDt607I0XHmpE67Vw==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       nanoid: 3.3.6
@@ -11390,6 +11456,23 @@ packages:
       - sass
       - stylus
       - sugarss
+    dev: true
+
+  /svelte-eslint-parser@0.33.0(svelte@4.0.0):
+    resolution: {integrity: sha512-5awZ6Bs+Tb/zQwa41PSdcLynAVQTwW0HGyCBjtbAQ59taLZqDgQSMzRlDmapjZdDtzERm0oXDZNE0E+PKJ6ryg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      svelte: ^3.37.0 || ^4.0.0
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+    dependencies:
+      eslint-scope: 7.2.0
+      eslint-visitor-keys: 3.4.1
+      espree: 9.6.1
+      postcss: 8.4.28
+      postcss-scss: 4.0.7(postcss@8.4.28)
+      svelte: 4.0.0
     dev: true
 
   /svelte-fragment-component@1.2.0(svelte@4.0.0):
@@ -12739,6 +12822,11 @@ packages:
 
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+    dev: true
+
+  /yaml@1.10.2:
+    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
+    engines: {node: '>= 6'}
     dev: true
 
   /yaml@2.2.1:

--- a/src/docs/components/site-header.svelte
+++ b/src/docs/components/site-header.svelte
@@ -40,7 +40,7 @@
 			<a
 				href={siteConfig.links.discord}
 				target="_blank"
-				rel="noreferrer"
+				rel="noopener noreferrer"
 				class=" text-neutral-400 transition-colors hover:text-neutral-50"
 			>
 				<Discord class="h-5 w-5" />
@@ -49,7 +49,7 @@
 			<a
 				href={siteConfig.links.github}
 				target="_blank"
-				rel="noreferrer"
+				rel="noopener noreferrer"
 				class="ml-6 text-neutral-400 transition-colors hover:text-neutral-50"
 			>
 				<GitHub class="h-5 w-5" />

--- a/src/docs/components/ui/button.svelte
+++ b/src/docs/components/ui/button.svelte
@@ -31,6 +31,7 @@
 		href?: never;
 	}
 
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	type $$Props = AnchorElement | ButtonElement;
 </script>
 

--- a/src/docs/previews/accordion/disabled/css/index.svelte
+++ b/src/docs/previews/accordion/disabled/css/index.svelte
@@ -31,7 +31,7 @@
 </script>
 
 <div class="root" use:melt={$root}>
-	{#each items as { id, title, description, disabled }, i}
+	{#each items as { id, title, description, disabled }}
 		<div use:melt={$item(id)} class="item">
 			<h2>
 				<button use:melt={$trigger({ value: id, disabled })} class="trigger">

--- a/src/docs/previews/accordion/main/css/index.svelte
+++ b/src/docs/previews/accordion/main/css/index.svelte
@@ -29,7 +29,7 @@
 </script>
 
 <div class="root" use:melt={$root}>
-	{#each items as { id, title, description }, i}
+	{#each items as { id, title, description }}
 		<div use:melt={$item(id)} class="item">
 			<h2>
 				<button use:melt={$trigger(id)} class="trigger">

--- a/src/docs/previews/accordion/multiple/css/index.svelte
+++ b/src/docs/previews/accordion/multiple/css/index.svelte
@@ -31,7 +31,7 @@
 </script>
 
 <div class="root" use:melt={$root}>
-	{#each items as { id, title, description }, i}
+	{#each items as { id, title, description }}
 		<div use:melt={$item(id)} class="item">
 			<h2>
 				<button use:melt={$trigger(id)} class="trigger">

--- a/src/docs/previews/link-preview/main/tailwind/index.svelte
+++ b/src/docs/previews/link-preview/main/tailwind/index.svelte
@@ -14,7 +14,7 @@
 	class="trigger"
 	href="https://github.com/melt-ui/melt-ui"
 	target="_blank"
-	rel="noreferrer"
+	rel="noopener noreferrer"
 	use:melt={$trigger}
 >
 	<img

--- a/src/docs/previews/pin-input/main/tailwind/index.svelte
+++ b/src/docs/previews/pin-input/main/tailwind/index.svelte
@@ -9,7 +9,7 @@
 </script>
 
 <div use:melt={$root} class="flex items-center gap-2">
-	{#each Array.from({ length: 5 }) as _, i}
+	{#each Array.from({ length: 5 }) as _}
 		<input
 			class="rounded-md bg-white text-center text-lg text-magnum-900 shadow-sm square-12"
 			use:melt={$input()}

--- a/src/routes/(landing-ui)/pin-input.svelte
+++ b/src/routes/(landing-ui)/pin-input.svelte
@@ -14,7 +14,7 @@
 </script>
 
 <div use:melt={$root} class={cn('flex items-center gap-2', className)}>
-	{#each Array.from({ length: 5 }) as _, i}
+	{#each Array.from({ length: 5 }) as _}
 		<input
 			class="rounded-xl bg-white text-center text-lg text-magnum-900 shadow-sm square-12"
 			use:melt={$input()}

--- a/src/routes/docs/builders/[name]/+page.svelte
+++ b/src/routes/docs/builders/[name]/+page.svelte
@@ -12,11 +12,13 @@
 
 	export let data: PageData;
 
+	// eslint-disable-next-line no-undef
 	type Component = $$Generic<typeof SvelteComponent>;
 	$: component = data.doc.default as unknown as Component;
 	$: doc = data.doc.metadata;
 	$: snippets = data.snippets;
 	$: mainPreview = data.mainPreview as unknown as Component;
+	// eslint-disable-next-line svelte/no-reactive-literals, svelte/no-immutable-reactive-statements
 	$: viewCode = false;
 	$: previews = data.previews;
 	$: features = data.builderData.features;

--- a/src/tests/accordion/AccordionTest.svelte
+++ b/src/tests/accordion/AccordionTest.svelte
@@ -12,7 +12,7 @@
 </script>
 
 <div use:melt={$root}>
-	{#each items as { id, triggerId, title, description }, i}
+	{#each items as { id, triggerId, title, description }}
 		<div use:melt={$item(id)} data-testid={id}>
 			<h2 class="flex">
 				<button data-testid={triggerId} use:melt={$trigger(id)}>

--- a/src/tests/link-preview/LinkPreviewTest.svelte
+++ b/src/tests/link-preview/LinkPreviewTest.svelte
@@ -13,7 +13,7 @@
 	class="trigger"
 	href="https://github.com/melt-ui/melt-ui"
 	target="_blank"
-	rel="noreferrer"
+	rel="noopener noreferrer"
 	use:melt={$trigger}
 >
 	<img


### PR DESCRIPTION
## Changes
- install `eslint-plugin-svelte` dependency
- remove `eslint-plugin-svelte3` dependency
- modernize eslint config
- configure `@typescript-eslint/no-unused-vars` properly to ignore underscore-prefixed vars and args
- opt in to additional `eslint-plugin-svelte` rules which are not part of the recommended config
- fix or disable reported lint issues

## Motivation
Close https://github.com/melt-ui/melt-ui/issues/428