### PR TITLE
fix: ensure type safety for `disabled` prop

### DIFF
--- a/src/lib/builders/accordion/create.ts
+++ b/src/lib/builders/accordion/create.ts
@@ -100,7 +100,7 @@ export const createAccordion = <Multiple extends boolean = false>(
 				// generate the content ID here so that we can grab it in the content
 				// builder action to ensure the values match.
 				return {
-					disabled: $disabled || disabled,
+					disabled: ($disabled || disabled) ?? undefined,
 					'aria-expanded': isSelected(itemValue, $value) ? true : false,
 					'aria-disabled': disabled ? true : false,
 					'data-disabled': disabled ? true : undefined,

--- a/src/lib/builders/checkbox/create.ts
+++ b/src/lib/builders/checkbox/create.ts
@@ -78,7 +78,7 @@ export function createCheckbox(props?: CreateCheckboxProps) {
 				value: $value,
 				checked: $checked === 'indeterminate' ? false : $checked,
 				required: $required,
-				disabled: $disabled,
+				disabled: $disabled ?? undefined,
 				style: styleToString({
 					position: 'absolute',
 					opacity: 0,

--- a/src/lib/builders/collapsible/create.ts
+++ b/src/lib/builders/collapsible/create.ts
@@ -43,7 +43,7 @@ export function createCollapsible(props?: CreateCollapsibleProps) {
 			({
 				'data-state': $open ? 'open' : 'closed',
 				'data-disabled': $disabled ? '' : undefined,
-				disabled: $disabled,
+				disabled: $disabled ?? undefined,
 			} as const),
 		action: (node: HTMLElement): MeltActionReturn<CollapsibleEvents['trigger']> => {
 			const unsub = addMeltEventListener(node, 'click', () => {

--- a/src/lib/builders/pin-input/create.ts
+++ b/src/lib/builders/pin-input/create.ts
@@ -92,7 +92,7 @@ export function createPinInput(props?: CreatePinInputProps) {
 				return {
 					'data-complete': $value.length && $value.every((v) => v.length > 0) ? '' : undefined,
 					placeholder: $placeholder,
-					disabled: $disabled,
+					disabled: $disabled ?? undefined,
 					type: $type,
 					value: currValue,
 				};

--- a/src/lib/builders/radio-group/create.ts
+++ b/src/lib/builders/radio-group/create.ts
@@ -179,7 +179,7 @@ export function createRadioGroup(props?: CreateRadioGroupProps) {
 			return {
 				'aria-hidden': true,
 				tabindex: -1,
-				disabled: $disabled,
+				disabled: $disabled ?? undefined,
 				value: $value,
 				required: $required,
 				style: styleToString({

--- a/src/lib/builders/select/create.ts
+++ b/src/lib/builders/select/create.ts
@@ -383,7 +383,7 @@ export function createSelect<
 				'data-state': $open ? 'open' : 'closed',
 				'data-disabled': $disabled ? true : undefined,
 				'aria-labelledby': ids.label,
-				disabled: $disabled,
+				disabled: $disabled ?? undefined,
 				id: ids.trigger,
 				tabindex: 0,
 			} as const;
@@ -659,7 +659,7 @@ export function createSelect<
 				hidden: true,
 				tabIndex: -1,
 				required: $required,
-				disabled: $disabled,
+				disabled: $disabled ?? undefined,
 				style: styleToString({
 					position: 'absolute',
 					opacity: 0,

--- a/src/lib/builders/slider/create.ts
+++ b/src/lib/builders/slider/create.ts
@@ -53,7 +53,7 @@ export const createSlider = (props?: CreateSliderProps) => {
 		stores: [disabled, orientation],
 		returned: ([$disabled, $orientation]) => {
 			return {
-				disabled: $disabled,
+				disabled: $disabled ?? undefined,
 				'data-orientation': $orientation,
 				style: $disabled ? undefined : 'touch-action: none;',
 				'data-melt-id': ids.root,

--- a/src/lib/builders/switch/create.ts
+++ b/src/lib/builders/switch/create.ts
@@ -43,7 +43,7 @@ export function createSwitch(props?: CreateSwitchProps) {
 		returned: ([$checked, $disabled, $required]) => {
 			return {
 				'data-disabled': $disabled,
-				disabled: $disabled,
+				disabled: $disabled ?? undefined,
 				'data-state': $checked ? 'checked' : 'unchecked',
 				type: 'button',
 				role: 'switch',
@@ -81,7 +81,7 @@ export function createSwitch(props?: CreateSwitchProps) {
 				value: $value,
 				checked: $checked,
 				required: $required,
-				disabled: $disabled,
+				disabled: $disabled ?? undefined,
 				style: styleToString({
 					position: 'absolute',
 					opacity: 0,

--- a/src/lib/builders/tags-input/create.ts
+++ b/src/lib/builders/tags-input/create.ts
@@ -233,7 +233,7 @@ export function createTagsInput(props?: CreateTagsInputProps) {
 			return {
 				'data-melt-id': ids.root,
 				'data-disabled': $disabled ? true : undefined,
-				disabled: $disabled,
+				disabled: $disabled ?? undefined,
 			} as const;
 		},
 		action: (node: HTMLElement): MeltActionReturn<TagsInputEvents['root']> => {
@@ -261,7 +261,7 @@ export function createTagsInput(props?: CreateTagsInputProps) {
 			return {
 				'data-melt-id': ids.input,
 				'data-disabled': $disabled ? '' : undefined,
-				disabled: $disabled,
+				disabled: $disabled ?? undefined,
 				placeholder: $placeholder,
 			};
 		},

--- a/src/lib/builders/toggle/create.ts
+++ b/src/lib/builders/toggle/create.ts
@@ -37,7 +37,7 @@ export function createToggle(props?: CreateToggleProps) {
 		returned: ([$pressed, $disabled]) => {
 			return {
 				'data-disabled': $disabled ? true : undefined,
-				disabled: $disabled,
+				disabled: $disabled ?? undefined,
 				'data-state': $pressed ? 'on' : 'off',
 				'aria-pressed': $pressed,
 				type: 'button',


### PR DESCRIPTION
I'm wondering whether it makes more sense to do the following instead, since I've seen `data-disabled="undefined"` sometimes:

```diff
{
-    disabled: $disabled ?? undefined,
+    ...($disabled ? { disabled: true } : {}),
}
```