### PR TITLE
fix: Dialog docs structure

### DIFF
--- a/src/docs/content/builders/dialog.md
+++ b/src/docs/content/builders/dialog.md
@@ -20,7 +20,18 @@ At a high level, the anatomy of a dialog looks like this:
 ```svelte
 <script lang="ts">
 	import { createDialog, melt } from '@melt-ui/svelte'
-	const { trigger, portal, overlay, content, title, description, close, open } = createDialog()
+	const { 
+		elements: {
+			trigger, 
+			portal, 
+			overlay, 
+			content, 
+			title, 
+			description, 
+			close, 
+			open,
+		},
+	} = createDialog();
 </script>
 
 <button use:melt={$trigger}> Open Dialog </button>
@@ -63,9 +74,16 @@ By default, we set the `role` attribute to `dialog`. If you want it to be consid
 dialog, you can set the `role` builder prop to `alertdialog`.
 
 ```ts {2}
-const { trigger, portal, overlay, content } = createDialog({
-	role: 'alertdialog'
-})
+const { 
+	elements: {
+		trigger, 
+		portal, 
+		overlay, 
+		content,
+		},
+	} = createDialog({
+	role: 'alertdialog',
+});
 ```
 
 ### Disable Scroll Prevention
@@ -74,9 +92,16 @@ By default, scrolling is prevented on the body when a dialog is open. You can di
 by setting the `preventScroll` builder prop to `false`.
 
 ```ts {2}
-const { trigger, portal, overlay, content } = createDialog({
-	preventScroll: false
-})
+const { 
+	elements: {
+		trigger, 
+		portal, 
+		overlay, 
+		content,
+		},
+	} = createDialog({
+	preventScroll: false,
+});
 ```
 
 ### Disable Close on Outside Click
@@ -85,9 +110,16 @@ By default, clicking outside of the dialog will close it. You can disable this b
 the `closeOnOutsideClick` builder prop to `false`.
 
 ```ts {2}
-const { trigger, portal, overlay, content } = createDialog({
-	closeOnOutsideClick: false
-})
+const { 
+	elements: {
+		trigger, 
+		portal, 
+		overlay, 
+		content,
+		},
+	} = createDialog({
+	closeOnOutsideClick: false,
+});
 ```
 
 ### Disable Close on Escape
@@ -96,9 +128,16 @@ By default, pressing the escape key will close the dialog. You can disable this 
 the `closeOnEscape` builder prop to `false`.
 
 ```ts {2}
-const { trigger, portal, overlay, content } = createDialog({
-	closeOnEscape: false
-})
+const { 
+	elements: {
+		trigger, 
+		portal, 
+		overlay, 
+		content,
+		},
+	} = createDialog({
+	closeOnEscape: false,
+});
 ```
 
 ## Example Components

--- a/src/docs/content/builders/dialog.md
+++ b/src/docs/content/builders/dialog.md
@@ -49,7 +49,7 @@ At a high level, the anatomy of a dialog looks like this:
 ```
 
 - **Trigger**: The button(s) that open the dialog
-- **Portalled**: The container that is portalled to the body
+- **Portalled**: The container that is portalled (to `body`, by default)
 - **Overlay**: The dim background that is typically behind a dialog element.
 - **Content**: Container for the content within the dialog.
   - **Title**: The title of the dialog

--- a/src/docs/content/builders/dialog.md
+++ b/src/docs/content/builders/dialog.md
@@ -49,6 +49,7 @@ At a high level, the anatomy of a dialog looks like this:
 ```
 
 - **Trigger**: The button(s) that open the dialog
+- **Portalled**: The container that is portalled to the body
 - **Overlay**: The dim background that is typically behind a dialog element.
 - **Content**: Container for the content within the dialog.
   - **Title**: The title of the dialog

--- a/src/docs/content/builders/dialog.md
+++ b/src/docs/content/builders/dialog.md
@@ -74,14 +74,7 @@ By default, we set the `role` attribute to `dialog`. If you want it to be consid
 dialog, you can set the `role` builder prop to `alertdialog`.
 
 ```ts {2}
