### PR TITLE
docs: make toasts close automatically

### DIFF
--- a/src/docs/previews/toast/main/tailwind/index.svelte
+++ b/src/docs/previews/toast/main/tailwind/index.svelte
@@ -38,7 +38,6 @@
 	function addRandomToast() {
 		addToast({
 			data: toastData[Math.floor(Math.random() * toastData.length)],
-			closeDelay: 0,
 		});
 	}
 </script>


### PR DESCRIPTION
this pr removes `closeDelay: 0` so that toasts in docs can close automatically using the default `closeDelay` (5000ms)