### PR TITLE
Fix: select nested portal bug

### DIFF
--- a/.changeset/big-weeks-suffer.md
+++ b/.changeset/big-weeks-suffer.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+Fix: Bug where selecitng an item in a `Select` would close it's parent popover or dialog

--- a/src/lib/builders/select/create.ts
+++ b/src/lib/builders/select/create.ts
@@ -268,7 +268,6 @@ export function createSelect<
 		stores: [isVisible, portal],
 		returned: ([$isVisible, $portal]) => {
 			return {
-				hidden: $isVisible ? undefined : true,
 				style: styleToString({
 					display: $isVisible ? undefined : 'none',
 				}),
@@ -359,13 +358,10 @@ export function createSelect<
 				})
 			);
 
-			const unsubPortal = usePortal(node, 'body')?.destroy;
-
 			return {
 				destroy() {
 					unsubDerived();
 					unsubPopper();
-					unsubPortal?.();
 					unsubScroll();
 					unsubEventListeners();
 				},

--- a/src/lib/internal/helpers/elements.ts
+++ b/src/lib/internal/helpers/elements.ts
@@ -6,7 +6,7 @@ import { isHTMLElement } from './is.js';
  */
 function getPortalParent(node: HTMLElement) {
 	let parent = node.parentElement;
-	while (isHTMLElement(parent) && parent.getAttribute('data-portal') === null) {
+	while (isHTMLElement(parent) && !parent.hasAttribute('data-portal')) {
 		parent = parent.parentElement;
 	}
 	return parent || 'body';


### PR DESCRIPTION
Closes: #451

We had an extra portal action in there causing the portal to always be set to the body, regardless of the `portal` prop or parent portal situation. Removing the 2nd portal action solves the issue and it now works as expected.