### PR TITLE
fix: Combobox isSelected function

### DIFF
--- a/.changeset/fair-bags-try.md
+++ b/.changeset/fair-bags-try.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+fix: Combobox isSelected function

--- a/src/docs/data/builders/combobox.ts
+++ b/src/docs/data/builders/combobox.ts
@@ -98,7 +98,7 @@ const builder = builderSchema(BUILDER_NAME, {
 			description: 'A readable store that returns true when no visible items are present.',
 		},
 		{
-			name: 'value',
+			name: 'selected',
 			type: 'Writable<T>',
 			description: 'A writable store whose value is the selected item.',
 		},

--- a/src/docs/previews/combobox/main/tailwind/index.svelte
+++ b/src/docs/previews/combobox/main/tailwind/index.svelte
@@ -137,11 +137,11 @@
 					data-[disabled]:opacity-50"
 				>
 					{#if $isSelected(book)}
-						<div class="check">
+						<div class="check absolute left-2 top-1/2 z-10 text-magnum-900">
 							<Check class="square-4" />
 						</div>
 					{/if}
-					<div>
+					<div class="pl-4">
 						<span class="font-medium">{book.title}</span>
 						<span class="block text-sm opacity-75">{book.author}</span>
 					</div>

--- a/src/lib/builders/combobox/create.ts
+++ b/src/lib/builders/combobox/create.ts
@@ -228,7 +228,7 @@ export function createCombobox<Value>(props?: CreateComboboxProps<Value>) {
 	 * This is useful for displaying additional markup on the selected item.
 	 */
 	const isSelected = derived([selected], ([$value]) => {
-		return (item: Value) => JSON.stringify($value?.value) === JSON.stringify(item);
+		return (item: Value) => deepEqual($value?.value, item);
 	});
 
 	/** -------- */

--- a/src/lib/builders/combobox/create.ts
+++ b/src/lib/builders/combobox/create.ts
@@ -228,7 +228,7 @@ export function createCombobox<Value>(props?: CreateComboboxProps<Value>) {
 	 * This is useful for displaying additional markup on the selected item.
 	 */
 	const isSelected = derived([selected], ([$value]) => {
-		return (item: Value) => $value === item;
+		return (item: Value) => JSON.stringify($value?.value) === JSON.stringify(item);
 	});
 
 	/** -------- */


### PR DESCRIPTION
Hey, I noticed that the `isSelected` function is currently always returning `false` since we're comparing two non-primitive object types. I changed the function to use `JSON.stringify()` instead which fixes that. Now the checkmark also shows up in the preview.