### PR TITLE
Fix bug with Tooltip `group` parameter

### DIFF
--- a/.changeset/fair-yaks-travel.md
+++ b/.changeset/fair-yaks-travel.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+Tooltip: Fix bug with `group` parameter

--- a/src/lib/builders/tooltip/create.ts
+++ b/src/lib/builders/tooltip/create.ts
@@ -258,18 +258,24 @@ export function createTooltip(props?: CreateTooltipProps) {
 	let isMouseInTooltipArea = false;
 
 	effect(open, ($open) => {
-		if (!$open) return;
+		const currentGroup = get(group);
+		if (currentGroup === undefined || currentGroup === false) {
+			return;
+		}
 
-		const groupValue = get(group);
-		if (groupValue === undefined || groupValue === false) {
+		if (!$open) {
+			if (groupMap.get(currentGroup) === open) {
+				// Tooltip is no longer open
+				groupMap.delete(currentGroup);
+			}
 			return;
 		}
 
 		// Close the currently open tooltip in the same group
 		// and set this tooltip as the open one.
-		const currentOpen = groupMap.get(groupValue);
+		const currentOpen = groupMap.get(currentGroup);
 		currentOpen?.set(false);
-		groupMap.set(groupValue, open);
+		groupMap.set(currentGroup, open);
 	});
 
 	effect([open, openReason], ([$open, $openReason]) => {

--- a/src/tests/tooltip/Tooltip.spec.ts
+++ b/src/tests/tooltip/Tooltip.spec.ts
@@ -199,16 +199,16 @@ describe('2 tooltips, group=undefined', () => {
 });
 
 describe('Single tooltip, group=true', () => {
-    test('Tooltip does not prevent itself from opening', async () => {
-        const open = writable(true);
-        render(Tooltip, {
-            open,
-            group: true
-        });
+	test('Tooltip does not prevent itself from opening', () => {
+		const open = writable(true);
+		render(Tooltip, {
+			open,
+			group: true,
+		});
 
-        open.set(false);
+		open.set(false);
 
-        open.set(true);
-        expect(get(open)).toBe(true);
-    })
-})
+		open.set(true);
+		expect(get(open)).toBe(true);
+	});
+});

--- a/src/tests/tooltip/Tooltip.spec.ts
+++ b/src/tests/tooltip/Tooltip.spec.ts
@@ -197,3 +197,18 @@ describe('2 tooltips, group=undefined', () => {
 		expect(get(open2)).toBe(true);
 	});
 });
+
+describe('Single tooltip, group=true', () => {
+    test('Tooltip does not prevent itself from opening', async () => {
+        const open = writable(true);
+        render(Tooltip, {
+            open,
+            group: true
+        });
+
+        open.set(false);
+
+        open.set(true);
+        expect(get(open)).toBe(true);
+    })
+})


### PR DESCRIPTION
Tooltips with a `group` would prevent themselves from reopening again unless another tooltip in the same group was opened. This is due to the effect not cleaning up after the tooltip closes, so it stays in the "open tooltips map" forever.

This PR fixes the bug and adds a test to validate the fix.