### PR TITLE
fix: docs tooltip content events

### DIFF
--- a/src/docs/data/builders/tooltip.ts
+++ b/src/docs/data/builders/tooltip.ts
@@ -85,7 +85,7 @@ const content = elementSchema('content', {
 			value: ATTRS.MELT('tooltip content'),
 		},
 	],
-	events: tooltipEvents['trigger'],
+	events: tooltipEvents['content'],
 });
 
 const arrow = elementSchema('arrow', {


### PR DESCRIPTION
Closes: #445 