### PR TITLE
Feat: Focus first empty input on pininput focus

### DIFF
--- a/.changeset/proud-squids-sell.md
+++ b/.changeset/proud-squids-sell.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+Feat: Focus first empty input on pin input focus

--- a/src/lib/builders/pin-input/create.ts
+++ b/src/lib/builders/pin-input/create.ts
@@ -209,6 +209,15 @@ export function createPinInput(props?: CreatePinInputProps) {
 					value.set(inputs.map((input) => input.value.slice(-1) ?? undefined));
 				}),
 				addMeltEventListener(node, 'focus', () => {
+					const { inputs, elIndex } = getInputs(node);
+					if (elIndex && inputs) {
+						const prevEl = prev(inputs, elIndex, false);
+						if (prevEl.value === '') {
+							prevEl.focus();
+							return;
+						}
+					}
+
 					node.setSelectionRange(1, 1);
 					node.placeholder = '';
 					tick().then(() => {


### PR DESCRIPTION
Closes: #488

When focusing on an individual input within a pin input, we'll check to see if the previous input's value is empty. If so, we focus on the previous input and do so until we find the first input in the pin input with a value, or focus all the way back to the first input.