### PR TITLE
fix: JSDoc for melt action

### DIFF
--- a/.changeset/pretty-numbers-remain.md
+++ b/.changeset/pretty-numbers-remain.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+fix: change JSDoc example for `melt` action

--- a/src/lib/internal/actions/melt/index.ts
+++ b/src/lib/internal/actions/melt/index.ts
@@ -19,10 +19,11 @@ type GetActionAttributes<Builder> = Builder extends Record<string, any> & {
  * @example
  * ```svelte
  * <script>
- * 	const { builder, melt } = createBuilder();
+ * 	import { createBuilder, melt } from '@melt-ui/svelte';
+ * 	const { elements: { root } } = createLabel();
  * </script>
  *
- * <div use:melt={$builder} />
+ * <label use:melt={$root} />
  * ```
  */
 export function melt<

--- a/src/lib/internal/actions/melt/index.ts
+++ b/src/lib/internal/actions/melt/index.ts
@@ -19,7 +19,7 @@ type GetActionAttributes<Builder> = Builder extends Record<string, any> & {
  * @example
  * ```svelte
  * <script>
- * 	import { createBuilder, melt } from '@melt-ui/svelte';
+ * 	import { createLabel, melt } from '@melt-ui/svelte';
  * 	const { elements: { root } } = createLabel();
  * </script>
  *


### PR DESCRIPTION
# Fixes issue:  
- Issue: #568 
- Correct the JSDoc for melt action import in the file located at ```src/lib/internal/actions/melt/index.ts```


## Previous JSDoc:
```
/**
 * A special action for Melt UI's preprocessor `@melt-ui/pp`.
 *
 * @see https://www.melt-ui.com/docs/preprocessor
 *
 * @example
 * ```svelte
 * <script>
 * 	const { builder, melt } = createBuilder();
 * </script>
 *
 * <div use:melt={$builder} />
 * ```
 */
```

## JSDoc after updation:
```
/**
 * A special action for Melt UI's preprocessor `@melt-ui/pp`.
 *
 * @see https://www.melt-ui.com/docs/preprocessor
 *
 * @example
 * ```svelte
 * <script>
 * 	import { createLabel, melt } from '@melt-ui/svelte';
 * 	const { elements: { root } } = createLabel();
 * </script>
 *
 * <label use:melt={$root} />
 * ```
 */
```

<br>
<br>

# Total changes made: 3