### PR TITLE
Implement disableTriggerRefocus

### DIFF
--- a/.changeset/empty-timers-enjoy.md
+++ b/.changeset/empty-timers-enjoy.md
@@ -1,0 +1,6 @@
+---
+"@melt-ui/svelte": patch
+---
+
+DropdownMenu: Implement `disableTriggerRefocus` prop
+

--- a/src/docs/constants.ts
+++ b/src/docs/constants.ts
@@ -46,6 +46,12 @@ export const PROPS = {
 		description: DESCRIPTIONS.FORCE_VISIBLE(args.name ?? 'element'),
 		default: args.default ?? 'false',
 	}),
+	DISABLE_TRIGGER_REFOCUS: (args: PropArgs = {}): Prop => ({
+		name: 'disableTriggerRefocus',
+		type: 'boolean',
+		description: `Whether or not to refocus the trigger when the ${args.name ?? 'element'} closes`,
+		default: args.default ?? 'false',
+	}),
 	DISABLED: (args: PropArgs = {}): Prop => ({
 		name: 'disabled',
 		type: 'boolean',

--- a/src/docs/data/builders/menu.ts
+++ b/src/docs/data/builders/menu.ts
@@ -23,6 +23,7 @@ export const menuBuilderProps = [
 	PROPS.DEFAULT_OPEN,
 	PROPS.OPEN,
 	PROPS.ON_OPEN_CHANGE,
+	PROPS.DISABLE_TRIGGER_REFOCUS
 ];
 
 export const menuBuilderOptions = [

--- a/src/lib/builders/dropdown-menu/create.ts
+++ b/src/lib/builders/dropdown-menu/create.ts
@@ -48,7 +48,7 @@ export function createDropdownMenu(props?: CreateDropdownMenuProps) {
 		rootActiveTrigger,
 		nextFocusable,
 		prevFocusable,
-		disableTriggerRefocus: true,
+		disableTriggerRefocus: props?.disableTriggerRefocus ?? false,
 		selector: 'dropdown-menu',
 		removeScroll: true,
 	});

--- a/src/lib/builders/menu/create.ts
+++ b/src/lib/builders/menu/create.ts
@@ -546,7 +546,6 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 
 						if (e.defaultPrevented) {
 							if (!isHTMLElement(itemEl)) return;
-
 							handleRovingFocus(itemEl);
 							return;
 						}
@@ -870,7 +869,6 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 							if (!isHTMLElement(menuEl)) return;
 
 							const firstItem = getMenuItems(menuEl)[0];
-
 							handleRovingFocus(firstItem);
 						}
 					}),
@@ -882,7 +880,6 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 
 						const triggerEl = e.currentTarget;
 						if (!isHTMLElement(triggerEl)) return;
-
 						handleRovingFocus(triggerEl);
 
 						const openTimer = get(subOpenTimer);
@@ -1101,7 +1098,7 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 				unsubs.push(removeScroll());
 			}
 
-			if (!$rootOpen && $rootActiveTrigger) {
+			if (!$rootOpen && $rootActiveTrigger && opts.disableTriggerRefocus === false) {
 				handleRovingFocus($rootActiveTrigger);
 			}
 
@@ -1120,6 +1117,9 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 					handleRovingFocus(menuItems[0]);
 				} else if ($rootActiveTrigger) {
 					// Focus on active trigger trigger
+					if (opts.disableTriggerRefocus) {
+						return;
+					}
 					handleRovingFocus($rootActiveTrigger);
 				} else {
 					if (opts.disableTriggerRefocus) {
@@ -1216,7 +1216,6 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 
 		const parentMenuEl = getParentMenu(target);
 		if (!parentMenuEl) return;
-
 		handleRovingFocus(parentMenuEl);
 	}
 
@@ -1456,7 +1455,6 @@ export function handleMenuNavigation(e: KeyboardEvent) {
 		default:
 			return;
 	}
-
 	handleRovingFocus(candidateNodes[nextIndex]);
 }
 

--- a/src/lib/builders/menu/types.ts
+++ b/src/lib/builders/menu/types.ts
@@ -99,6 +99,13 @@ export type _CreateMenuProps = {
 	 * @default true
 	 */
 	typeahead?: boolean;
+
+	/**
+	 * Whether to disable the functionality that the trigger element is refocused when the menu is closed.
+	 *
+	 * @type {boolean}
+	 */
+	disableTriggerRefocus?: boolean;
 };
 
 export type _CreateSubmenuProps = Pick<_CreateMenuProps, 'arrowSize' | 'positioning'> & {


### PR DESCRIPTION
closes #646

Expose the existing `disableTriggerRefocus` from the `menu` builder to the `dropdown menu` builder, and exit early on the 2 calls that refocuses the trigger on close

This causes deep links (hash links) to work properly as when the property is true, the focus will not be moved back to the trigger