### PR TITLE
Docs: CSS Color-Scheme dark

### DIFF
--- a/src/app.postcss
+++ b/src/app.postcss
@@ -3,6 +3,10 @@
 @tailwind components;
 @tailwind utilities;
 
+html {
+	color-scheme: dark;
+}
+
 body {
 	background-color: theme('colors.neutral.900');
 	color: theme('colors.white');


### PR DESCRIPTION
`color-scheme: dark` on `<html>` will make the browser's default elements dark to keep consistency with the Docs' theme overall. In this case, the only affected part will be the scrollbar.