### PR TITLE
Escape additional conflicting characters in markdown

### DIFF
--- a/mdsvex.config.js
+++ b/mdsvex.config.js
@@ -121,7 +121,9 @@ function remarkEscapeSvelte() {
 
 		function escape(node) {
 			for (let i = 0; i < entities.length; i += 1) {
-				node.value = node.value.replace(entities[i][0], entities[i][1]);
+				for (const entity of entities) {
+					node.value = node.value.replace(entity[0], entity[1]);
+				}
 			}
 		}
 	};


### PR DESCRIPTION
We're currently only escaping one of the 4 characters which causes issues when trying to render them within inline code blocks. This PR escapes the other entities as well.