### PR TITLE
fix: Corrected dialog-docs highlight

### DIFF
--- a/src/docs/content/builders/dialog.md
+++ b/src/docs/content/builders/dialog.md
@@ -65,10 +65,8 @@ an alert dialog would be appropriate.
 By default, we set the `role` attribute to `dialog`. If you want it to be considered an alert
 dialog, you can set the `role` builder prop to `alertdialog`.
 
-```ts {4}
-const {
-	/* ... */
-} = createDialog({
+```ts {2}
+const { /* ... */ } = createDialog({
 	role: 'alertdialog'
 })
 ```
@@ -78,10 +76,8 @@ const {
 By default, scrolling is prevented on the body when a dialog is open. You can disable this behavior
 by setting the `preventScroll` builder prop to `false`.
 
-```ts {4}
-const {
-	/* ... */
-} = createDialog({
+```ts {2}
+const {	/* ... */ } = createDialog({
 	preventScroll: false
 })
 ```
@@ -91,10 +87,8 @@ const {
 By default, clicking outside of the dialog will close it. You can disable this behavior by setting
 the `closeOnOutsideClick` builder prop to `false`.
 
-```ts {4}
-const {
-	/* ... */
-} = createDialog({
+```ts {2}
+const {	/* ... */ } = createDialog({
 	closeOnOutsideClick: false
 })
 ```
@@ -104,10 +98,8 @@ const {
 By default, pressing the escape key will close the dialog. You can disable this behavior by setting
 the `closeOnEscape` builder prop to `false`.
 
-```ts {4}
-const {
-	/* ... */
-} = createDialog({
+```ts {2}
+const { /* ... */ } = createDialog({
 	closeOnEscape: false
 })
 ```

--- a/src/docs/content/builders/dialog.md
+++ b/src/docs/content/builders/dialog.md
@@ -65,7 +65,7 @@ an alert dialog would be appropriate.
 By default, we set the `role` attribute to `dialog`. If you want it to be considered an alert
 dialog, you can set the `role` builder prop to `alertdialog`.
 
-```ts {2}
+```ts {4}
 const {
 	/* ... */
 } = createDialog({
@@ -78,7 +78,7 @@ const {
 By default, scrolling is prevented on the body when a dialog is open. You can disable this behavior
 by setting the `preventScroll` builder prop to `false`.
 
-```ts {2}
+```ts {4}
 const {
 	/* ... */
 } = createDialog({
@@ -91,7 +91,7 @@ const {
 By default, clicking outside of the dialog will close it. You can disable this behavior by setting
 the `closeOnOutsideClick` builder prop to `false`.
 
-```ts {2}
+```ts {4}
 const {
 	/* ... */
 } = createDialog({
@@ -104,7 +104,7 @@ const {
 By default, pressing the escape key will close the dialog. You can disable this behavior by setting
 the `closeOnEscape` builder prop to `false`.
 
-```ts {2}
+```ts {4}
 const {
 	/* ... */
 } = createDialog({


### PR DESCRIPTION
# Fixes issue:
- Issue: **Dialog docs has incorrect highlighting** (Issue not created, Only PR)
- Correct dialog docs highlighting

<br>

# Current dialog docs:

![Screenshot from 2023-10-08 15-02-39](https://github.com/melt-ui/melt-ui/assets/91054457/d43ff0d1-f2c4-475a-ac8a-928a0f2e4dd2)


# Changes to be made:
- Change ```ts {2}``` to  ```ts {4}```

<br>

# Dialog docs after update:
![image](https://github.com/melt-ui/melt-ui/assets/91054457/69b3c849-a260-4a1b-9e22-ccd4a1a279d5)

<br>

# Files changed:
- **dialog.md** (src/docs/content/builders/dialog.md)

# Total changes: 4