### PR TITLE
fix: select controlled store type

### DIFF
--- a/.changeset/serious-avocados-cry.md
+++ b/.changeset/serious-avocados-cry.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+Select: Fix `selected` prop type

--- a/src/lib/builders/select/types.ts
+++ b/src/lib/builders/select/types.ts
@@ -134,7 +134,7 @@ export type CreateSelectProps<
 	/**
 	 * An optional controlled store that manages the value state of the combobox.
 	 */
-	selected?: Writable<S>;
+	selected?: Writable<S | undefined>;
 
 	/**
 	 * A change handler for the value store called when the value would normally change.


### PR DESCRIPTION
The default value of the store can be undefined.