### PR TITLE
Add generics to exported types

### DIFF
--- a/.changeset/two-shrimps-notice.md
+++ b/.changeset/two-shrimps-notice.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+fix: add generics to exported types

--- a/src/lib/builders/accordion/types.ts
+++ b/src/lib/builders/accordion/types.ts
@@ -65,7 +65,6 @@ export type AccordionHeadingProps =
 	  }
 	| number;
 
-// export type Accordion = BuilderReturn<typeof createAccordion>;
 export type Accordion<Multiple extends boolean = false> = BuilderReturn<
 	typeof createAccordion<Multiple>
 >;

--- a/src/lib/builders/accordion/types.ts
+++ b/src/lib/builders/accordion/types.ts
@@ -65,8 +65,19 @@ export type AccordionHeadingProps =
 	  }
 	| number;
 
-export type Accordion = BuilderReturn<typeof createAccordion>;
-export type AccordionElements = Accordion['elements'];
-export type AccordionOptions = Accordion['options'];
-export type AccordionStates = Accordion['states'];
-export type AccordionHelpers = Accordion['helpers'];
+// export type Accordion = BuilderReturn<typeof createAccordion>;
+export type Accordion<Multiple extends boolean = false> = BuilderReturn<
+	typeof createAccordion<Multiple>
+>;
+export type AccordionElements<Multiple extends boolean = false> = BuilderReturn<
+	typeof createAccordion<Multiple>
+>['elements'];
+export type AccordionOptions<Multiple extends boolean = false> = BuilderReturn<
+	typeof createAccordion<Multiple>
+>['options'];
+export type AccordionStates<Multiple extends boolean = false> = BuilderReturn<
+	typeof createAccordion<Multiple>
+>['states'];
+export type AccordionHelpers<Multiple extends boolean = false> = BuilderReturn<
+	typeof createAccordion<Multiple>
+>['helpers'];

