### PR TITLE
Increase transition duration when transition is used with overlay

### DIFF
--- a/src/docs/components/custom-event-dialog.svelte
+++ b/src/docs/components/custom-event-dialog.svelte
@@ -26,7 +26,7 @@
     translate-x-[-50%] translate-y-[-50%] rounded-md
     bg-neutral-800 p-4 shadow-lg md:p-8"
 		transition:flyAndScale={{
-			duration: 150,
+			duration: 350,
 			y: 8,
 			start: 0.96,
 		}}

--- a/src/docs/components/nav/mobile-nav.svelte
+++ b/src/docs/components/nav/mobile-nav.svelte
@@ -30,7 +30,7 @@
 		<div
 			use:melt={$overlay}
 			class="fixed inset-0 z-50 bg-black/80 backdrop-blur-sm"
-			transition:fade={{ duration: 150 }}
+			transition:fade={{ duration: 350 }}
 		/>
 		<div
 			use:melt={$content}

--- a/src/docs/components/type-dialog.svelte
+++ b/src/docs/components/type-dialog.svelte
@@ -27,7 +27,7 @@
     translate-x-[-50%] translate-y-[-50%] rounded-md
     bg-neutral-800 p-4 shadow-lg md:p-8"
 		transition:flyAndScale={{
-			duration: 150,
+			duration: 350,
 			y: 8,
 			start: 0.96,
 		}}

--- a/src/docs/previews/dialog/alert/css/index.svelte
+++ b/src/docs/previews/dialog/alert/css/index.svelte
@@ -27,7 +27,7 @@
 		<div
 			class="content"
 			transition:flyAndScale={{
-				duration: 150,
+				duration: 350,
 				y: 8,
 				start: 0.96,
 			}}

--- a/src/docs/previews/dialog/alert/tailwind/index.svelte
+++ b/src/docs/previews/dialog/alert/tailwind/index.svelte
@@ -36,7 +36,7 @@
             max-w-[450px] translate-x-[-50%] translate-y-[-50%] rounded-md bg-white
             p-6 shadow-lg"
 			transition:flyAndScale={{
-				duration: 150,
+				duration: 350,
 				y: 8,
 				start: 0.96,
 			}}

--- a/src/docs/previews/dialog/controlled/css/index.svelte
+++ b/src/docs/previews/dialog/controlled/css/index.svelte
@@ -30,7 +30,7 @@
 		<div
 			class="content"
 			transition:flyAndScale={{
-				duration: 150,
+				duration: 350,
 				y: 8,
 				start: 0.96,
 			}}

--- a/src/docs/previews/dialog/controlled/tailwind/index.svelte
+++ b/src/docs/previews/dialog/controlled/tailwind/index.svelte
@@ -38,7 +38,7 @@
             max-w-[450px] translate-x-[-50%] translate-y-[-50%] rounded-md bg-white
             p-6 shadow-lg"
 			transition:flyAndScale={{
-				duration: 150,
+				duration: 350,
 				y: 8,
 				start: 0.96,
 			}}

--- a/src/docs/previews/dialog/drawer/css/index.svelte
+++ b/src/docs/previews/dialog/drawer/css/index.svelte
@@ -24,7 +24,7 @@
 		<div
 			use:melt={$overlay}
 			class="overlay"
-			transition:fade={{ duration: 150 }}
+			transition:fade={{ duration: 350 }}
 		/>
 		<div
 			use:melt={$content}

--- a/src/docs/previews/dialog/drawer/tailwind/index.svelte
+++ b/src/docs/previews/dialog/drawer/tailwind/index.svelte
@@ -31,7 +31,7 @@
 		<div
 			use:melt={$overlay}
 			class="fixed inset-0 z-50 bg-black/50"
-			transition:fade={{ duration: 150 }}
+			transition:fade={{ duration: 350 }}
 		/>
 		<div
 			use:melt={$content}

--- a/src/docs/previews/dialog/main/css/index.svelte
+++ b/src/docs/previews/dialog/main/css/index.svelte
@@ -25,7 +25,7 @@
 		<div
 			class="content"
 			transition:flyAndScale={{
-				duration: 150,
+				duration: 350,
 				y: 8,
 				start: 0.96,
 			}}

--- a/src/docs/previews/dialog/main/tailwind/index.svelte
+++ b/src/docs/previews/dialog/main/tailwind/index.svelte
@@ -36,7 +36,7 @@
             max-w-[450px] translate-x-[-50%] translate-y-[-50%] rounded-xl bg-white
             p-6 shadow-lg"
 			transition:flyAndScale={{
-				duration: 150,
+				duration: 350,
 				y: 8,
 				start: 0.96,
 			}}

--- a/src/docs/previews/dialog/nested/css/index.svelte
+++ b/src/docs/previews/dialog/nested/css/index.svelte
@@ -38,7 +38,7 @@
 		<div
 			class="content"
 			transition:flyAndScale={{
-				duration: 150,
+				duration: 350,
 				y: 8,
 				start: 0.96,
 			}}
@@ -67,7 +67,7 @@
 		<div
 			class="content content-nested"
 			transition:flyAndScale={{
-				duration: 150,
+				duration: 350,
 				y: 8,
 				start: 0.96,
 			}}

--- a/src/docs/previews/dialog/nested/tailwind/index.svelte
+++ b/src/docs/previews/dialog/nested/tailwind/index.svelte
@@ -46,7 +46,7 @@
             max-w-[450px] translate-x-[-50%] translate-y-[-50%] rounded-md bg-white
             p-6 shadow-lg"
 			transition:flyAndScale={{
-				duration: 150,
+				duration: 350,
 				y: 8,
 				start: 0.96,
 			}}
@@ -86,7 +86,7 @@
                         max-w-[500px] translate-x-[-50%] translate-y-[-50%] rounded-md bg-white
                         p-6 shadow-2xl"
 						transition:flyAndScale={{
-							duration: 150,
+							duration: 350,
 							y: 8,
 							start: 0.96,
 						}}

--- a/src/stories/Dialog/BaseDialog.svelte
+++ b/src/stories/Dialog/BaseDialog.svelte
@@ -53,7 +53,7 @@
 			class="fixed left-[50%] top-[50%] z-50 max-h-[85vh] w-[90vw] max-w-[450px]
 				translate-x-[-50%] translate-y-[-50%] rounded-md bg-white p-6
 				shadow-lg"
-			transition:flyAndScale={{ duration: 150, y: 8, start: 0.96 }}
+			transition:flyAndScale={{ duration: 350, y: 8, start: 0.96 }}
 			use:melt={$content}
 		>
 			<slot title={$title} description={$description} close={$close} />


### PR DESCRIPTION
Dialog overlay doesn't stop touch events from firing other elements like it does with click events. It seems like increasing the duration for the transitions can prevent the touch events to fire events behind the overlay. This PR increases the duration from `150`to `350` in all instances where an overlay has a transition. This fixes the issue on iPad Air and iPhone 15 in xCode simulator. It's only tested in simulator, though, if a real touch event lasts longer it might need to be increased. Not tested on Android devices.

LInked to issue: https://github.com/melt-ui/melt-ui/issues/468