-const { 
-	elements: {
-		trigger, 
-		portal, 
-		overlay, 
-		content,
-		},
-	} = createDialog({
+const { /* ... */ } = createDialog({
 	role: 'alertdialog',
 });
 ```
@@ -92,14 +85,7 @@ By default, scrolling is prevented on the body when a dialog is open. You can di
 by setting the `preventScroll` builder prop to `false`.
 
 ```ts {2}
-const { 
-	elements: {
-		trigger, 
-		portal, 
-		overlay, 
-		content,
-		},
-	} = createDialog({
+const { /* ... */ } = createDialog({
 	preventScroll: false,
 });
 ```
@@ -110,14 +96,7 @@ By default, clicking outside of the dialog will close it. You can disable this b
 the `closeOnOutsideClick` builder prop to `false`.
 
 ```ts {2}
-const { 
-	elements: {
-		trigger, 
-		portal, 
-		overlay, 
-		content,
-		},
-	} = createDialog({
+const { /* ... */ } = createDialog({
 	closeOnOutsideClick: false,
 });
 ```
@@ -128,14 +107,7 @@ By default, pressing the escape key will close the dialog. You can disable this 
 the `closeOnEscape` builder prop to `false`.
 
 ```ts {2}
-const { 
-	elements: {
-		trigger, 
-		portal, 
-		overlay, 
-		content,
-		},
-	} = createDialog({
+const { /* ... */ } = createDialog({
 	closeOnEscape: false,
 });
 ```

--- a/src/docs/content/builders/dialog.md
+++ b/src/docs/content/builders/dialog.md
@@ -23,7 +23,7 @@ At a high level, the anatomy of a dialog looks like this:
 	const { 
 		elements: {
 			trigger, 
-			portal, 
+			portalled, 
 			overlay, 
 			content, 
 			title, 
@@ -148,7 +148,7 @@ Dialogs can be nested. For example, here's a dialog that opens another dialog.
 
 ## Accessibility
 
-Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog/) &
+Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/) &
 [Alert Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/)
 
 <KbdTable {keyboard} />

--- a/src/docs/content/controlled.md
+++ b/src/docs/content/controlled.md
@@ -46,16 +46,9 @@ interaction.
 	import { writable } from 'svelte/store'
 
 	const {
-		elements: { 
-			trigger, 
-			overlay, 
-			content, 
-			title, 
-			description, 
-			close,
-		},
-		states: { open },
-	} = createDialog();
+		elements: { trigger, overlay, content, title, description, close },
+		states: { open }
+	} = createDialog()
 
 	open.set(true)
 </script>
@@ -76,17 +69,10 @@ It's as simple as passing your own `open` store to the `createDialog` builder.
 	const customOpen = writable(false)
 
 	const {
-		elements: { 
-			trigger, 
-			overlay, 
-			content, 
-			title, 
-			description, 
-			close, 
-		},
+		elements: { trigger, overlay, content, title, description, close }
 	} = createDialog({
-		open: customOpen,
-	});
+		open: customOpen
+	})
 </script>
 ```
 
@@ -133,17 +119,10 @@ store from being set to `true` based on some arbitrary condition.
 	}
 
 	const {
-		elements: { 
-			trigger, 
-			overlay, 
-			content, 
-			title, 
-			description, 
-			close,
-		},
+		elements: { trigger, overlay, content, title, description, close }
 	} = createDialog({
-		onOpenChange: handleOpen,
-	});
+		onOpenChange: handleOpen
+	})
 </script>
 ```
 

--- a/src/docs/content/controlled.md
+++ b/src/docs/content/controlled.md
@@ -46,9 +46,16 @@ interaction.
 	import { writable } from 'svelte/store'
 
 	const {
-		elements: { trigger, overlay, content, title, description, close },
-		states: { open }
-	} = createDialog()
+		elements: { 
+			trigger, 
+			overlay, 
+			content, 
+			title, 
+			description, 
+			close,
+		},
+		states: { open },
+	} = createDialog();
 
 	open.set(true)
 </script>
@@ -69,10 +76,17 @@ It's as simple as passing your own `open` store to the `createDialog` builder.
 	const customOpen = writable(false)
 
 	const {
-		elements: { trigger, overlay, content, title, description, close }
+		elements: { 
+			trigger, 
+			overlay, 
+			content, 
+			title, 
+			description, 
+			close, 
+		},
 	} = createDialog({
-		open: customOpen
-	})
+		open: customOpen,
+	});
 </script>
 ```
 
@@ -119,10 +133,17 @@ store from being set to `true` based on some arbitrary condition.
 	}
 
 	const {
-		elements: { trigger, overlay, content, title, description, close }
+		elements: { 
+			trigger, 
+			overlay, 
+			content, 
+			title, 
+			description, 
+			close,
+		},
 	} = createDialog({
-		onOpenChange: handleOpen
-	})
+		onOpenChange: handleOpen,
+	});
 </script>
 ```
 

--- a/src/docs/data/builders/dialog.ts
+++ b/src/docs/data/builders/dialog.ts
@@ -78,7 +78,7 @@ const portalled = elementSchema('portalled', {
 	dataAttributes: [
 		{
 			name: 'data-portal',
-			value: ATTRS.OPEN_CLOSED,
+			value: ATTRS.MELT('portalled'),
 		},
 		{
 			name: 'data-melt-dialog-portalled',

--- a/src/docs/data/builders/dialog.ts
+++ b/src/docs/data/builders/dialog.ts
@@ -73,6 +73,20 @@ const trigger = elementSchema('trigger', {
 	events: dialogEvents['trigger'],
 });
 
+const portalled = elementSchema('portalled', {
+	description: "The element that will be portalled (or moved) to a different location in the DOM based on the `portal` prop value.",
+	dataAttributes: [
+		{
+			name: 'data-portal',
+			value: ATTRS.OPEN_CLOSED,
+		},
+		{
+			name: 'data-melt-dialog-portalled',
+			value: ATTRS.MELT('portalled'),
+		}
+	],
+});	
+
 const overlay = elementSchema('overlay', {
 	description: 'The overlay element which covers the page when the dialog is open.',
 	dataAttributes: [
@@ -155,7 +169,7 @@ const keyboard: KeyboardSchema = [
 	},
 ];
 
-const schemas = [builder, trigger, overlay, content, close, title, description];
+const schemas = [builder, trigger, portalled, overlay, content, close, title, description];
 const features = [
 	'Fully managed focus',
 	'Can be controlled or uncontrolled',


### PR DESCRIPTION
# Fixes issue:
- Issue: https://github.com/melt-ui/melt-ui/issues/337
- Correct the Docs structure for ```createDialog()``` to get the uniformity between code and documentation
<br>

# Previous structure of the docs:
```
const { trigger, portal, overlay, content, title, description, close, open } = createDialog()
```


 # Changed structure for the docs:
```
const {
  elements: {
    trigger, 
    portal, 
    overlay, 
    content, 
    title, 
    description, 
    close, 
    open,
  },
} = createDialog();
```


# Updated files:
- **dialog.md** (src/docs/content/builders/dialog.md)
- **controlled.md** (src/docs/content/controlled.md)
