### PR TITLE
feat(devcontainers): add the ability to use GitHub Codespaces and VS Code remote containers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+ARG NODE_MAJOR_VERSION
+ARG PNPM_VERSION
+
+FROM mcr.microsoft.com/devcontainers/javascript-node:${NODE_MAJOR_VERSION}
+
+ENV EDITOR="code -w" VISUAL="code -w"
+
+# install system dependencies for playwright
+RUN npx --yes playwright install-deps
+
+# install additional npm packages
+RUN su node -c 'npm i -g pnpm@${PNPM_VERSION}'

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+	"name": "melt-ui",
+	"dockerFile": "Dockerfile",
+	"build": {
+		"args": { "NODE_MAJOR_VERSION": "18", "PNPM_VERSION": "8.6.3" }
+	},
+	"postCreateCommand": [".devcontainer/post-create.sh"],
+	"portsAttributes": {
+		"5173": { "label": "Melt UI" },
+		"6006": { "label": "Storybook" },
+		"9323": { "label": "Playwright Report" }
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"bradlc.vscode-tailwindcss",
+				"dbaeumer.vscode-eslint",
+				"esbenp.prettier-vscode",
+				"svelte.svelte-vscode"
+			]
+		}
+	}
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 # when in a VS Code or GitHub Codespaces devcontainer
-if [ -n "${REMOTE_CONTAINERS}" ]; then
+if [ -n "${REMOTE_CONTAINERS}" ] || [ -n "${CODESPACES}" ]; then
 	this_dir=$(cd -P -- "$(dirname -- "$(command -v -- "$0")")" && pwd -P)
 	workspace_root=$(realpath ${this_dir}/..)
 

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+# when in a VS Code or GitHub Codespaces devcontainer
+if [ -n "${REMOTE_CONTAINERS}" ]; then
+	this_dir=$(cd -P -- "$(dirname -- "$(command -v -- "$0")")" && pwd -P)
+	workspace_root=$(realpath ${this_dir}/..)
+
+	# perform additional one-time setup just after
+	# the devcontainer is created
+	pnpm install --dir "${workspace_root}" # install workspace node dependencies
+	npx --yes playwright install           # install playwright browsers
+
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ storybook-static
 /test-results/
 /playwright-report/
 /playwright/.cache/
+/.pnpm-store/

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
 		"@iconify-json/lucide": "^1.1.104",
 		"@iconify-json/simple-icons": "^1.1.57",
 		"@melt-ui/pp": "0.1.0",
-		"@playwright/test": "^1.36.0",
+		"@playwright/test": "^1.39.0",
 		"@storybook/addon-essentials": "^7.3.2",
 		"@storybook/addon-interactions": "^7.3.2",
 		"@storybook/addon-links": "^7.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,8 +41,8 @@ devDependencies:
     specifier: 0.1.0
     version: 0.1.0(@melt-ui/svelte@0.30.1)(svelte@4.0.0)
   '@playwright/test':
-    specifier: ^1.36.0
-    version: 1.36.0
+    specifier: ^1.39.0
+    version: 1.39.0
   '@storybook/addon-essentials':
     specifier: ^7.3.2
     version: 7.3.2(react-dom@18.2.0)(react@18.2.0)
@@ -2459,15 +2459,12 @@ packages:
     dev: true
     optional: true
 
-  /@playwright/test@1.36.0:
-    resolution: {integrity: sha512-yN+fvMYtiyLFDCQos+lWzoX4XW3DNuaxjBu68G0lkgLgC6BP+m/iTxJQoSicz/x2G5EsrqlZTqTIP9sTgLQerg==}
+  /@playwright/test@1.39.0:
+    resolution: {integrity: sha512-3u1iFqgzl7zr004bGPYiN/5EZpRUSFddQBra8Rqll5N0/vfpqlP9I9EXqAoGacuAbX6c9Ulg/Cjqglp5VkK6UQ==}
     engines: {node: '>=16'}
     hasBin: true
     dependencies:
-      '@types/node': 20.3.1
-      playwright-core: 1.36.0
-    optionalDependencies:
-      fsevents: 2.3.2
+      playwright: 1.39.0
     dev: true
 
   /@polka/url@1.0.0-next.21:
@@ -10065,10 +10062,20 @@ packages:
       pathe: 1.1.1
     dev: true
 
-  /playwright-core@1.36.0:
-    resolution: {integrity: sha512-7RTr8P6YJPAqB+8j5ATGHqD6LvLLM39sYVNsslh78g8QeLcBs5750c6+msjrHUwwGt+kEbczBj1XB22WMwn+WA==}
+  /playwright-core@1.39.0:
+    resolution: {integrity: sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==}
     engines: {node: '>=16'}
     hasBin: true
+    dev: true
+
+  /playwright@1.39.0:
+    resolution: {integrity: sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==}
+    engines: {node: '>=16'}
+    hasBin: true
+    dependencies:
+      playwright-core: 1.39.0
+    optionalDependencies:
+      fsevents: 2.3.2
     dev: true
 
   /polished@4.2.2:


### PR DESCRIPTION
For `Hacktoberfest`, I have been adding `GitHub Codespaces` / `VS Code Remote Containers` configuration for OSS projects to make it easier for contributors to the project to get up and running with the correct developer setup. Including the appropriate configuration for a project allows contributors to work entirely within a web browser via `GH Codespaces`, or inside of fully, and correctly configured containers on their own computer with `VS Code Remote Containers` (both of these use the same configuration, as `GH Codespaces` leverages the `Remote Containers` features under the hood).

For the `melt-ui` project, this configuration includes the following:
- Preinstalled `Node LTS`
- Preinstalled `ESLint`,  `Prettier`, `Tailwind CSS`, and `Svelte` extensions
- Preinstalled `playwright` dependencies
- Automation of the `pnpm install` when the devcontainer is first created

Basically everything needed for a contributor to open the project after a fresh clone and be immediately productive, either locally with `VS Code` or remotely with `GitHub Codespaces`!

> [!NOTE]
> This `devcontainer` is based off of the Microsoft-provided "node" Docker image, which is based off the Debian12 Docker image. Playwright only started to support Firefox for Debian12 in `playwright@1.37.0` ([ref](https://github.com/microsoft/playwright/issues/23532)) which is _one minor version_ greater than the version of playwright in the _pnpm-lock.yml_ for `melt-ui`. Due to the fact that the _package.json_ specified `^1.36.0` for `playwright` and version `1.37.0` is semver-compatible with the specified version, I have updated to the latest semver-compatible version in my changes here, specifically `1.39.0`.
>
> I have run all `playwright` tests inside the `devcontainer` both headlessly and non-headlessly and have confirmed that everything still works correctly. I would have preferred to make no changes besides adding this configuration, but since the version bump was so small and only to a semver-compatible version, I decided it was worth it so that _everything_ works inside the `devcontainer`, including `playwright` tests.

For reference, here are some other repositories for whom I've opened PRs to do the same:

- https://github.com/AnilSeervi/inspirational-quotes/pull/19
- https://github.com/Icon-Shelf/icon-shelf/pull/135 (note that this one is a GUI electron app, but it's still possible to containerize it and do development in the cloud on GH Codespaces!)
- https://github.com/developertools-tech/developertools.tech/issues/36
- https://github.com/date-fns/date-fns/pull/3551
- https://github.com/floating-ui/floating-ui/pull/2606
- https://github.com/EveryBoard/EveryBoard/pull/155
- https://github.com/compiler-explorer/compiler-explorer/pull/5631
- https://github.com/JamesLMilner/terra-draw/pull/108

