### PR TITLE
Avoid calling openTooltip on every mousemove.

### DIFF
--- a/.changeset/rotten-worms-warn.md
+++ b/.changeset/rotten-worms-warn.md
@@ -1,0 +1,8 @@
+---
+"@melt-ui/svelte": patch
+---
+
+Tooltip: Avoid calling openTooltip on every mousemove, fixing a couple of bugs:
+- onOpenChange was being called for every mouse move within the tooltip.
+- Overlapping grace areas were fighting over the group.
+

--- a/src/lib/builders/tooltip/create.ts
+++ b/src/lib/builders/tooltip/create.ts
@@ -302,9 +302,7 @@ export function createTooltip(props?: CreateTooltipProps) {
 
 				if ($openReason !== 'pointer') return;
 
-				if (isMouseInTooltipArea) {
-					openTooltip('pointer');
-				} else {
+				if (!isMouseInTooltipArea) {
 					closeTooltip();
 				}
 			})


### PR DESCRIPTION
openTooltip is already being called in pointerevent and focus. The effect should only be concerned with closing the tooltip once the pointer leaves the grace area.

This fixes a couple issues:
1. onOpenChange was being called for every mouse move within the tooltip.
2. Overlapping grace areas were fighting over the group.

You can see the bug occurring in the Tooltip example here:
https://github.com/pauldemarco/melt-ui/tree/tooltip-group-bug