### PR TITLE
[Table of Contents]: add mutation observer

### DIFF
--- a/.changeset/small-schools-bow.md
+++ b/.changeset/small-schools-bow.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': minor
+---
+
+add mutation observer to ToC to make it update when headings change and also return the original heading node within the headings list

--- a/src/docs/components/table-of-contents/table-of-contents.svelte
+++ b/src/docs/components/table-of-contents/table-of-contents.svelte
@@ -7,7 +7,10 @@
 	 * The filter function is for removing headings from the ToC
 	 * docs page where we have a preview with lots of headings.
 	 */
-	const { activeHeadingIdxs, headingsTree, item } = createTableOfContents({
+	const {
+		elements: { item },
+		states: { activeHeadingIdxs, headingsTree },
+	} = createTableOfContents({
 		selector: '#mdsvex',
 		exclude: ['h1', 'h4', 'h5', 'h6'],
 		activeType: 'all',

--- a/src/docs/components/table-of-contents/tree.svelte
+++ b/src/docs/components/table-of-contents/tree.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import type { TableOfContentsItem, CreateTableOfContentsReturn } from '$lib';
+	import type { TableOfContentsItem, TableOfContentsElements } from '$lib';
 
 	export let tree: TableOfContentsItem[] = [];
 	export let activeHeadingIdxs: number[];
-	export let item: CreateTableOfContentsReturn['item'];
+	export let item: TableOfContentsElements['item'];
 	export let level = 1;
 </script>
 

--- a/src/docs/previews/table-of-contents/main/tailwind/index.svelte
+++ b/src/docs/previews/table-of-contents/main/tailwind/index.svelte
@@ -3,7 +3,10 @@
 	import Tree from './tree.svelte';
 	import { createTableOfContents } from '$lib';
 
-	const { activeHeadingIdxs, headingsTree, item } = createTableOfContents({
+	const {
+		elements: { item },
+		states: { activeHeadingIdxs, headingsTree },
+	} = createTableOfContents({
 		selector: '#toc-builder-preview',
 		exclude: ['h1', 'h4', 'h5', 'h6'],
 		activeType: 'lowest-parents',

--- a/src/docs/previews/table-of-contents/main/tailwind/index.svelte
+++ b/src/docs/previews/table-of-contents/main/tailwind/index.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { Bird } from 'lucide-svelte';
 	import Tree from './tree.svelte';
 	import { createTableOfContents } from '$lib';
 
@@ -26,6 +27,8 @@
 			}
 		},
 	});
+
+	let hideHeading = false;
 </script>
 
 <div
@@ -35,15 +38,30 @@
 		id="toc-builder-preview"
 		class="space-y-2 overflow-y-auto rounded-lg bg-white p-4 text-neutral-900"
 	>
-		<h2>First Heading</h2>
-		<p>This is the first heading.</p>
-		<h3>Sub-Heading</h3>
-		<p>This is a sub-heading H3 example.</p>
+		<button
+			on:click={() => (hideHeading = !hideHeading)}
+			class="border-1 rounded-md border-magnum-500 bg-magnum-500/70 px-2 py-1 hover:bg-magnum-500"
+		>
+			{hideHeading ? 'Show heading' : 'Hide heading'}
+		</button>
+
+		{#if !hideHeading}
+			<h2>First Heading</h2>
+			<p>This is the first heading.</p>
+
+			<h3>Sub-Heading</h3>
+			<p>This is a sub-heading H3 example.</p>
+		{/if}
 		<h4>This H4 is excluded</h4>
 		<p>
 			H4 headings were added to the list of excluded heading tags, so this will
 			not show up in the table of contents.
 		</p>
+		<h2 class="inline-flex items-center justify-center gap-2">
+			<Bird />
+			Icon heading
+		</h2>
+		<p>Here we have a heading with an icon.</p>
 		<h2 data-toc-ignore>This H2 gets ignored</h2>
 		<p>
 			You can adjust the filter function to show or hide headings based on
@@ -78,11 +96,13 @@
 	<div class="overflow-y-auto rounded-lg bg-white p-4">
 		<p class="font-semibold text-neutral-900">On This Page</p>
 		<nav>
-			<Tree
-				tree={$headingsTree}
-				activeHeadingIdxs={$activeHeadingIdxs}
-				{item}
-			/>
+			{#key $headingsTree}
+				<Tree
+					tree={$headingsTree}
+					activeHeadingIdxs={$activeHeadingIdxs}
+					{item}
+				/>
+			{/key}
 		</nav>
 	</div>
 </div>

--- a/src/docs/previews/table-of-contents/main/tailwind/tree.svelte
+++ b/src/docs/previews/table-of-contents/main/tailwind/tree.svelte
@@ -18,9 +18,16 @@
 				<a
 					href="#{heading.id}"
 					use:melt={$item(heading.id)}
-					class="inline-block text-neutral-500 no-underline transition-colors
+					class="inline-flex items-center justify-center gap-1 text-neutral-500 no-underline transition-colors
 					 hover:!text-magnum-600 data-[active]:text-magnum-700"
 				>
+					<!--
+						The original heading node is also passed down,
+						so you can display headings however you want.
+					-->
+					{#if heading.node.children?.length > 0}
+						{@html heading.node.children[0].outerHTML}
+					{/if}
 					{heading.title}
 				</a>
 				{#if heading.children && heading.children.length}

--- a/src/docs/previews/table-of-contents/main/tailwind/tree.svelte
+++ b/src/docs/previews/table-of-contents/main/tailwind/tree.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 	import {
 		type TableOfContentsItem,
-		type CreateTableOfContentsReturn,
+		type TableOfContentsElements,
 		melt,
 	} from '$lib';
 
 	export let tree: TableOfContentsItem[] = [];
 	export let activeHeadingIdxs: number[];
-	export let item: CreateTableOfContentsReturn['item'];
+	export let item: TableOfContentsElements['item'];
 	export let level = 1;
 </script>
 

--- a/src/docs/previews/table-of-contents/main/tailwind/tree.svelte
+++ b/src/docs/previews/table-of-contents/main/tailwind/tree.svelte
@@ -22,13 +22,11 @@
 					 hover:!text-magnum-600 data-[active]:text-magnum-700"
 				>
 					<!--
-						The original heading node is also passed down,
-						so you can display headings however you want.
+						Along with the heading title, the original heading node 
+						is also passed down, so you can display headings 
+						however you want.
 					-->
-					{#if heading.node.children?.length > 0}
-						{@html heading.node.children[0].outerHTML}
-					{/if}
-					{heading.title}
+					{@html heading.node.innerHTML}
 				</a>
 				{#if heading.children && heading.children.length}
 					<svelte:self

--- a/src/lib/builders/table-of-contents/create.ts
+++ b/src/lib/builders/table-of-contents/create.ts
@@ -387,8 +387,12 @@ export function createTableOfContents(args: CreateTableOfContentsArgs) {
 	});
 
 	return {
-		activeHeadingIdxs,
-		headingsTree,
-		item,
+		elements: {
+			item
+		},
+		states: {
+			activeHeadingIdxs,
+			headingsTree
+		}
 	};
 }

--- a/src/lib/builders/table-of-contents/create.ts
+++ b/src/lib/builders/table-of-contents/create.ts
@@ -121,7 +121,6 @@ export function createTableOfContents(args: CreateTableOfContentsArgs) {
 
 		const includedHeadings = possibleHeadings.filter((h) => !exclude.includes(h));
 
-		// const elementTarget = document.querySelector(selector);
 		const targetHeaders: NodeListOf<HTMLHeadingElement> | undefined =
 			elementTarget?.querySelectorAll(includedHeadings.join(', '));
 

--- a/src/lib/builders/table-of-contents/create.ts
+++ b/src/lib/builders/table-of-contents/create.ts
@@ -378,7 +378,7 @@ export function createTableOfContents(args: CreateTableOfContentsArgs) {
 		initialization();
 
 		mutationObserver = new MutationObserver(mutationHandler);
-		mutationObserver.observe(elementTarget, { childList: true })
+		mutationObserver.observe(elementTarget, { childList: true, subtree: true })
 
 		return () => {
 			observer?.disconnect();

--- a/src/lib/builders/table-of-contents/types.ts
+++ b/src/lib/builders/table-of-contents/types.ts
@@ -54,4 +54,6 @@ export type TableOfContentsItem = {
 	children?: TableOfContentsItem[];
 };
 
-export type CreateTableOfContentsReturn = ReturnType<typeof createTableOfContents>;
+export type TableOfContents = ReturnType<typeof createTableOfContents>;
+export type TableOfContentsElements = TableOfContents['elements'];
+export type TableOfContentsStates = TableOfContents['states'];

--- a/src/lib/builders/table-of-contents/types.ts
+++ b/src/lib/builders/table-of-contents/types.ts
@@ -50,6 +50,7 @@ export type TableOfContentsItem = {
 	title: string;
 	index: number;
 	id: string;
+	node: HTMLHeadingElement,
 	children?: TableOfContentsItem[];
 };
 


### PR DESCRIPTION
**Changes:**
- add a mutation observer that checks if new headings were added or removed and updates the headings list if yes
- add the original heading node to the list of returned items so people have more control over how headings are displayed in the ToC
- update returns of builder function to match current structure
- update types

Addresses the following issues:
- Closes #476 
- Closes #450