### PR TITLE
tooltip builder `disableHoverableContent` option

### DIFF
--- a/.changeset/shaggy-fans-cheer.md
+++ b/.changeset/shaggy-fans-cheer.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": minor
+---
+
+Tooltip: Add `disableHoverableContent` prop

--- a/src/docs/data/builders/tooltip.ts
+++ b/src/docs/data/builders/tooltip.ts
@@ -31,6 +31,12 @@ const OPTION_PROPS = [
 		default: '500',
 		description: 'The delay in milliseconds before the tooltip closes after a pointer leave event.',
 	},
+	{
+		name: 'disableHoverableContent',
+		type: 'boolean',
+		default: 'false',
+		description: 'Prevents the tooltip content element from remaining open when hovered. If `true`, the tooltip will only be open when hovering the trigger element.'
+	}
 ];
 
 const BUILDER_NAME = 'tooltip';

--- a/src/lib/builders/tooltip/create.ts
+++ b/src/lib/builders/tooltip/create.ts
@@ -39,6 +39,7 @@ const defaults = {
 	forceVisible: false,
 	portal: 'body',
 	closeOnEscape: true,
+	disableHoverableContent: false,
 } satisfies CreateTooltipProps;
 
 type TooltipParts = 'trigger' | 'content' | 'arrow';
@@ -57,6 +58,7 @@ export function createTooltip(props?: CreateTooltipProps) {
 		forceVisible,
 		portal,
 		closeOnEscape,
+		disableHoverableContent,
 	} = options;
 
 	const openWritable = withDefaults.open ?? writable(withDefaults.defaultOpen);
@@ -244,8 +246,9 @@ export function createTooltip(props?: CreateTooltipProps) {
 			addEventListener(document, 'mousemove', (e) => {
 				const contentEl = document.getElementById(ids.content);
 				if (!contentEl) return;
-
-				const polygon = makeHullFromElements([$activeTrigger, contentEl]);
+				
+				const polygonElements = get(disableHoverableContent) ? [$activeTrigger] : [$activeTrigger, contentEl];
+				const polygon = makeHullFromElements(polygonElements);
 
 				isMouseInTooltipArea = pointInPolygon(
 					{

--- a/src/lib/builders/tooltip/types.ts
+++ b/src/lib/builders/tooltip/types.ts
@@ -15,6 +15,7 @@ export type CreateTooltipProps = {
 	closeDelay?: number;
 	forceVisible?: boolean;
 	closeOnEscape?: boolean;
+	disableHoverableContent?: boolean;
 	/**
 	 * If not undefined, the tooltip will be rendered within the provided element or selector.
 	 *


### PR DESCRIPTION
This PR adds `disableHoverableContent` as an option to the tooltip builder function. The behavior is consistent with same option in Radix and the implementation simply removes the content element from the polygon used for isMouseInTooltipArea. 

Default for the option is false, same as current behavior. I experimented with the docs example and the change works but I haven't implemented any rigorous testing. 

I also updated the documentation for the tooltip builder to reflect the new option.