### PR TITLE
Fix: Tooltip ghost hitbox in docs

### DIFF
--- a/src/docs/components/tooltip.svelte
+++ b/src/docs/components/tooltip.svelte
@@ -33,11 +33,12 @@
 
 	[data-melt-tooltip-content] {
 		opacity: 0;
-
+		visibility: hidden;
 		transition: 150ms ease;
 
 		&[data-open] {
 			opacity: 1;
+			visibility: visible;
 		}
 	}
 </style>


### PR DESCRIPTION
Current behavior:

![wrong](https://github.com/melt-ui/melt-ui/assets/37531387/cc08d829-da66-4c85-94ec-5661d862237e)


Fixed behavior:

![correct](https://github.com/melt-ui/melt-ui/assets/37531387/312aaa66-0d30-4889-a2c0-78071d25981b)
