### PR TITLE
fix: `melt` action now throws an error if it's used without the PP

### DIFF
--- a/.changeset/eighty-items-march.md
+++ b/.changeset/eighty-items-march.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+The `melt` action now throws a helpful error if it's used without our [preprocessor](https://github.com/melt-ui/preprocessor)

--- a/src/lib/internal/actions/melt/index.ts
+++ b/src/lib/internal/actions/melt/index.ts
@@ -33,6 +33,7 @@ export function melt<
 	A extends Record<string, any>,
 	Param = never
 >(node: Element, params: Builder): ActionReturn<Builder, Attributes> {
-	// @ts-expect-error calls the action for debugging purposes
-	return params.action(node);
+	throw new Error(
+		"[MELTUI ERROR]: The `use:melt` action cannot be used without MeltUI's Preprocessor. See: https://www.melt-ui.com/docs/preprocessor"
+	);
 }


### PR DESCRIPTION
Partially fixes #606

Here's how the error will appear in the dev console:

![console error](https://i.imgur.com/VJg3FHz.png)

We could keep it brief like this by only providing a link to the PP docs, or we can further add install instructions such as: 

`Install the preprocessor with: "npm install -D @melt-ui/pp"`

or

`Install the preprocessor with: "npx @melt-ui/cli init"`