### PR TITLE
tests/slider changes

### DIFF
--- a/src/tests/slider/Slider.spec.ts
+++ b/src/tests/slider/Slider.spec.ts
@@ -527,3 +527,42 @@ describe('Slider (value=[3,6], min=0, max=10, step=3)', () => {
 		}
 	});
 });
+
+describe('Slider changing options after building', () => {
+	const props = {
+		value: [5],
+		min: 0,
+		max: 10,
+		step: 1,
+	};
+
+	test('Changing min', async () => {
+		const { getAllByTestId, rerender } = render(Slider, props);
+
+		expect(getAllByTestId('tick')).toHaveLength(11);
+
+		await rerender({ ...props, resetMin: 2 });
+
+		expect(getAllByTestId('tick')).toHaveLength(9);
+	});
+
+	test('Changing max', async () => {
+		const { getAllByTestId, rerender } = render(Slider, props);
+
+		expect(getAllByTestId('tick')).toHaveLength(11);
+
+		await rerender({ ...props, resetMax: 8 });
+
+		expect(getAllByTestId('tick')).toHaveLength(9);
+	});
+
+	test('Changing step', async () => {
+		const { getAllByTestId, rerender } = render(Slider, props);
+
+		expect(getAllByTestId('tick')).toHaveLength(11);
+
+		await rerender({ ...props, resetStep: 2 });
+
+		expect(getAllByTestId('tick')).toHaveLength(6);
+	});
+});

--- a/src/tests/slider/Slider.svelte
+++ b/src/tests/slider/Slider.svelte
@@ -4,15 +4,32 @@
 	export let max = 100;
 	export let min = 0;
 	export let step = 1;
+	export let resetMin: number | undefined;
+	export let resetMax: number | undefined;
+	export let resetStep: number | undefined;
+
 	const {
 		elements: { root, range, thumb, tick },
-		states: { ticks }
+		states: { ticks },
+		options: { min: optionsMin, max: optionsMax, step: optionsStep },
 	} = createSlider({
 		defaultValue: value,
 		max,
 		min,
 		step,
 	});
+
+	$: {
+		if (resetMin) {
+			$optionsMin = resetMin;
+		}
+		if (resetMax) {
+			$optionsMax = resetMax;
+		}
+		if (resetStep) {
+			$optionsStep = resetStep;
+		}
+	}
 </script>
 
 <main>


### PR DESCRIPTION
 Adds a slider options resetting test and the necessary props to Slider.svelte, proving that it was our application that was wrong and not melt-ui 🫠