### PR TITLE
chore(package.json): add 'repository' property to `package.json`

### DIFF
--- a/.changeset/forty-weeks-bow.md
+++ b/.changeset/forty-weeks-bow.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+chore(package.json): add 'repository' property to `package.json`

--- a/package.json
+++ b/package.json
@@ -2,9 +2,7 @@
 	"name": "@melt-ui/svelte",
 	"version": "0.47.5",
 	"license": "MIT",
-	"repository": {
-		"url": "github:melt-ui/melt-ui"
-	},
+	"repository": "github:melt-ui/melt-ui",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build && npm run package",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
 	"name": "@melt-ui/svelte",
 	"version": "0.47.5",
 	"license": "MIT",
+	"repository": {
+		"url": "github:melt-ui/melt-ui"
+	},
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build && npm run package",


### PR DESCRIPTION
# 📖 Description
Add `repository` property to `package.json`

## 🔖 Resources
https://docs.npmjs.com/cli/v10/configuring-npm/package-json#repository

# 📚 Context
The Renovate bot is not capturing release notes of Melt UI (even they are present in https://github.com/melt-ui/melt-ui/releases). This change will collaterally fix that issue.

You can read more details here: https://github.com/renovatebot/renovate/discussions/24304#discussioncomment-6944256
