### PR TITLE
Up key should focus last menu item if there is no selection

### DIFF
--- a/.changeset/tricky-plums-speak.md
+++ b/.changeset/tricky-plums-speak.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+Dropdown Menu: Up key focuses last menu item if there is no selection

--- a/src/lib/builders/menu/create.ts
+++ b/src/lib/builders/menu/create.ts
@@ -1443,7 +1443,7 @@ export function handleMenuNavigation(e: KeyboardEvent) {
 			nextIndex = currentIndex < candidateNodes.length - 1 ? currentIndex + 1 : currentIndex;
 			break;
 		case kbd.ARROW_UP:
-			nextIndex = currentIndex > 0 ? currentIndex - 1 : 0;
+			nextIndex = currentIndex < 0 ? candidateNodes.length - 1 : currentIndex > 0 ? currentIndex - 1 : 0;
 			break;
 		case kbd.HOME:
 			nextIndex = 0;


### PR DESCRIPTION
When a menu such as `DropDownMenu` is opened there is initially no focussed item, which is expected.

Current behaviour is that when either the down or up arrow key are pressed, the first item is always highlighted. To my mind, down should focus the first item, while up should focus the last. This matches the current behaviour of the ComboBox component.

This PR implements what I think should be the expected behaviour.