### PR TITLE
Add `aria-disabled` to slider root

### DIFF
--- a/.changeset/loud-bags-hug.md
+++ b/.changeset/loud-bags-hug.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+Slider: Add `aria-disabled` to root

--- a/src/lib/builders/slider/create.ts
+++ b/src/lib/builders/slider/create.ts
@@ -55,6 +55,7 @@ export const createSlider = (props?: CreateSliderProps) => {
 		returned: ([$disabled, $orientation]) => {
 			return {
 				disabled: disabledAttr($disabled),
+                'aria-disabled': $disabled ? 'true' : 'false',
 				'data-orientation': $orientation,
 				style: $disabled ? undefined : 'touch-action: none;',
 				'data-melt-id': ids.root,

--- a/src/lib/builders/slider/create.ts
+++ b/src/lib/builders/slider/create.ts
@@ -55,7 +55,7 @@ export const createSlider = (props?: CreateSliderProps) => {
 		returned: ([$disabled, $orientation]) => {
 			return {
 				disabled: disabledAttr($disabled),
-                'aria-disabled': $disabled ? 'true' : 'false',
+				'aria-disabled': $disabled ? 'true' : 'false',
 				'data-orientation': $orientation,
 				style: $disabled ? undefined : 'touch-action: none;',
 				'data-melt-id': ids.root,

--- a/src/lib/builders/slider/create.ts
+++ b/src/lib/builders/slider/create.ts
@@ -1,6 +1,7 @@
 import {
 	addEventListener,
 	addMeltEventListener,
+	ariaDisabledAttr,
 	builder,
 	createElHelpers,
 	disabledAttr,
@@ -55,7 +56,7 @@ export const createSlider = (props?: CreateSliderProps) => {
 		returned: ([$disabled, $orientation]) => {
 			return {
 				disabled: disabledAttr($disabled),
-				'aria-disabled': $disabled ? 'true' : 'false',
+				'aria-disabled': ariaDisabledAttr($disabled),
 				'data-orientation': $orientation,
 				style: $disabled ? undefined : 'touch-action: none;',
 				'data-melt-id': ids.root,

--- a/src/lib/internal/helpers/attr.ts
+++ b/src/lib/internal/helpers/attr.ts
@@ -1,3 +1,7 @@
 export function disabledAttr(disabled: boolean | undefined) {
 	return disabled ? true : undefined;
 }
+
+export function ariaDisabledAttr(disabled: boolean | undefined) {
+    return disabled ? 'true' : undefined;
+}

--- a/src/lib/internal/helpers/attr.ts
+++ b/src/lib/internal/helpers/attr.ts
@@ -3,5 +3,5 @@ export function disabledAttr(disabled: boolean | undefined) {
 }
 
 export function ariaDisabledAttr(disabled: boolean | undefined) {
-    return disabled ? 'true' : undefined;
+	return disabled ? 'true' : undefined;
 }


### PR DESCRIPTION
This PR adds an aria-disabled attributes to the Slider's root element.

PS: sorry for doing 2 PRs, the old branch got messed up, so I deleted it.