### PR TITLE
Remove bug autofocusing dropdown menu triggers

### DIFF
--- a/.changeset/four-ears-chew.md
+++ b/.changeset/four-ears-chew.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+Fix dropdown menu autofocus

--- a/src/lib/builders/menu/create.ts
+++ b/src/lib/builders/menu/create.ts
@@ -1122,13 +1122,6 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 						return;
 					}
 					handleRovingFocus($rootActiveTrigger);
-				} else {
-					if (opts.disableTriggerRefocus) {
-						return;
-					}
-					const triggerEl = document.getElementById(rootIds.trigger);
-					if (!triggerEl) return;
-					handleRovingFocus(triggerEl);
 				}
 			});
 


### PR DESCRIPTION
I'm afraid my previous PR #647 introduced a bug whereby mounting a dropdown menu causes the trigger to be focused initially. 

![shame-go-t](https://github.com/melt-ui/melt-ui/assets/8914722/60ffad05-ee32-40af-afa2-3824d3819e06)

The problem arises from this `effect` (in `menu/create.ts`) initially running and setting focus to the trigger on mount.

```js
effect(
		[rootOpen, rootActiveTrigger, preventScroll],
		([$rootOpen, $rootActiveTrigger, $preventScroll]) => {
			if (!isBrowser) return;

			const unsubs: Array<() => void> = [];

			if (opts.removeScroll && $rootOpen && $preventScroll) {
				unsubs.push(removeScroll());
			}

			if (!$rootOpen && $rootActiveTrigger && opts.disableTriggerRefocus === false) {
				handleRovingFocus($rootActiveTrigger);
			}

			sleep(1).then(() => {
				const menuEl = document.getElementById(rootIds.menu);
				if (menuEl && $rootOpen && get(isUsingKeyboard)) {
					if (opts.disableFocusFirstItem) {
						handleRovingFocus(menuEl);
						return;
					}
					// Get menu items belonging to the root menu
					const menuItems = getMenuItems(menuEl);
					if (!menuItems.length) return;

					// Focus on first menu item
					handleRovingFocus(menuItems[0]);
				} else if ($rootActiveTrigger) {
					// Focus on active trigger trigger
					if (opts.disableTriggerRefocus) {
						return;
					}
					handleRovingFocus($rootActiveTrigger);
				} else {
					if (opts.disableTriggerRefocus) {
						return;
					}
					const triggerEl = document.getElementById(rootIds.trigger);
					if (!triggerEl) return;
					handleRovingFocus(triggerEl);
				}
			});

			return () => {
				unsubs.forEach((unsub) => unsub());
			};
		}
	);
```

Before my PR `disableTriggerRefocus` was true and therefore the final else block did not fire.

My solution proposal would be to simply delete the else, since I'm unsure why it would be needed? as I understand the code, focus should only be moved to the trigger if the dropdown has been opened.

An alternative could be to simply skip the first execution of the effect. Or more closely track whether or not the dropdown has been opened.
