### PR TITLE
Fix: menubar trigger toggle bug

### DIFF
--- a/.changeset/tough-cars-bake.md
+++ b/.changeset/tough-cars-bake.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+Fix: bug preventing menubar triggers from toggling

--- a/src/lib/builders/menubar/create.ts
+++ b/src/lib/builders/menubar/create.ts
@@ -31,6 +31,7 @@ import {
 	addMeltEventListener,
 	getPortalDestination,
 	removeScroll,
+	isElement,
 } from '$lib/internal/helpers/index.js';
 import { onDestroy, onMount, tick } from 'svelte';
 import { usePopper } from '$lib/internal/actions/index.js';
@@ -161,6 +162,12 @@ export function createMenubar(props?: CreateMenubarProps) {
 									floating: $positioning,
 									portal: getPortalDestination(node, $portal),
 									clickOutside: {
+										ignore: (e) => {
+											const target = e.target;
+											const menubarEl = document.getElementById(rootIds.menubar);
+											if (!menubarEl || !isElement(target)) return false;
+											return menubarEl.contains(target);
+										},
 										handler: () => {
 											activeMenu.set('');
 										},


### PR DESCRIPTION
We previously weren't ignoring the menubar triggers within the `clickOutside` handler for the `menu` elements, meaning that before the click event made it to the trigger, we were setting the `activeMenu` to `''` causing the trigger to think that there wasn't already a menu open.

This PR fixed that issue by ignoring the menubar element and its descendants for `clickOutside` handling.