--- a/src/lib/builders/combobox/types.ts
+++ b/src/lib/builders/combobox/types.ts
@@ -19,7 +19,6 @@ export type ComboboxSelected<Multiple extends boolean, Value> = WhenTrue<
 export type CreateComboboxProps<
 	Value,
 	Multiple extends boolean = false,
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	S extends ComboboxSelected<Multiple, Value> = ComboboxSelected<Multiple, Value>
 > = {
 	/**
@@ -140,34 +139,29 @@ export type ComboboxItemProps<Value> = ComboboxOption<Value> & {
 export type Combobox<
 	Value = unknown,
 	Multiple extends boolean = false,
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	S extends ComboboxSelected<Multiple, Value> = ComboboxSelected<Multiple, Value>
 > = BuilderReturn<typeof createCombobox<Value, Multiple, S>>;
 
 export type ComboboxElements<
 	Value = unknown,
 	Multiple extends boolean = false,
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	S extends ComboboxSelected<Multiple, Value> = ComboboxSelected<Multiple, Value>
 > = Combobox<Value, Multiple, S>['elements'];
 
 export type ComboboxOptions<
 	Value = unknown,
 	Multiple extends boolean = false,
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	S extends ComboboxSelected<Multiple, Value> = ComboboxSelected<Multiple, Value>
 > = Combobox<Value, Multiple, S>['options'];
 
 export type ComboboxStates<
 	Value = unknown,
 	Multiple extends boolean = false,
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	S extends ComboboxSelected<Multiple, Value> = ComboboxSelected<Multiple, Value>
 > = Combobox<Value, Multiple, S>['states'];
 
 export type ComboboxHelpers<
 	Value = unknown,
 	Multiple extends boolean = false,
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	S extends ComboboxSelected<Multiple, Value> = ComboboxSelected<Multiple, Value>
 > = Combobox<Value, Multiple, S>['helpers'];

--- a/src/lib/builders/select/types.ts
+++ b/src/lib/builders/select/types.ts
@@ -150,8 +150,33 @@ export type SelectOptionProps<Value = unknown> = SelectOption<Value> & {
 	disabled?: boolean;
 };
 
-export type Select = BuilderReturn<typeof createSelect>;
-export type SelectElements = Select['elements'];
-export type SelectOptions = Select['options'];
-export type SelectStates = Select['states'];
-export type SelectHelpers = Select['helpers'];
+export type Select<
+	Value = unknown,
+	Multiple extends boolean = false,
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	S extends SelectSelected<Multiple, Value> = SelectSelected<Multiple, Value>
+> = BuilderReturn<typeof createSelect<Value, Multiple, S>>;
+export type SelectElements<
+	Value = unknown,
+	Multiple extends boolean = false,
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	S extends SelectSelected<Multiple, Value> = SelectSelected<Multiple, Value>
+> = BuilderReturn<typeof createSelect<Value, Multiple, S>>['elements'];
+export type SelectOptions<
+	Value = unknown,
+	Multiple extends boolean = false,
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	S extends SelectSelected<Multiple, Value> = SelectSelected<Multiple, Value>
+> = BuilderReturn<typeof createSelect<Value, Multiple, S>>['options'];
+export type SelectStates<
+	Value = unknown,
+	Multiple extends boolean = false,
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	S extends SelectSelected<Multiple, Value> = SelectSelected<Multiple, Value>
+> = BuilderReturn<typeof createSelect<Value, Multiple, S>>['states'];
+export type SelectHelpers<
+	Value = unknown,
+	Multiple extends boolean = false,
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	S extends SelectSelected<Multiple, Value> = SelectSelected<Multiple, Value>
+> = BuilderReturn<typeof createSelect<Value, Multiple, S>>['helpers'];

--- a/src/lib/builders/select/types.ts
+++ b/src/lib/builders/select/types.ts
@@ -20,7 +20,6 @@ export type SelectSelected<Multiple extends boolean, Value> = WhenTrue<
 export type CreateSelectProps<
 	Value = unknown,
 	Multiple extends boolean = false,
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	S extends SelectSelected<Multiple, Value> = SelectSelected<Multiple, Value>
 > = {
 	/**
@@ -153,30 +152,25 @@ export type SelectOptionProps<Value = unknown> = SelectOption<Value> & {
 export type Select<
 	Value = unknown,
 	Multiple extends boolean = false,
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	S extends SelectSelected<Multiple, Value> = SelectSelected<Multiple, Value>
 > = BuilderReturn<typeof createSelect<Value, Multiple, S>>;
 export type SelectElements<
 	Value = unknown,
 	Multiple extends boolean = false,
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	S extends SelectSelected<Multiple, Value> = SelectSelected<Multiple, Value>
 > = BuilderReturn<typeof createSelect<Value, Multiple, S>>['elements'];
 export type SelectOptions<
 	Value = unknown,
 	Multiple extends boolean = false,
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	S extends SelectSelected<Multiple, Value> = SelectSelected<Multiple, Value>
 > = BuilderReturn<typeof createSelect<Value, Multiple, S>>['options'];
 export type SelectStates<
 	Value = unknown,
 	Multiple extends boolean = false,
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	S extends SelectSelected<Multiple, Value> = SelectSelected<Multiple, Value>
 > = BuilderReturn<typeof createSelect<Value, Multiple, S>>['states'];
 export type SelectHelpers<
 	Value = unknown,
 	Multiple extends boolean = false,
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	S extends SelectSelected<Multiple, Value> = SelectSelected<Multiple, Value>
 > = BuilderReturn<typeof createSelect<Value, Multiple, S>>['helpers'];

--- a/src/lib/builders/toast/types.ts
+++ b/src/lib/builders/toast/types.ts
@@ -31,8 +31,8 @@ export type Toast<T = object> = {
 	getPercentage: () => number;
 };
 
-export type Toasts = BuilderReturn<typeof createToaster>;
-export type ToastsElements = Toasts['elements'];
-export type ToastsOptions = Toasts['options'];
-export type ToastsStates = Toasts['states'];
-export type ToastsHelpers = Toasts['helpers'];
+export type Toasts<T = object> = BuilderReturn<typeof createToaster<T>>;
+export type ToastsElements<T = object> = BuilderReturn<typeof createToaster<T>>['elements'];
+export type ToastsOptions<T = object> = BuilderReturn<typeof createToaster<T>>['options'];
+export type ToastsStates<T = object> = BuilderReturn<typeof createToaster<T>>['states'];
+export type ToastsHelpers<T = object> = BuilderReturn<typeof createToaster<T>>['helpers'];

--- a/src/lib/builders/toggle-group/types.ts
+++ b/src/lib/builders/toggle-group/types.ts
@@ -23,8 +23,18 @@ export type ToggleGroupItemProps =
 	  }
 	| string;
 
-export type ToggleGroup = BuilderReturn<typeof createToggleGroup>;
-export type ToggleGroupElements = ToggleGroup['elements'];
-export type ToggleGroupOptions = ToggleGroup['options'];
-export type ToggleGroupStates = ToggleGroup['states'];
-export type ToggleGroupHelpers = ToggleGroup['helpers'];
+export type ToggleGroup<T extends ToggleGroupType = 'single'> = BuilderReturn<
+	typeof createToggleGroup<T>
+>;
+export type ToggleGroupElements<T extends ToggleGroupType = 'single'> = BuilderReturn<
+	typeof createToggleGroup<T>
+>['elements'];
+export type ToggleGroupOptions<T extends ToggleGroupType = 'single'> = BuilderReturn<
+	typeof createToggleGroup<T>
+>['options'];
+export type ToggleGroupStates<T extends ToggleGroupType = 'single'> = BuilderReturn<
+	typeof createToggleGroup<T>
+>['states'];
+export type ToggleGroupHelpers<T extends ToggleGroupType = 'single'> = BuilderReturn<
+	typeof createToggleGroup<T>
+>['helpers'];


### PR DESCRIPTION
Added generics to exported types for accordion, select, toast and toggle group.

Fixes #538 