### PR TITLE
Feat: Bring your own ids

### DIFF
--- a/.changeset/heavy-shoes-stare.md
+++ b/.changeset/heavy-shoes-stare.md
@@ -1,5 +1,5 @@
 ---
-"@melt-ui/svelte": patch
+"@melt-ui/svelte": minor
 ---
 
 Feat: ability to override internal ids via a prop

--- a/.changeset/heavy-shoes-stare.md
+++ b/.changeset/heavy-shoes-stare.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+Feat: ability to override internal ids via a prop

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile

--- a/src/docs/components/tables/api-table.svelte
+++ b/src/docs/components/tables/api-table.svelte
@@ -75,6 +75,14 @@
 			</svelte:fragment>
 		</ReturnedPropsTable>
 	{/if}
+	{#if data.ids && data.ids.length}
+		<ReturnedPropsTable data={data.ids} title="IDs" tableHeading="Option">
+			<svelte:fragment slot="info">
+				Some elements come with predefined IDs for internal use. We provide stores for each ID, that
+				can be changed at any time by setting the respective store to a new value.
+			</svelte:fragment>
+		</ReturnedPropsTable>
+	{/if}
 	{#if data.dataAttributes && data.dataAttributes.length}
 		<DataAttrTable data={data.dataAttributes} />
 	{/if}

--- a/src/docs/data/builders/accordion.ts
+++ b/src/docs/data/builders/accordion.ts
@@ -1,7 +1,6 @@
 import { ATTRS, KBD, PROPS, SEE } from '$docs/constants.js';
 import type { KeyboardSchema } from '$docs/types.js';
 import { builderSchema, elementSchema } from '$docs/utils/index.js';
-import { accordionIdParts } from '$lib';
 import { accordionEvents } from '$lib/builders/accordion/events.js';
 import type { BuilderData } from './index.js';
 
@@ -23,7 +22,6 @@ const OPTION_PROPS = [
 const BUILDER_NAME = 'accordion';
 
 const builder = builderSchema(BUILDER_NAME, {
-	ids: accordionIdParts,
 	title: 'createAccordion',
 	props: [
 		...OPTION_PROPS,

--- a/src/docs/data/builders/accordion.ts
+++ b/src/docs/data/builders/accordion.ts
@@ -56,6 +56,11 @@ const builder = builderSchema(BUILDER_NAME, {
 				'A callback called when the value of the `value` store should be changed. This is useful for controlling the value of the accordion from outside the accordion.',
 			see: SEE.CHANGE_FUNCTIONS,
 		},
+		{
+			name: 'ids',
+			type: 'Record<"root", string>',
+			description: 'Override the internally generated ids for the elements.',
+		},
 	],
 	elements: [
 		{

--- a/src/docs/data/builders/accordion.ts
+++ b/src/docs/data/builders/accordion.ts
@@ -1,6 +1,7 @@
 import { ATTRS, KBD, PROPS, SEE } from '$docs/constants.js';
 import type { KeyboardSchema } from '$docs/types.js';
 import { builderSchema, elementSchema } from '$docs/utils/index.js';
+import { accordionIdParts } from '$lib';
 import { accordionEvents } from '$lib/builders/accordion/events.js';
 import type { BuilderData } from './index.js';
 
@@ -22,6 +23,7 @@ const OPTION_PROPS = [
 const BUILDER_NAME = 'accordion';
 
 const builder = builderSchema(BUILDER_NAME, {
+	ids: accordionIdParts,
 	title: 'createAccordion',
 	props: [
 		...OPTION_PROPS,
@@ -55,11 +57,6 @@ const builder = builderSchema(BUILDER_NAME, {
 			description:
 				'A callback called when the value of the `value` store should be changed. This is useful for controlling the value of the accordion from outside the accordion.',
 			see: SEE.CHANGE_FUNCTIONS,
-		},
-		{
-			name: 'ids',
-			type: 'Record<"root", string>',
-			description: 'Override the internally generated ids for the elements.',
 		},
 	],
 	elements: [

--- a/src/docs/data/builders/combobox.ts
+++ b/src/docs/data/builders/combobox.ts
@@ -2,6 +2,7 @@ import { ATTRS, KBD, PROPS, SEE } from '$docs/constants.js';
 import type { KeyboardSchema } from '$docs/types.js';
 import { builderSchema, elementSchema } from '$docs/utils/index.js';
 import { comboboxEvents } from '$lib/builders/combobox/events.js';
+import { listboxIdParts } from '$lib/builders/listbox/create.js';
 import type { BuilderData } from './index.js';
 import { getMenuArrowSchema } from './menu.js';
 
@@ -34,6 +35,7 @@ const OPTION_PROPS = [
 const BUILDER_NAME = 'combobox';
 
 const builder = builderSchema(BUILDER_NAME, {
+	ids: listboxIdParts,
 	title: 'createCombobox',
 	props: [
 		{

--- a/src/docs/data/builders/combobox.ts
+++ b/src/docs/data/builders/combobox.ts
@@ -63,6 +63,11 @@ const builder = builderSchema(BUILDER_NAME, {
 		PROPS.OPEN,
 		PROPS.ON_OPEN_CHANGE,
 		...OPTION_PROPS,
+		{
+			name: 'ids',
+			type: 'Record<"trigger" | "content", string>',
+			description: 'Override the internally generated ids for the elements.',
+		},
 	],
 	elements: [
 		{

--- a/src/docs/data/builders/dialog.ts
+++ b/src/docs/data/builders/dialog.ts
@@ -27,7 +27,17 @@ const BUILDER_NAME = 'dialog';
 
 const builder = builderSchema(BUILDER_NAME, {
 	title: 'createDialog',
-	props: [...OPTION_PROPS, PROPS.DEFAULT_OPEN, PROPS.OPEN, PROPS.ON_OPEN_CHANGE],
+	props: [
+		...OPTION_PROPS,
+		PROPS.DEFAULT_OPEN,
+		PROPS.OPEN,
+		PROPS.ON_OPEN_CHANGE,
+		{
+			name: 'ids',
+			type: 'Record<"content" | "title" | "description" | "trigger", string>',
+			description: 'Override the internally generated ids for the elements.',
+		},
+	],
 	elements: [
 		{
 			name: 'trigger',

--- a/src/docs/data/builders/dialog.ts
+++ b/src/docs/data/builders/dialog.ts
@@ -1,6 +1,7 @@
 import { ATTRS, KBD, PROPS } from '$docs/constants.js';
 import type { KeyboardSchema } from '$docs/types.js';
 import { builderSchema, elementSchema } from '$docs/utils/index.js';
+import { dialogIdParts } from '$lib';
 import { dialogEvents } from '$lib/builders/dialog/events.js';
 import type { BuilderData } from './index.js';
 
@@ -26,18 +27,9 @@ const OPTION_PROPS = [
 const BUILDER_NAME = 'dialog';
 
 const builder = builderSchema(BUILDER_NAME, {
+	ids: dialogIdParts,
 	title: 'createDialog',
-	props: [
-		...OPTION_PROPS,
-		PROPS.DEFAULT_OPEN,
-		PROPS.OPEN,
-		PROPS.ON_OPEN_CHANGE,
-		{
-			name: 'ids',
-			type: 'Record<"content" | "title" | "description" | "trigger", string>',
-			description: 'Override the internally generated ids for the elements.',
-		},
-	],
+	props: [...OPTION_PROPS, PROPS.DEFAULT_OPEN, PROPS.OPEN, PROPS.ON_OPEN_CHANGE],
 	elements: [
 		{
 			name: 'trigger',

--- a/src/docs/data/builders/link-preview.ts
+++ b/src/docs/data/builders/link-preview.ts
@@ -1,5 +1,6 @@
 import { ATTRS, PROPS } from '$docs/constants.js';
 import { builderSchema, elementSchema } from '$docs/utils/index.js';
+import { linkPreviewIdParts } from '$lib';
 import { linkPreviewEvents } from '$lib/builders/link-preview/events.js';
 import type { BuilderData } from './index.js';
 import { getMenuArrowSchema } from './menu.js';
@@ -31,18 +32,9 @@ const OPTION_PROPS = [
 const BUILDER_NAME = 'link preview';
 
 const builder = builderSchema(BUILDER_NAME, {
+	ids: linkPreviewIdParts,
 	title: 'createLinkPreview',
-	props: [
-		...OPTION_PROPS,
-		PROPS.DEFAULT_OPEN,
-		PROPS.OPEN,
-		PROPS.ON_OPEN_CHANGE,
-		{
-			name: 'ids',
-			type: 'Record<"content" | "trigger", string>',
-			description: 'Override the internally generated ids for the elements.',
-		},
-	],
+	props: [...OPTION_PROPS, PROPS.DEFAULT_OPEN, PROPS.OPEN, PROPS.ON_OPEN_CHANGE],
 	elements: [
 		{
 			name: 'trigger',

--- a/src/docs/data/builders/link-preview.ts
+++ b/src/docs/data/builders/link-preview.ts
@@ -32,7 +32,17 @@ const BUILDER_NAME = 'link preview';
 
 const builder = builderSchema(BUILDER_NAME, {
 	title: 'createLinkPreview',
-	props: [...OPTION_PROPS, PROPS.DEFAULT_OPEN, PROPS.OPEN, PROPS.ON_OPEN_CHANGE],
+	props: [
+		...OPTION_PROPS,
+		PROPS.DEFAULT_OPEN,
+		PROPS.OPEN,
+		PROPS.ON_OPEN_CHANGE,
+		{
+			name: 'ids',
+			type: 'Record<"content" | "trigger", string>',
+			description: 'Override the internally generated ids for the elements.',
+		},
+	],
 	elements: [
 		{
 			name: 'trigger',

--- a/src/docs/data/builders/menu.ts
+++ b/src/docs/data/builders/menu.ts
@@ -24,6 +24,11 @@ export const menuBuilderProps = [
 	PROPS.OPEN,
 	PROPS.ON_OPEN_CHANGE,
 	PROPS.CLOSE_FOCUS,
+	{
+		name: 'ids',
+		type: 'Record<"trigger" | "menu", string>',
+		description: 'Override the internally generated ids for the elements.',
+	},
 ];
 
 export const menuBuilderOptions = [
@@ -298,6 +303,13 @@ function getMenuSubmenuBuilderSchema() {
 			PROPS.POSITIONING({ default: 'placement: "right-start"' }),
 			PROPS.ARROW_SIZE,
 			PROPS.DISABLED({ name: 'submenu' }),
+			PROPS.OPEN,
+			PROPS.ON_OPEN_CHANGE,
+			{
+				name: 'ids',
+				type: 'Record<"trigger" | "menu", string>',
+				description: 'Override the internally generated ids for the elements.',
+			},
 		],
 		elements: [
 			{

--- a/src/docs/data/builders/menubar.ts
+++ b/src/docs/data/builders/menubar.ts
@@ -5,20 +5,15 @@ import type { BuilderData } from './index.js';
 import { builder as dropdownBuilder } from './dropdown-menu.js';
 import { getMenuSchemas, getMenuTriggerDataAttrs } from './menu.js';
 import { menubarEvents } from '$lib/builders/menubar/events.js';
+import { menubarIdParts } from '$lib';
 
 const OPTION_PROPS = [PROPS.CLOSE_ON_ESCAPE, PROPS.LOOP];
 const BUILDER_NAME = 'menubar';
 
 const builder = builderSchema(BUILDER_NAME, {
+	ids: menubarIdParts,
 	title: 'createMenubar',
-	props: [
-		...OPTION_PROPS,
-		{
-			name: 'ids',
-			type: 'Record<"menubar", string>',
-			description: 'Override the internally generated ids for the elements.',
-		},
-	],
+	props: [...OPTION_PROPS],
 	builders: [
 		{
 			name: 'createMenu',

--- a/src/docs/data/builders/menubar.ts
+++ b/src/docs/data/builders/menubar.ts
@@ -11,7 +11,14 @@ const BUILDER_NAME = 'menubar';
 
 const builder = builderSchema(BUILDER_NAME, {
 	title: 'createMenubar',
-	props: OPTION_PROPS,
+	props: [
+		...OPTION_PROPS,
+		{
+			name: 'ids',
+			type: 'Record<"menubar", string>',
+			description: 'Override the internally generated ids for the elements.',
+		},
+	],
 	builders: [
 		{
 			name: 'createMenu',

--- a/src/docs/data/builders/pin-input.ts
+++ b/src/docs/data/builders/pin-input.ts
@@ -1,6 +1,7 @@
 import { ATTRS, KBD, SEE } from '$docs/constants.js';
 import type { KeyboardSchema } from '$docs/types.js';
 import { builderSchema, elementSchema } from '$docs/utils/index.js';
+import { pinInputIdParts } from '$lib';
 import { pinInputEvents } from '$lib/builders/pin-input/events.js';
 import { isMac } from '$lib/internal/helpers/index.js';
 import type { BuilderData } from './index.js';
@@ -42,6 +43,7 @@ const OPTION_PROPS = [
 const BUILDER_NAME = 'pin input';
 
 const builder = builderSchema(BUILDER_NAME, {
+	ids: pinInputIdParts,
 	title: 'createPinInput',
 	props: [
 		...OPTION_PROPS,
@@ -62,11 +64,6 @@ const builder = builderSchema(BUILDER_NAME, {
 			description:
 				'A callback called when the value of the `value` store should be changed. This is useful for controlling the value of the pin-input from outside the pin-input.',
 			see: SEE.CHANGE_FUNCTIONS,
-		},
-		{
-			name: 'ids',
-			type: 'Record<"root", string>',
-			description: 'Override the internally generated ids for the elements.',
 		},
 	],
 	elements: [

--- a/src/docs/data/builders/pin-input.ts
+++ b/src/docs/data/builders/pin-input.ts
@@ -63,6 +63,11 @@ const builder = builderSchema(BUILDER_NAME, {
 				'A callback called when the value of the `value` store should be changed. This is useful for controlling the value of the pin-input from outside the pin-input.',
 			see: SEE.CHANGE_FUNCTIONS,
 		},
+		{
+			name: 'ids',
+			type: 'Record<"root", string>',
+			description: 'Override the internally generated ids for the elements.',
+		},
 	],
 	elements: [
 		{

--- a/src/docs/data/builders/popover.ts
+++ b/src/docs/data/builders/popover.ts
@@ -29,7 +29,17 @@ const BUILDER_NAME = 'popover';
 
 const builder = builderSchema(BUILDER_NAME, {
 	title: 'createPopover',
-	props: [...OPTION_PROPS, PROPS.DEFAULT_OPEN, PROPS.OPEN, PROPS.ON_OPEN_CHANGE],
+	props: [
+		...OPTION_PROPS,
+		PROPS.DEFAULT_OPEN,
+		PROPS.OPEN,
+		PROPS.ON_OPEN_CHANGE,
+		{
+			name: 'ids',
+			type: 'Record<"content" | "trigger", string>',
+			description: 'Override the internally generated ids for the elements.',
+		},
+	],
 	elements: [
 		{
 			name: 'trigger',

--- a/src/docs/data/builders/popover.ts
+++ b/src/docs/data/builders/popover.ts
@@ -1,6 +1,7 @@
 import { ATTRS, KBD, PROPS } from '$docs/constants.js';
 import type { KeyboardSchema } from '$docs/types.js';
 import { builderSchema, elementSchema } from '$docs/utils/index.js';
+import { popoverIdParts } from '$lib';
 import { popoverEvents } from '$lib/builders/popover/events.js';
 import type { BuilderData } from './index.js';
 
@@ -28,18 +29,9 @@ const OPTION_PROPS = [
 const BUILDER_NAME = 'popover';
 
 const builder = builderSchema(BUILDER_NAME, {
+	ids: popoverIdParts,
 	title: 'createPopover',
-	props: [
-		...OPTION_PROPS,
-		PROPS.DEFAULT_OPEN,
-		PROPS.OPEN,
-		PROPS.ON_OPEN_CHANGE,
-		{
-			name: 'ids',
-			type: 'Record<"content" | "trigger", string>',
-			description: 'Override the internally generated ids for the elements.',
-		},
-	],
+	props: [...OPTION_PROPS, PROPS.DEFAULT_OPEN, PROPS.OPEN, PROPS.ON_OPEN_CHANGE],
 	elements: [
 		{
 			name: 'trigger',

--- a/src/docs/data/builders/select.ts
+++ b/src/docs/data/builders/select.ts
@@ -67,10 +67,14 @@ const builder = builderSchema(BUILDER_NAME, {
 			default: 'false',
 			description: 'Whether or not the select is a multiple select.',
 		},
-
 		PROPS.DEFAULT_OPEN,
 		PROPS.OPEN,
 		PROPS.ON_OPEN_CHANGE,
+		{
+			name: 'ids',
+			type: 'Record<"trigger" | "content", string>',
+			description: 'Override the internally generated ids for the elements.',
+		},
 	],
 	elements: [
 		{

--- a/src/docs/data/builders/select.ts
+++ b/src/docs/data/builders/select.ts
@@ -1,6 +1,7 @@
 import { ATTRS, DESCRIPTIONS, KBD, PROPS, SEE } from '$docs/constants.js';
 import type { KeyboardSchema } from '$docs/types.js';
 import { builderSchema, elementSchema } from '$docs/utils/index.js';
+import { listboxIdParts } from '$lib/builders/listbox/create.js';
 import { selectEvents } from '$lib/builders/select/events.js';
 import type { BuilderData } from './index.js';
 
@@ -35,6 +36,7 @@ const OPTION_PROPS = [
 const BUILDER_NAME = 'select';
 
 const builder = builderSchema(BUILDER_NAME, {
+	ids: listboxIdParts,
 	title: 'createSelect',
 	props: [
 		{
@@ -70,11 +72,6 @@ const builder = builderSchema(BUILDER_NAME, {
 		PROPS.DEFAULT_OPEN,
 		PROPS.OPEN,
 		PROPS.ON_OPEN_CHANGE,
-		{
-			name: 'ids',
-			type: 'Record<"trigger" | "content", string>',
-			description: 'Override the internally generated ids for the elements.',
-		},
 	],
 	elements: [
 		{

--- a/src/docs/data/builders/slider.ts
+++ b/src/docs/data/builders/slider.ts
@@ -1,6 +1,7 @@
 import { ATTRS, KBD, PROPS, SEE, TYPES } from '$docs/constants.js';
 import type { KeyboardSchema } from '$docs/types.js';
 import { builderSchema, elementSchema } from '$docs/utils/index.js';
+import { sliderIdParts } from '$lib';
 import { sliderEvents } from '$lib/builders/slider/events.js';
 import type { BuilderData } from './index.js';
 
@@ -37,6 +38,7 @@ const OPTION_PROPS = [
 const BUILDER_NAME = 'slider';
 
 const builder = builderSchema(BUILDER_NAME, {
+	ids: sliderIdParts,
 	title: 'createSlider',
 	props: [
 		...OPTION_PROPS,
@@ -58,11 +60,6 @@ const builder = builderSchema(BUILDER_NAME, {
 			type: 'ChangeFn<number>',
 			description: 'A callback that is called when the value of the slider changes.',
 			see: SEE.CHANGE_FUNCTIONS,
-		},
-		{
-			name: 'ids',
-			type: 'Record<"root", string>',
-			description: 'Override the internally generated ids for the elements.',
 		},
 	],
 	elements: [

--- a/src/docs/data/builders/slider.ts
+++ b/src/docs/data/builders/slider.ts
@@ -1,7 +1,7 @@
 import { ATTRS, KBD, PROPS, SEE, TYPES } from '$docs/constants.js';
 import type { KeyboardSchema } from '$docs/types.js';
 import { builderSchema, elementSchema } from '$docs/utils/index.js';
-import { sliderIdParts } from '$lib';
+
 import { sliderEvents } from '$lib/builders/slider/events.js';
 import type { BuilderData } from './index.js';
 
@@ -38,7 +38,6 @@ const OPTION_PROPS = [
 const BUILDER_NAME = 'slider';
 
 const builder = builderSchema(BUILDER_NAME, {
-	ids: sliderIdParts,
 	title: 'createSlider',
 	props: [
 		...OPTION_PROPS,

--- a/src/docs/data/builders/slider.ts
+++ b/src/docs/data/builders/slider.ts
@@ -59,6 +59,11 @@ const builder = builderSchema(BUILDER_NAME, {
 			description: 'A callback that is called when the value of the slider changes.',
 			see: SEE.CHANGE_FUNCTIONS,
 		},
+		{
+			name: 'ids',
+			type: 'Record<"root", string>',
+			description: 'Override the internally generated ids for the elements.',
+		},
 	],
 	elements: [
 		{

--- a/src/docs/data/builders/tags-input.ts
+++ b/src/docs/data/builders/tags-input.ts
@@ -114,6 +114,11 @@ const builder = builderSchema(BUILDER_NAME, {
 			description: 'A function that is called when the tags change.',
 			see: SEE.CHANGE_FUNCTIONS,
 		},
+		{
+			name: 'ids',
+			type: 'Record<"root" | "input", string>',
+			description: 'Override the internally generated ids for the elements.',
+		},
 	],
 	elements: [
 		{

--- a/src/docs/data/builders/tags-input.ts
+++ b/src/docs/data/builders/tags-input.ts
@@ -1,6 +1,7 @@
 import { ATTRS, PROPS, SEE } from '$docs/constants.js';
 import type { KeyboardSchema } from '$docs/types.js';
 import { builderSchema, elementSchema } from '$docs/utils/index.js';
+import { tagInputIdParts } from '$lib';
 import { tagsInputEvents } from '$lib/builders/tags-input/events.js';
 import type { BuilderData } from './index.js';
 
@@ -94,6 +95,7 @@ const OPTION_PROPS = [
 const BUILDER_NAME = 'tags input';
 
 const builder = builderSchema(BUILDER_NAME, {
+	ids: tagInputIdParts,
 	title: 'createTags',
 	props: [
 		...OPTION_PROPS,
@@ -113,11 +115,6 @@ const builder = builderSchema(BUILDER_NAME, {
 			type: 'ChangeFn<Tags[]>',
 			description: 'A function that is called when the tags change.',
 			see: SEE.CHANGE_FUNCTIONS,
-		},
-		{
-			name: 'ids',
-			type: 'Record<"root" | "input", string>',
-			description: 'Override the internally generated ids for the elements.',
 		},
 	],
 	elements: [

--- a/src/docs/data/builders/tags-input.ts
+++ b/src/docs/data/builders/tags-input.ts
@@ -1,7 +1,6 @@
 import { ATTRS, PROPS, SEE } from '$docs/constants.js';
 import type { KeyboardSchema } from '$docs/types.js';
 import { builderSchema, elementSchema } from '$docs/utils/index.js';
-import { tagInputIdParts } from '$lib';
 import { tagsInputEvents } from '$lib/builders/tags-input/events.js';
 import type { BuilderData } from './index.js';
 
@@ -95,7 +94,6 @@ const OPTION_PROPS = [
 const BUILDER_NAME = 'tags input';
 
 const builder = builderSchema(BUILDER_NAME, {
-	ids: tagInputIdParts,
 	title: 'createTags',
 	props: [
 		...OPTION_PROPS,

--- a/src/docs/data/builders/tooltip.ts
+++ b/src/docs/data/builders/tooltip.ts
@@ -1,6 +1,7 @@
 import { ATTRS, KBD, PROPS } from '$docs/constants.js';
 import type { KeyboardSchema } from '$docs/types.js';
 import { builderSchema, elementSchema } from '$docs/utils/index.js';
+import { tooltipIdParts } from '$lib';
 import { tooltipEvents } from '$lib/builders/tooltip/events.js';
 import type { BuilderData } from './index.js';
 
@@ -49,18 +50,9 @@ const OPTION_PROPS = [
 const BUILDER_NAME = 'tooltip';
 
 const builder = builderSchema(BUILDER_NAME, {
+	ids: tooltipIdParts,
 	title: 'createTooltip',
-	props: [
-		...OPTION_PROPS,
-		PROPS.DEFAULT_OPEN,
-		PROPS.OPEN,
-		PROPS.ON_OPEN_CHANGE,
-		{
-			name: 'ids',
-			type: 'Record<"content" | "trigger", string>',
-			description: 'Override the internally generated ids for the elements.',
-		},
-	],
+	props: [...OPTION_PROPS, PROPS.DEFAULT_OPEN, PROPS.OPEN, PROPS.ON_OPEN_CHANGE],
 	elements: [
 		{
 			name: 'trigger',

--- a/src/docs/data/builders/tooltip.ts
+++ b/src/docs/data/builders/tooltip.ts
@@ -50,7 +50,17 @@ const BUILDER_NAME = 'tooltip';
 
 const builder = builderSchema(BUILDER_NAME, {
 	title: 'createTooltip',
-	props: [...OPTION_PROPS, PROPS.DEFAULT_OPEN, PROPS.OPEN, PROPS.ON_OPEN_CHANGE],
+	props: [
+		...OPTION_PROPS,
+		PROPS.DEFAULT_OPEN,
+		PROPS.OPEN,
+		PROPS.ON_OPEN_CHANGE,
+		{
+			name: 'ids',
+			type: 'Record<"content" | "trigger", string>',
+			description: 'Override the internally generated ids for the elements.',
+		},
+	],
 	elements: [
 		{
 			name: 'trigger',

--- a/src/docs/data/builders/tree.ts
+++ b/src/docs/data/builders/tree.ts
@@ -1,22 +1,17 @@
 import { DESCRIPTIONS, KBD, PROPS } from '$docs/constants';
 import type { KeyboardSchema } from '$docs/types';
 import { builderSchema, elementSchema } from '$docs/utils';
+import { treeIdParts } from '$lib';
 import { treeEvents } from '$lib/builders/tree/events';
 import type { BuilderData } from '.';
 
 const BUILDER_NAME = 'tree-view';
 
 const builder = builderSchema(BUILDER_NAME, {
+	ids: treeIdParts,
 	title: 'createTreeViewBuilder',
 	description: DESCRIPTIONS.BUILDER('tree-view'),
-	props: [
-		PROPS.FORCE_VISIBLE,
-		{
-			name: 'ids',
-			type: 'Record<"tree", string>',
-			description: 'Override the internally generated ids for the elements.',
-		},
-	],
+	props: [PROPS.FORCE_VISIBLE],
 	elements: [
 		{
 			name: 'tree',

--- a/src/docs/data/builders/tree.ts
+++ b/src/docs/data/builders/tree.ts
@@ -1,14 +1,12 @@
 import { DESCRIPTIONS, KBD, PROPS } from '$docs/constants';
 import type { KeyboardSchema } from '$docs/types';
 import { builderSchema, elementSchema } from '$docs/utils';
-import { treeIdParts } from '$lib';
 import { treeEvents } from '$lib/builders/tree/events';
 import type { BuilderData } from '.';
 
 const BUILDER_NAME = 'tree-view';
 
 const builder = builderSchema(BUILDER_NAME, {
-	ids: treeIdParts,
 	title: 'createTreeViewBuilder',
 	description: DESCRIPTIONS.BUILDER('tree-view'),
 	props: [PROPS.FORCE_VISIBLE],

--- a/src/docs/data/builders/tree.ts
+++ b/src/docs/data/builders/tree.ts
@@ -9,7 +9,14 @@ const BUILDER_NAME = 'tree-view';
 const builder = builderSchema(BUILDER_NAME, {
 	title: 'createTreeViewBuilder',
 	description: DESCRIPTIONS.BUILDER('tree-view'),
-	props: [PROPS.FORCE_VISIBLE],
+	props: [
+		PROPS.FORCE_VISIBLE,
+		{
+			name: 'ids',
+			type: 'Record<"tree", string>',
+			description: 'Override the internally generated ids for the elements.',
+		},
+	],
 	elements: [
 		{
 			name: 'tree',

--- a/src/docs/types.ts
+++ b/src/docs/types.ts
@@ -126,6 +126,7 @@ export type APISchema = {
 	actions?: ReturnedProps;
 	options?: ReturnedProps;
 	returnedProps?: ReturnedProps;
+	ids?: ReturnedProps;
 };
 
 export type KeyboardSchema = Array<{

--- a/src/docs/utils/content.ts
+++ b/src/docs/utils/content.ts
@@ -56,7 +56,7 @@ function genIds(ids: string[] | readonly string[]): ReturnedProps {
 	return ids.map((id) => {
 		return {
 			name: id,
-			description: `The writable store that represents the id of the ${id} element.`,
+			description: `The writable store that represents the id of the \`${id}\` element.`,
 			type: 'Writable<string>',
 		};
 	});

--- a/src/lib/builders/accordion/create.ts
+++ b/src/lib/builders/accordion/create.ts
@@ -13,7 +13,7 @@ import {
 	toWritableStores,
 	type ChangeFn,
 	disabledAttr,
-	generateDefaultIds,
+	generateIds,
 } from '$lib/internal/helpers/index.js';
 import type { MeltActionReturn } from '$lib/internal/types.js';
 import { tick } from 'svelte';
@@ -41,7 +41,7 @@ export const createAccordion = <Multiple extends boolean = false>(
 		omit(withDefaults, 'value', 'onValueChange', 'defaultValue', 'ids')
 	);
 
-	const ids = { ...generateDefaultIds(idParts), ...withDefaults.ids };
+	const ids = { ...generateIds(idParts), ...withDefaults.ids };
 
 	const { disabled, forceVisible } = options;
 

--- a/src/lib/builders/accordion/create.ts
+++ b/src/lib/builders/accordion/create.ts
@@ -17,13 +17,13 @@ import {
 } from '$lib/internal/helpers/index.js';
 import type { MeltActionReturn } from '$lib/internal/types.js';
 import { tick } from 'svelte';
-import { derived, writable } from 'svelte/store';
+import { derived, get, writable } from 'svelte/store';
 import type { AccordionEvents } from './events.js';
 import type { AccordionHeadingProps, AccordionItemProps, CreateAccordionProps } from './types.js';
 
 type AccordionParts = 'trigger' | 'item' | 'content' | 'heading';
-const idParts = ['root'] as const;
-export type AccordionIdParts = (typeof idParts)[number];
+export const accordionIdParts = ['root'] as const;
+export type AccordionIdParts = typeof accordionIdParts;
 
 const { name, selector } = createElHelpers<AccordionParts>('accordion');
 
@@ -41,7 +41,7 @@ export const createAccordion = <Multiple extends boolean = false>(
 		omit(withDefaults, 'value', 'onValueChange', 'defaultValue', 'ids')
 	);
 
-	const ids = { ...generateIds(idParts), ...withDefaults.ids };
+	const ids = toWritableStores({ ...generateIds(accordionIdParts), ...withDefaults.ids });
 
 	const { disabled, forceVisible } = options;
 
@@ -63,8 +63,9 @@ export const createAccordion = <Multiple extends boolean = false>(
 	});
 
 	const root = builder(name(), {
-		returned: () => ({
-			'data-melt-id': ids.root,
+		stores: [ids.root],
+		returned: ([$rootId]) => ({
+			'data-melt-id': $rootId,
 		}),
 	});
 
@@ -139,7 +140,7 @@ export const createAccordion = <Multiple extends boolean = false>(
 					}
 
 					const el = e.target;
-					const rootEl = getElementByMeltId(ids.root);
+					const rootEl = getElementByMeltId(get(ids.root));
 					if (!rootEl || !isHTMLElement(el)) return;
 
 					const items = Array.from(rootEl.querySelectorAll(selector('trigger')));

--- a/src/lib/builders/accordion/create.ts
+++ b/src/lib/builders/accordion/create.ts
@@ -2,8 +2,10 @@ import {
 	addMeltEventListener,
 	builder,
 	createElHelpers,
+	disabledAttr,
 	executeCallbacks,
 	generateId,
+	generateIds,
 	getElementByMeltId,
 	isHTMLElement,
 	kbd,
@@ -12,18 +14,14 @@ import {
 	styleToString,
 	toWritableStores,
 	type ChangeFn,
-	disabledAttr,
-	generateIds,
 } from '$lib/internal/helpers/index.js';
 import type { MeltActionReturn } from '$lib/internal/types.js';
 import { tick } from 'svelte';
-import { derived, get, writable } from 'svelte/store';
+import { derived, writable } from 'svelte/store';
 import type { AccordionEvents } from './events.js';
 import type { AccordionHeadingProps, AccordionItemProps, CreateAccordionProps } from './types.js';
 
 type AccordionParts = 'trigger' | 'item' | 'content' | 'heading';
-export const accordionIdParts = ['root'] as const;
-export type AccordionIdParts = typeof accordionIdParts;
 
 const { name, selector } = createElHelpers<AccordionParts>('accordion');
 
@@ -37,11 +35,9 @@ export const createAccordion = <Multiple extends boolean = false>(
 	props?: CreateAccordionProps<Multiple>
 ) => {
 	const withDefaults = { ...defaults, ...props };
-	const options = toWritableStores(
-		omit(withDefaults, 'value', 'onValueChange', 'defaultValue', 'ids')
-	);
+	const options = toWritableStores(omit(withDefaults, 'value', 'onValueChange', 'defaultValue'));
 
-	const ids = toWritableStores({ ...generateIds(accordionIdParts), ...withDefaults.ids });
+	const meltIds = generateIds(['root']);
 
 	const { disabled, forceVisible } = options;
 
@@ -63,9 +59,8 @@ export const createAccordion = <Multiple extends boolean = false>(
 	});
 
 	const root = builder(name(), {
-		stores: [ids.root],
-		returned: ([$rootId]) => ({
-			'data-melt-id': $rootId,
+		returned: () => ({
+			'data-melt-id': meltIds.root,
 		}),
 	});
 
@@ -140,7 +135,7 @@ export const createAccordion = <Multiple extends boolean = false>(
 					}
 
 					const el = e.target;
-					const rootEl = getElementByMeltId(get(ids.root));
+					const rootEl = getElementByMeltId(meltIds.root);
 					if (!rootEl || !isHTMLElement(el)) return;
 
 					const items = Array.from(rootEl.querySelectorAll(selector('trigger')));
@@ -239,7 +234,7 @@ export const createAccordion = <Multiple extends boolean = false>(
 	}
 
 	return {
-		ids,
+		ids: meltIds,
 		elements: {
 			root,
 			item,

--- a/src/lib/builders/accordion/create.ts
+++ b/src/lib/builders/accordion/create.ts
@@ -13,6 +13,7 @@ import {
 	toWritableStores,
 	type ChangeFn,
 	disabledAttr,
+	generateDefaultIds,
 } from '$lib/internal/helpers/index.js';
 import type { MeltActionReturn } from '$lib/internal/types.js';
 import { tick } from 'svelte';
@@ -21,6 +22,9 @@ import type { AccordionEvents } from './events.js';
 import type { AccordionHeadingProps, AccordionItemProps, CreateAccordionProps } from './types.js';
 
 type AccordionParts = 'trigger' | 'item' | 'content' | 'heading';
+const idParts = ['root'] as const;
+export type AccordionIdParts = (typeof idParts)[number];
+
 const { name, selector } = createElHelpers<AccordionParts>('accordion');
 
 const defaults = {
@@ -33,7 +37,12 @@ export const createAccordion = <Multiple extends boolean = false>(
 	props?: CreateAccordionProps<Multiple>
 ) => {
 	const withDefaults = { ...defaults, ...props };
-	const options = toWritableStores(omit(withDefaults, 'value', 'onValueChange', 'defaultValue'));
+	const options = toWritableStores(
+		omit(withDefaults, 'value', 'onValueChange', 'defaultValue', 'ids')
+	);
+
+	const ids = { ...generateDefaultIds(idParts), ...withDefaults.ids };
+
 	const { disabled, forceVisible } = options;
 
 	const valueWritable = withDefaults.value ?? writable(withDefaults.defaultValue);
@@ -52,10 +61,6 @@ export const createAccordion = <Multiple extends boolean = false>(
 	const isSelectedStore = derived(value, ($value) => {
 		return (key: string) => isSelected(key, $value);
 	});
-
-	const ids = {
-		root: generateId(),
-	};
 
 	const root = builder(name(), {
 		returned: () => ({

--- a/src/lib/builders/accordion/types.ts
+++ b/src/lib/builders/accordion/types.ts
@@ -1,7 +1,7 @@
-import type { BuilderReturn, Expand, WhenTrue } from '$lib/internal/types.js';
+import type { ChangeFn, IdObj } from '$lib/internal/helpers/index.js';
+import type { BuilderReturn, WhenTrue } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
 import type { AccordionIdParts, createAccordion } from './create.js';
-import type { ChangeFn, IdObj } from '$lib/internal/helpers/index.js';
 export type { AccordionComponentEvents } from './events.js';
 
 type AccordionValue<Multiple extends boolean> = WhenTrue<Multiple, string[], string>;
@@ -55,7 +55,7 @@ export type CreateAccordionProps<Multiple extends boolean = false> = {
 	 * Optionally override the default ids we assign to the elements
 	 * that make up the accordion.
 	 */
-	ids?: Expand<IdObj<AccordionIdParts>>;
+	ids?: IdObj<AccordionIdParts>;
 };
 
 export type AccordionItemProps =

--- a/src/lib/builders/accordion/types.ts
+++ b/src/lib/builders/accordion/types.ts
@@ -1,7 +1,7 @@
-import type { ChangeFn, IdObj } from '$lib/internal/helpers/index.js';
+import type { ChangeFn } from '$lib/internal/helpers/index.js';
 import type { BuilderReturn, WhenTrue } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
-import type { AccordionIdParts, createAccordion } from './create.js';
+import type { createAccordion } from './create.js';
 export type { AccordionComponentEvents } from './events.js';
 
 type AccordionValue<Multiple extends boolean> = WhenTrue<Multiple, string[], string>;
@@ -50,12 +50,6 @@ export type CreateAccordionProps<Multiple extends boolean = false> = {
 	 * @see https://melt-ui.com/docs/controlled#change-functions
 	 */
 	onValueChange?: ChangeFn<AccordionValue<Multiple> | undefined>;
-
-	/**
-	 * Optionally override the default ids we assign to the elements
-	 * that make up the accordion.
-	 */
-	ids?: IdObj<AccordionIdParts>;
 };
 
 export type AccordionItemProps =

--- a/src/lib/builders/accordion/types.ts
+++ b/src/lib/builders/accordion/types.ts
@@ -1,7 +1,7 @@
-import type { BuilderReturn, WhenTrue } from '$lib/internal/types.js';
+import type { BuilderReturn, Expand, WhenTrue } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
-import type { createAccordion } from './create.js';
-import type { ChangeFn } from '$lib/internal/helpers/index.js';
+import type { AccordionIdParts, createAccordion } from './create.js';
+import type { ChangeFn, IdObj } from '$lib/internal/helpers/index.js';
 export type { AccordionComponentEvents } from './events.js';
 
 type AccordionValue<Multiple extends boolean> = WhenTrue<Multiple, string[], string>;
@@ -50,6 +50,12 @@ export type CreateAccordionProps<Multiple extends boolean = false> = {
 	 * @see https://melt-ui.com/docs/controlled#change-functions
 	 */
 	onValueChange?: ChangeFn<AccordionValue<Multiple> | undefined>;
+
+	/**
+	 * Optionally override the default ids we assign to the elements
+	 * that make up the accordion.
+	 */
+	ids?: Expand<IdObj<AccordionIdParts>>;
 };
 
 export type AccordionItemProps =

--- a/src/lib/builders/context-menu/create.ts
+++ b/src/lib/builders/context-menu/create.ts
@@ -15,6 +15,7 @@ import {
 	isLeftClick,
 	kbd,
 	noop,
+	omit,
 	overridable,
 	styleToString,
 	toWritableStores,
@@ -60,7 +61,7 @@ const { name, selector } = createElHelpers<_MenuParts>('context-menu');
 export function createContextMenu(props?: CreateContextMenuProps) {
 	const withDefaults = { ...defaults, ...props } satisfies CreateContextMenuProps;
 
-	const rootOptions = toWritableStores(withDefaults);
+	const rootOptions = toWritableStores(omit(withDefaults, 'ids'));
 	const { positioning, closeOnOutsideClick, portal, forceVisible, closeOnEscape, loop } =
 		rootOptions;
 
@@ -89,6 +90,7 @@ export function createContextMenu(props?: CreateContextMenuProps) {
 		prevFocusable,
 		selector: 'context-menu',
 		removeScroll: true,
+		ids: withDefaults.ids,
 	});
 
 	const point = writable<Point | null>(null);

--- a/src/lib/builders/dialog/create.ts
+++ b/src/lib/builders/dialog/create.ts
@@ -123,13 +123,13 @@ export function createDialog(props?: CreateDialogProps) {
 	});
 
 	const trigger = builder(name('trigger'), {
-		stores: open,
-		returned: ($open) => {
+		stores: [open, ids.trigger, ids.content],
+		returned: ([$open, $triggerId, $contentId]) => {
 			return {
-				id: ids.trigger,
+				id: $triggerId,
 				'aria-haspopup': 'dialog',
 				'aria-expanded': $open,
-				'aria-controls': ids.content,
+				'aria-controls': $contentId,
 				type: 'button',
 			} as const;
 		},
@@ -187,13 +187,13 @@ export function createDialog(props?: CreateDialogProps) {
 	});
 
 	const content = builder(name('content'), {
-		stores: [isVisible],
-		returned: ([$isVisible]) => {
+		stores: [isVisible, ids.content, ids.description, ids.title],
+		returned: ([$isVisible, $contentId, $descriptionId, $titleId]) => {
 			return {
-				id: ids.content,
+				id: $contentId,
 				role: get(role),
-				'aria-describedby': ids.description,
-				'aria-labelledby': ids.title,
+				'aria-describedby': $descriptionId,
+				'aria-labelledby': $titleId,
 				'data-state': $isVisible ? 'open' : 'closed',
 				tabindex: -1,
 				hidden: $isVisible ? undefined : true,
@@ -299,14 +299,16 @@ export function createDialog(props?: CreateDialogProps) {
 	});
 
 	const title = builder(name('title'), {
-		returned: () => ({
-			id: ids.title,
+		stores: [ids.title],
+		returned: ([$titleId]) => ({
+			id: $titleId,
 		}),
 	});
 
 	const description = builder(name('description'), {
-		returned: () => ({
-			id: ids.description,
+		stores: [ids.description],
+		returned: ([$descriptionId]) => ({
+			id: $descriptionId,
 		}),
 	});
 

--- a/src/lib/builders/dialog/create.ts
+++ b/src/lib/builders/dialog/create.ts
@@ -55,8 +55,8 @@ const defaults = {
 
 const openDialogIds = writable<string[]>([]);
 
-const idParts = ['content', 'title', 'description', 'trigger'] as const;
-export type DialogIdParts = (typeof idParts)[number];
+export const dialogIdParts = ['content', 'title', 'description', 'trigger'] as const;
+export type DialogIdParts = typeof dialogIdParts;
 
 export function createDialog(props?: CreateDialogProps) {
 	const withDefaults = { ...defaults, ...props } satisfies CreateDialogProps;
@@ -76,10 +76,10 @@ export function createDialog(props?: CreateDialogProps) {
 
 	const activeTrigger = writable<HTMLElement | null>(null);
 
-	const ids = {
-		...generateIds(idParts),
+	const ids = toWritableStores({
+		...generateIds(dialogIdParts),
 		...withDefaults.ids,
-	};
+	});
 
 	const openWritable = withDefaults.open ?? writable(withDefaults.defaultOpen);
 	const open = overridable(openWritable, withDefaults?.onOpenChange);
@@ -97,7 +97,7 @@ export function createDialog(props?: CreateDialogProps) {
 
 	function handleClose() {
 		open.set(false);
-		const triggerEl = document.getElementById(ids.trigger);
+		const triggerEl = document.getElementById(get(ids.trigger));
 		handleFocus({
 			prop: get(closeFocus),
 			defaultEl: triggerEl,
@@ -105,7 +105,7 @@ export function createDialog(props?: CreateDialogProps) {
 	}
 
 	onMount(() => {
-		activeTrigger.set(document.getElementById(ids.trigger));
+		activeTrigger.set(document.getElementById(get(ids.trigger)));
 	});
 
 	effect([open], ([$open]) => {
@@ -113,11 +113,11 @@ export function createDialog(props?: CreateDialogProps) {
 		sleep(100).then(() => {
 			if ($open) {
 				openDialogIds.update((prev) => {
-					prev.push(ids.content);
+					prev.push(get(ids.content));
 					return prev;
 				});
 			} else {
-				openDialogIds.update((prev) => prev.filter((id) => id !== ids.content));
+				openDialogIds.update((prev) => prev.filter((id) => id !== get(ids.content)));
 			}
 		});
 	});
@@ -235,7 +235,7 @@ export function createDialog(props?: CreateDialogProps) {
 							if (e.defaultPrevented) return;
 
 							const $openDialogIds = get(openDialogIds);
-							const isLast = last($openDialogIds) === ids.content;
+							const isLast = last($openDialogIds) === get(ids.content);
 							if ($closeOnOutsideClick && isLast) {
 								handleClose();
 							}
@@ -340,7 +340,7 @@ export function createDialog(props?: CreateDialogProps) {
 		if ($preventScroll && $open) unsubs.push(removeScroll());
 
 		if ($open) {
-			const contentEl = document.getElementById(ids.content);
+			const contentEl = document.getElementById(get(ids.content));
 			handleFocus({ prop: get(openFocus), defaultEl: contentEl });
 		}
 

--- a/src/lib/builders/dialog/create.ts
+++ b/src/lib/builders/dialog/create.ts
@@ -22,7 +22,7 @@ import {
 	styleToString,
 	toWritableStores,
 	handleFocus,
-	generateDefaultIds,
+	generateIds,
 } from '$lib/internal/helpers/index.js';
 import type { Defaults, MeltActionReturn } from '$lib/internal/types.js';
 import { onMount, tick } from 'svelte';
@@ -77,7 +77,7 @@ export function createDialog(props?: CreateDialogProps) {
 	const activeTrigger = writable<HTMLElement | null>(null);
 
 	const ids = {
-		...generateDefaultIds(idParts),
+		...generateIds(idParts),
 		...withDefaults.ids,
 	};
 

--- a/src/lib/builders/dialog/create.ts
+++ b/src/lib/builders/dialog/create.ts
@@ -10,7 +10,6 @@ import {
 	createElHelpers,
 	effect,
 	executeCallbacks,
-	generateId,
 	getPortalDestination,
 	isBrowser,
 	isHTMLElement,
@@ -23,12 +22,14 @@ import {
 	styleToString,
 	toWritableStores,
 	handleFocus,
+	generateDefaultIds,
 } from '$lib/internal/helpers/index.js';
 import type { Defaults, MeltActionReturn } from '$lib/internal/types.js';
 import { onMount, tick } from 'svelte';
 import { derived, get, writable } from 'svelte/store';
 import type { DialogEvents } from './events.js';
 import type { CreateDialogProps } from './types.js';
+import { omit } from '../../internal/helpers/object';
 
 type DialogParts =
 	| 'trigger'
@@ -54,10 +55,14 @@ const defaults = {
 
 const openDialogIds = writable<string[]>([]);
 
+const idParts = ['content', 'title', 'description', 'trigger'] as const;
+export type DialogIdParts = (typeof idParts)[number];
+
 export function createDialog(props?: CreateDialogProps) {
 	const withDefaults = { ...defaults, ...props } satisfies CreateDialogProps;
 
-	const options = toWritableStores(withDefaults);
+	const options = toWritableStores(omit(withDefaults, 'ids'));
+
 	const {
 		preventScroll,
 		closeOnEscape,
@@ -72,10 +77,8 @@ export function createDialog(props?: CreateDialogProps) {
 	const activeTrigger = writable<HTMLElement | null>(null);
 
 	const ids = {
-		content: generateId(),
-		title: generateId(),
-		description: generateId(),
-		trigger: generateId(),
+		...generateDefaultIds(idParts),
+		...withDefaults.ids,
 	};
 
 	const openWritable = withDefaults.open ?? writable(withDefaults.defaultOpen);

--- a/src/lib/builders/dialog/types.ts
+++ b/src/lib/builders/dialog/types.ts
@@ -1,7 +1,7 @@
-import type { BuilderReturn, Expand } from '$lib/internal/types.js';
+import type { ChangeFn, FocusProp, IdObj } from '$lib/internal/helpers/index.js';
+import type { BuilderReturn } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
 import type { DialogIdParts, createDialog } from './create.js';
-import type { ChangeFn, FocusProp, IdObj } from '$lib/internal/helpers/index.js';
 export type { DialogComponentEvents } from './events.js';
 export type CreateDialogProps = {
 	preventScroll?: boolean;
@@ -35,7 +35,7 @@ export type CreateDialogProps = {
 	/**
 	 * Optionally override the default ids we assign to the elements
 	 */
-	ids?: Expand<IdObj<DialogIdParts>>;
+	ids?: IdObj<DialogIdParts>;
 };
 
 export type Dialog = BuilderReturn<typeof createDialog>;

--- a/src/lib/builders/dialog/types.ts
+++ b/src/lib/builders/dialog/types.ts
@@ -1,7 +1,7 @@
-import type { BuilderReturn } from '$lib/internal/types.js';
+import type { BuilderReturn, Expand } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
-import type { createDialog } from './create.js';
-import type { ChangeFn, FocusProp } from '$lib/internal/helpers/index.js';
+import type { DialogIdParts, createDialog } from './create.js';
+import type { ChangeFn, FocusProp, IdObj } from '$lib/internal/helpers/index.js';
 export type { DialogComponentEvents } from './events.js';
 export type CreateDialogProps = {
 	preventScroll?: boolean;
@@ -31,6 +31,11 @@ export type CreateDialogProps = {
 	 * on close.
 	 */
 	closeFocus?: FocusProp;
+
+	/**
+	 * Optionally override the default ids we assign to the elements
+	 */
+	ids?: Expand<IdObj<DialogIdParts>>;
 };
 
 export type Dialog = BuilderReturn<typeof createDialog>;

--- a/src/lib/builders/dropdown-menu/create.ts
+++ b/src/lib/builders/dropdown-menu/create.ts
@@ -2,6 +2,7 @@ import { overridable, toWritableStores } from '$lib/internal/helpers/index.js';
 import { writable } from 'svelte/store';
 import { createMenuBuilder } from '../menu/index.js';
 import type { CreateDropdownMenuProps } from './types.js';
+import { omit } from '../../internal/helpers/object';
 
 const defaults = {
 	arrowSize: 8,
@@ -24,7 +25,7 @@ const defaults = {
 export function createDropdownMenu(props?: CreateDropdownMenuProps) {
 	const withDefaults = { ...defaults, ...props } satisfies CreateDropdownMenuProps;
 
-	const rootOptions = toWritableStores(withDefaults);
+	const rootOptions = toWritableStores(omit(withDefaults, 'ids'));
 
 	const openWritable = withDefaults.open ?? writable(withDefaults.defaultOpen);
 	const rootOpen = overridable(openWritable, withDefaults?.onOpenChange);
@@ -53,6 +54,7 @@ export function createDropdownMenu(props?: CreateDropdownMenuProps) {
 		prevFocusable,
 		selector: 'dropdown-menu',
 		removeScroll: true,
+		ids: withDefaults.ids,
 	});
 
 	return {

--- a/src/lib/builders/link-preview/create.ts
+++ b/src/lib/builders/link-preview/create.ts
@@ -24,7 +24,7 @@ import { onMount } from 'svelte';
 import { derived, get, writable, type Readable } from 'svelte/store';
 import type { LinkPreviewEvents } from './events.js';
 import type { CreateLinkPreviewProps } from './types.js';
-import { generateDefaultIds } from '../../internal/helpers/id';
+import { generateIds } from '../../internal/helpers/id';
 import { omit } from '../../internal/helpers/object';
 
 type LinkPreviewParts = 'trigger' | 'content' | 'arrow';
@@ -73,7 +73,7 @@ export function createLinkPreview(props: CreateLinkPreviewProps = {}) {
 		closeOnEscape,
 	} = options;
 
-	const ids = { ...generateDefaultIds(idParts), ...withDefaults.ids };
+	const ids = { ...generateIds(idParts), ...withDefaults.ids };
 	let timeout: number | null = null;
 	let originalBodyUserSelect: string;
 

--- a/src/lib/builders/link-preview/create.ts
+++ b/src/lib/builders/link-preview/create.ts
@@ -6,7 +6,6 @@ import {
 	derivedVisible,
 	effect,
 	executeCallbacks,
-	generateId,
 	getPortalDestination,
 	getTabbableNodes,
 	isBrowser,
@@ -25,6 +24,8 @@ import { onMount } from 'svelte';
 import { derived, get, writable, type Readable } from 'svelte/store';
 import type { LinkPreviewEvents } from './events.js';
 import type { CreateLinkPreviewProps } from './types.js';
+import { generateDefaultIds } from '../../internal/helpers/id';
+import { omit } from '../../internal/helpers/object';
 
 type LinkPreviewParts = 'trigger' | 'content' | 'arrow';
 const { name } = createElHelpers<LinkPreviewParts>('hover-card');
@@ -43,6 +44,9 @@ const defaults = {
 	closeOnEscape: true,
 } satisfies CreateLinkPreviewProps;
 
+const idParts = ['trigger', 'content'] as const;
+export type LinkPreviewIdParts = (typeof idParts)[number];
+
 export function createLinkPreview(props: CreateLinkPreviewProps = {}) {
 	const withDefaults = { ...defaults, ...props } satisfies CreateLinkPreviewProps;
 
@@ -56,7 +60,7 @@ export function createLinkPreview(props: CreateLinkPreviewProps = {}) {
 	// type OpenReason = 'pointer' | 'focus';
 	// const openReason = writable<null | OpenReason>(null);
 
-	const options = toWritableStores(withDefaults);
+	const options = toWritableStores(omit(withDefaults, 'ids'));
 
 	const {
 		openDelay,
@@ -69,11 +73,7 @@ export function createLinkPreview(props: CreateLinkPreviewProps = {}) {
 		closeOnEscape,
 	} = options;
 
-	const ids = {
-		content: generateId(),
-		trigger: generateId(),
-	};
-
+	const ids = { ...generateDefaultIds(idParts), ...withDefaults.ids };
 	let timeout: number | null = null;
 	let originalBodyUserSelect: string;
 

--- a/src/lib/builders/link-preview/create.ts
+++ b/src/lib/builders/link-preview/create.ts
@@ -22,18 +22,18 @@ import {
 import type { MeltActionReturn } from '$lib/internal/types.js';
 import { onMount } from 'svelte';
 import { derived, get, writable, type Readable } from 'svelte/store';
-import type { LinkPreviewEvents } from './events.js';
-import type { CreateLinkPreviewProps } from './types.js';
 import { generateIds } from '../../internal/helpers/id';
 import { omit } from '../../internal/helpers/object';
+import type { LinkPreviewEvents } from './events.js';
+import type { CreateLinkPreviewProps } from './types.js';
 
 type LinkPreviewParts = 'trigger' | 'content' | 'arrow';
 const { name } = createElHelpers<LinkPreviewParts>('hover-card');
 
 const defaults = {
 	defaultOpen: false,
-	openDelay: 700,
-	closeDelay: 300,
+	openDelay: 1000,
+	closeDelay: 100,
 	positioning: {
 		placement: 'bottom',
 	},
@@ -44,8 +44,8 @@ const defaults = {
 	closeOnEscape: true,
 } satisfies CreateLinkPreviewProps;
 
-const idParts = ['trigger', 'content'] as const;
-export type LinkPreviewIdParts = (typeof idParts)[number];
+export const linkPreviewIdParts = ['trigger', 'content'] as const;
+export type LinkPreviewIdParts = typeof linkPreviewIdParts;
 
 export function createLinkPreview(props: CreateLinkPreviewProps = {}) {
 	const withDefaults = { ...defaults, ...props } satisfies CreateLinkPreviewProps;
@@ -73,7 +73,7 @@ export function createLinkPreview(props: CreateLinkPreviewProps = {}) {
 		closeOnEscape,
 	} = options;
 
-	const ids = { ...generateIds(idParts), ...withDefaults.ids };
+	const ids = toWritableStores({ ...generateIds(linkPreviewIdParts), ...withDefaults.ids });
 	let timeout: number | null = null;
 	let originalBodyUserSelect: string;
 
@@ -108,15 +108,15 @@ export function createLinkPreview(props: CreateLinkPreviewProps = {}) {
 	) as Readable<() => void>;
 
 	const trigger = builder(name('trigger'), {
-		stores: [open],
-		returned: ([$open]) => {
+		stores: [open, ids.trigger, ids.content],
+		returned: ([$open, $triggerId, $contentId]) => {
 			return {
 				role: 'button' as const,
 				'aria-haspopup': 'dialog' as const,
 				'aria-expanded': $open,
 				'data-state': $open ? 'open' : 'closed',
-				'aria-controls': ids.content,
-				id: ids.trigger,
+				'aria-controls': $contentId,
+				id: $triggerId,
 			};
 		},
 		action: (node: HTMLElement): MeltActionReturn<LinkPreviewEvents['trigger']> => {
@@ -145,8 +145,8 @@ export function createLinkPreview(props: CreateLinkPreviewProps = {}) {
 	const isVisible = derivedVisible({ open, forceVisible, activeTrigger });
 
 	const content = builder(name('content'), {
-		stores: [isVisible, portal],
-		returned: ([$isVisible, $portal]) => {
+		stores: [isVisible, portal, ids.content],
+		returned: ([$isVisible, $portal, $contentId]) => {
 			return {
 				hidden: $isVisible ? undefined : true,
 				tabindex: -1,
@@ -156,7 +156,7 @@ export function createLinkPreview(props: CreateLinkPreviewProps = {}) {
 					userSelect: 'text',
 					WebkitUserSelect: 'text',
 				}),
-				id: ids.content,
+				id: $contentId,
 				'data-state': $isVisible ? 'open' : 'closed',
 				'data-portal': $portal ? '' : undefined,
 			};
@@ -255,7 +255,7 @@ export function createLinkPreview(props: CreateLinkPreviewProps = {}) {
 	effect([containSelection], ([$containSelection]) => {
 		if (!isBrowser || !$containSelection) return;
 		const body = document.body;
-		const contentElement = document.getElementById(ids.content);
+		const contentElement = document.getElementById(get(ids.content));
 		if (!contentElement) return;
 		// prefix for safari
 		originalBodyUserSelect = body.style.userSelect || body.style.webkitUserSelect;
@@ -275,7 +275,7 @@ export function createLinkPreview(props: CreateLinkPreviewProps = {}) {
 	});
 
 	onMount(() => {
-		const triggerEl = document.getElementById(ids.trigger);
+		const triggerEl = document.getElementById(get(ids.trigger));
 		if (!triggerEl) return;
 		activeTrigger.set(triggerEl);
 	});
@@ -300,7 +300,7 @@ export function createLinkPreview(props: CreateLinkPreviewProps = {}) {
 
 		document.addEventListener('pointerup', handlePointerUp);
 
-		const contentElement = document.getElementById(ids.content);
+		const contentElement = document.getElementById(get(ids.content));
 		if (!contentElement) return;
 		const tabbables = getTabbableNodes(contentElement);
 		tabbables.forEach((tabbable) => tabbable.setAttribute('tabindex', '-1'));

--- a/src/lib/builders/link-preview/types.ts
+++ b/src/lib/builders/link-preview/types.ts
@@ -1,8 +1,8 @@
 import type { FloatingConfig } from '$lib/internal/actions/index.js';
-import type { BuilderReturn, Expand } from '$lib/internal/types.js';
+import type { ChangeFn, IdObj } from '$lib/internal/helpers/index.js';
+import type { BuilderReturn } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
 import type { LinkPreviewIdParts, createLinkPreview } from './create.js';
-import type { ChangeFn, IdObj } from '$lib/internal/helpers/index.js';
 export type { LinkPreviewComponentEvents } from './events.js';
 export type CreateLinkPreviewProps = {
 	/**
@@ -92,7 +92,7 @@ export type CreateLinkPreviewProps = {
 	/**
 	 * Optionally override the default ids we assign to the elements
 	 */
-	ids?: Expand<IdObj<LinkPreviewIdParts>>;
+	ids?: IdObj<LinkPreviewIdParts>;
 };
 
 export type LinkPreview = BuilderReturn<typeof createLinkPreview>;

--- a/src/lib/builders/link-preview/types.ts
+++ b/src/lib/builders/link-preview/types.ts
@@ -1,8 +1,8 @@
 import type { FloatingConfig } from '$lib/internal/actions/index.js';
-import type { BuilderReturn } from '$lib/internal/types.js';
+import type { BuilderReturn, Expand } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
-import type { createLinkPreview } from './create.js';
-import type { ChangeFn } from '$lib/internal/helpers/index.js';
+import type { LinkPreviewIdParts, createLinkPreview } from './create.js';
+import type { ChangeFn, IdObj } from '$lib/internal/helpers/index.js';
 export type { LinkPreviewComponentEvents } from './events.js';
 export type CreateLinkPreviewProps = {
 	/**
@@ -88,6 +88,11 @@ export type CreateLinkPreviewProps = {
 	 * @default 'body'
 	 */
 	portal?: HTMLElement | string | null;
+
+	/**
+	 * Optionally override the default ids we assign to the elements
+	 */
+	ids?: Expand<IdObj<LinkPreviewIdParts>>;
 };
 
 export type LinkPreview = BuilderReturn<typeof createLinkPreview>;

--- a/src/lib/builders/listbox/create.ts
+++ b/src/lib/builders/listbox/create.ts
@@ -41,6 +41,7 @@ import { onMount, tick } from 'svelte';
 import { derived, get, writable, type Readable } from 'svelte/store';
 import { createLabel } from '../label/create.js';
 import type { ListboxEvents } from './events.js';
+import { generateDefaultIds } from '../../internal/helpers/id';
 import type {
 	CreateListboxProps,
 	ListboxOption,
@@ -71,6 +72,9 @@ const defaults = {
 	typeahead: true,
 	highlightOnHover: true,
 } satisfies Defaults<CreateListboxProps<unknown>>;
+
+const idParts = ['trigger', 'menu', 'label'] as const;
+export type ListboxIdParts = (typeof idParts)[number];
 
 /**
  * Creates an ARIA-1.2-compliant listbox.
@@ -105,7 +109,7 @@ export function createListbox<
 	const open = overridable(openWritable, withDefaults?.onOpenChange);
 
 	const options = toWritableStores({
-		...omit(withDefaults, 'open', 'defaultOpen', 'builder'),
+		...omit(withDefaults, 'open', 'defaultOpen', 'builder', 'ids'),
 		multiple: withDefaults.multiple ?? (false as Multiple),
 	});
 
@@ -128,11 +132,7 @@ export function createListbox<
 	} = options;
 	const { name, selector } = createElHelpers(withDefaults.builder);
 
-	const ids = {
-		trigger: generateId(),
-		menu: generateId(),
-		label: generateId(),
-	};
+	const ids = { ...generateDefaultIds(idParts), ...withDefaults.ids };
 
 	const { handleTypeaheadSearch } = createTypeaheadSearch({
 		onMatch: (element) => {

--- a/src/lib/builders/listbox/create.ts
+++ b/src/lib/builders/listbox/create.ts
@@ -41,7 +41,7 @@ import { onMount, tick } from 'svelte';
 import { derived, get, writable, type Readable } from 'svelte/store';
 import { createLabel } from '../label/create.js';
 import type { ListboxEvents } from './events.js';
-import { generateDefaultIds } from '../../internal/helpers/id';
+import { generateIds } from '../../internal/helpers/id';
 import type {
 	CreateListboxProps,
 	ListboxOption,
@@ -132,7 +132,7 @@ export function createListbox<
 	} = options;
 	const { name, selector } = createElHelpers(withDefaults.builder);
 
-	const ids = { ...generateDefaultIds(idParts), ...withDefaults.ids };
+	const ids = { ...generateIds(idParts), ...withDefaults.ids };
 
 	const { handleTypeaheadSearch } = createTypeaheadSearch({
 		onMatch: (element) => {

--- a/src/lib/builders/listbox/create.ts
+++ b/src/lib/builders/listbox/create.ts
@@ -14,7 +14,6 @@ import {
 	executeCallbacks,
 	forward,
 	generateId,
-	getElementByMeltId,
 	getOptions,
 	getPortalDestination,
 	hiddenInputAttrs,
@@ -39,9 +38,9 @@ import type { Defaults, MeltActionReturn } from '$lib/internal/types.js';
 import { dequal as deepEqual } from 'dequal';
 import { onMount, tick } from 'svelte';
 import { derived, get, writable, type Readable } from 'svelte/store';
+import { generateIds } from '../../internal/helpers/id';
 import { createLabel } from '../label/create.js';
 import type { ListboxEvents } from './events.js';
-import { generateIds } from '../../internal/helpers/id';
 import type {
 	CreateListboxProps,
 	ListboxOption,
@@ -190,7 +189,7 @@ export function createListbox<
 	async function openMenu() {
 		open.set(true);
 
-		const triggerEl = getElementByMeltId(get(ids.trigger));
+		const triggerEl = document.getElementById(get(ids.trigger));
 		if (!triggerEl) return;
 
 		// The active trigger is used to anchor the menu to the input element.
@@ -261,7 +260,6 @@ export function createListbox<
 				'aria-controls': $menuId,
 				'aria-expanded': $open,
 				'aria-labelledby': $labelId,
-				'data-melt-id': $triggerId,
 				// autocomplete: 'off',
 				id: $triggerId,
 				role: 'combobox',
@@ -627,7 +625,7 @@ export function createListbox<
 		const menuEl = document.getElementById(get(ids.menu));
 		if (!menuEl) return;
 
-		const triggerEl = getElementByMeltId(get(ids.trigger));
+		const triggerEl = document.getElementById(get(ids.trigger));
 		if (triggerEl) {
 			activeTrigger.set(triggerEl);
 		}

--- a/src/lib/builders/listbox/types.ts
+++ b/src/lib/builders/listbox/types.ts
@@ -1,8 +1,8 @@
-import type { BuilderReturn, Expand, WhenTrue } from '$lib/internal/types.js';
+import type { FloatingConfig } from '$lib/internal/actions/index.js';
 import type { ChangeFn, IdObj } from '$lib/internal/helpers/index.js';
+import type { BuilderReturn, WhenTrue } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
 import type { ListboxIdParts, createListbox } from './create.js';
-import type { FloatingConfig } from '$lib/internal/actions/index.js';
 export type { ListboxComponentEvents } from './events.js';
 
 export type ListboxOption<Value = unknown> = {
@@ -162,7 +162,7 @@ export type CreateListboxProps<
 	/**
 	 * Optionally override the default ids we assign to the elements
 	 */
-	ids?: Expand<IdObj<ListboxIdParts>>;
+	ids?: IdObj<ListboxIdParts>;
 };
 
 export type ListboxOptionProps<Value = unknown> = ListboxOption<Value> & {

--- a/src/lib/builders/listbox/types.ts
+++ b/src/lib/builders/listbox/types.ts
@@ -1,7 +1,7 @@
-import type { BuilderReturn, WhenTrue } from '$lib/internal/types.js';
-import type { ChangeFn } from '$lib/internal/helpers/index.js';
+import type { BuilderReturn, Expand, WhenTrue } from '$lib/internal/types.js';
+import type { ChangeFn, IdObj } from '$lib/internal/helpers/index.js';
 import type { Writable } from 'svelte/store';
-import type { createListbox } from './create.js';
+import type { ListboxIdParts, createListbox } from './create.js';
 import type { FloatingConfig } from '$lib/internal/actions/index.js';
 export type { ListboxComponentEvents } from './events.js';
 
@@ -158,6 +158,11 @@ export type CreateListboxProps<
 	 * @default true
 	 */
 	highlightOnHover?: boolean;
+
+	/**
+	 * Optionally override the default ids we assign to the elements
+	 */
+	ids?: Expand<IdObj<ListboxIdParts>>;
 };
 
 export type ListboxOptionProps<Value = unknown> = ListboxOption<Value> & {

--- a/src/lib/builders/menu/create.ts
+++ b/src/lib/builders/menu/create.ts
@@ -14,7 +14,7 @@ import {
 	disabledAttr,
 	effect,
 	executeCallbacks,
-	generateDefaultIds,
+	generateIds,
 	getNextFocusable,
 	getPortalDestination,
 	getPreviousFocusable,
@@ -139,7 +139,7 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 
 	const { typed, handleTypeaheadSearch } = createTypeaheadSearch();
 
-	const rootIds = { ...generateDefaultIds(idParts), ...opts.ids };
+	const rootIds = { ...generateIds(idParts), ...opts.ids };
 
 	const isVisible = derivedVisible({
 		open: rootOpen,
@@ -650,7 +650,7 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 		const subOpenTimer = writable<number | null>(null);
 		const pointerGraceTimer = writable(0);
 
-		const subIds = { ...generateDefaultIds(idParts), ...withDefaults.ids };
+		const subIds = { ...generateIds(idParts), ...withDefaults.ids };
 
 		onMount(() => {
 			/**

--- a/src/lib/builders/menu/create.ts
+++ b/src/lib/builders/menu/create.ts
@@ -14,7 +14,7 @@ import {
 	disabledAttr,
 	effect,
 	executeCallbacks,
-	generateId,
+	generateDefaultIds,
 	getNextFocusable,
 	getPortalDestination,
 	getPreviousFocusable,
@@ -56,6 +56,9 @@ export const SUB_CLOSE_KEYS: Record<TextDirection, string[]> = {
 	ltr: [kbd.ARROW_LEFT],
 	rtl: [kbd.ARROW_RIGHT],
 };
+
+const idParts = ['menu', 'trigger'] as const;
+export type _MenuIdParts = (typeof idParts)[number];
 
 const defaults = {
 	arrowSize: 8,
@@ -136,10 +139,7 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 
 	const { typed, handleTypeaheadSearch } = createTypeaheadSearch();
 
-	const rootIds = {
-		menu: generateId(),
-		trigger: generateId(),
-	};
+	const rootIds = { ...generateDefaultIds(idParts), ...opts.ids };
 
 	const isVisible = derivedVisible({
 		open: rootOpen,
@@ -650,10 +650,7 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 		const subOpenTimer = writable<number | null>(null);
 		const pointerGraceTimer = writable(0);
 
-		const subIds = {
-			menu: generateId(),
-			trigger: generateId(),
-		};
+		const subIds = { ...generateDefaultIds(idParts), ...withDefaults.ids };
 
 		onMount(() => {
 			/**

--- a/src/lib/builders/menu/types.ts
+++ b/src/lib/builders/menu/types.ts
@@ -1,8 +1,8 @@
 import type { FloatingConfig } from '$lib/internal/actions/index.js';
 import type { TextDirection } from '$lib/internal/types.js';
-import type { ChangeFn, FocusProp } from '$lib/internal/helpers/index.js';
+import type { ChangeFn, FocusProp, IdObj } from '$lib/internal/helpers/index.js';
 import type { Writable } from 'svelte/store';
-import type { createMenuBuilder } from './create.js';
+import type { _MenuIdParts, createMenuBuilder } from './create.js';
 
 export type _CreateMenuProps = {
 	/**
@@ -110,11 +110,16 @@ export type _CreateMenuProps = {
 	 * Optionally prevent focusing the first item in the menu
 	 */
 	disableFocusFirstItem?: boolean;
+
+	/**
+	 * Optionally override the default ids we assign to the elements
+	 */
+	ids?: Expand<IdObj<_MenuIdParts>>;
 };
 
 export type _CreateSubmenuProps = Pick<
 	_CreateMenuProps,
-	'arrowSize' | 'positioning' | 'open' | 'onOpenChange'
+	'arrowSize' | 'positioning' | 'open' | 'onOpenChange' | 'ids'
 > & {
 	disabled?: boolean;
 };
@@ -178,6 +183,8 @@ export type _MenuBuilderOptions = {
 	 * rather than in the menu builder factory.
 	 */
 	removeScroll: boolean;
+
+	ids?: Expand<IdObj<_MenuIdParts>>;
 };
 
 export type _MenuParts =

--- a/src/lib/builders/menu/types.ts
+++ b/src/lib/builders/menu/types.ts
@@ -114,7 +114,7 @@ export type _CreateMenuProps = {
 	/**
 	 * Optionally override the default ids we assign to the elements
 	 */
-	ids?: Expand<IdObj<_MenuIdParts>>;
+	ids?: IdObj<_MenuIdParts>;
 };
 
 export type _CreateSubmenuProps = Pick<

--- a/src/lib/builders/menubar/create.ts
+++ b/src/lib/builders/menubar/create.ts
@@ -38,7 +38,7 @@ import type { MeltActionReturn } from '$lib/internal/types.js';
 import type { CreateMenubarMenuProps, CreateMenubarProps } from './types.js';
 import type { MenubarEvents } from './events.js';
 import { omit } from '../../internal/helpers/object';
-import { generateDefaultIds } from '../../internal/helpers/id';
+import { generateIds } from '../../internal/helpers/id';
 
 const MENUBAR_NAV_KEYS = [kbd.ARROW_LEFT, kbd.ARROW_RIGHT, kbd.HOME, kbd.END];
 
@@ -65,7 +65,7 @@ export function createMenubar(props?: CreateMenubarProps) {
 	const closeTimer = writable(0);
 	let scrollRemoved = false;
 
-	const ids = { ...generateDefaultIds(idParts), ...withDefaults.ids };
+	const ids = { ...generateIds(idParts), ...withDefaults.ids };
 
 	const menubar = builder(name(), {
 		returned() {

--- a/src/lib/builders/menubar/create.ts
+++ b/src/lib/builders/menubar/create.ts
@@ -18,7 +18,6 @@ import {
 	effect,
 	styleToString,
 	noop,
-	generateId,
 	isBrowser,
 	getNextFocusable,
 	getPreviousFocusable,
@@ -38,6 +37,8 @@ import { usePopper } from '$lib/internal/actions/index.js';
 import type { MeltActionReturn } from '$lib/internal/types.js';
 import type { CreateMenubarMenuProps, CreateMenubarProps } from './types.js';
 import type { MenubarEvents } from './events.js';
+import { omit } from '../../internal/helpers/object';
+import { generateDefaultIds } from '../../internal/helpers/id';
 
 const MENUBAR_NAV_KEYS = [kbd.ARROW_LEFT, kbd.ARROW_RIGHT, kbd.HOME, kbd.END];
 
@@ -48,10 +49,13 @@ const defaults = {
 	closeOnEscape: true,
 } satisfies CreateMenubarProps;
 
+const idParts = ['menubar'] as const;
+export type MenubarIdParts = (typeof idParts)[number];
+
 export function createMenubar(props?: CreateMenubarProps) {
 	const withDefaults = { ...defaults, ...props } satisfies CreateMenubarProps;
 
-	const options = toWritableStores(withDefaults);
+	const options = toWritableStores(omit(withDefaults, 'ids'));
 	const { loop, closeOnEscape } = options;
 	const activeMenu = writable<string>('');
 
@@ -61,9 +65,7 @@ export function createMenubar(props?: CreateMenubarProps) {
 	const closeTimer = writable(0);
 	let scrollRemoved = false;
 
-	const ids = {
-		menubar: generateId(),
-	};
+	const ids = { ...generateDefaultIds(idParts), ...withDefaults.ids };
 
 	const menubar = builder(name(), {
 		returned() {

--- a/src/lib/builders/menubar/types.ts
+++ b/src/lib/builders/menubar/types.ts
@@ -1,6 +1,7 @@
-import type { BuilderReturn } from '$lib/internal/types.js';
+import type { IdObj } from '$lib/internal/helpers/id.js';
+import type { BuilderReturn, Expand } from '$lib/internal/types.js';
 import type { _Menu } from '../menu/index.js';
-import type { createMenubar } from './create.js';
+import type { MenubarIdParts, createMenubar } from './create.js';
 export type { MenubarComponentEvents } from './events.js';
 // Props
 export type CreateMenubarProps = {
@@ -16,6 +17,11 @@ export type CreateMenubarProps = {
 	 * Whether to close the active menu when the escape key is pressed.
 	 */
 	closeOnEscape?: boolean;
+
+	/**
+	 * Optionally override the default ids we assign to the elements
+	 */
+	ids?: Expand<IdObj<MenubarIdParts>>;
 };
 export type CreateMenubarMenuProps = _Menu['builder'];
 export type CreateMenubarSubmenuProps = _Menu['submenu'];

--- a/src/lib/builders/menubar/types.ts
+++ b/src/lib/builders/menubar/types.ts
@@ -1,5 +1,5 @@
 import type { IdObj } from '$lib/internal/helpers/id.js';
-import type { BuilderReturn, Expand } from '$lib/internal/types.js';
+import type { BuilderReturn } from '$lib/internal/types.js';
 import type { _Menu } from '../menu/index.js';
 import type { MenubarIdParts, createMenubar } from './create.js';
 export type { MenubarComponentEvents } from './events.js';
@@ -21,7 +21,7 @@ export type CreateMenubarProps = {
 	/**
 	 * Optionally override the default ids we assign to the elements
 	 */
-	ids?: Expand<IdObj<MenubarIdParts>>;
+	ids?: IdObj<MenubarIdParts>;
 };
 export type CreateMenubarMenuProps = _Menu['builder'];
 export type CreateMenubarSubmenuProps = _Menu['submenu'];

--- a/src/lib/builders/pin-input/create.ts
+++ b/src/lib/builders/pin-input/create.ts
@@ -20,7 +20,7 @@ import { tick } from 'svelte';
 import { derived, get, readonly, writable } from 'svelte/store';
 import type { PinInputEvents } from './events.js';
 import type { CreatePinInputProps } from './types.js';
-import { generateDefaultIds } from '../../internal/helpers/id';
+import { generateIds } from '../../internal/helpers/id';
 
 const { name, selector } = createElHelpers<'input' | 'hidden-input'>('pin-input');
 
@@ -59,7 +59,7 @@ export function createPinInput(props?: CreatePinInputProps) {
 	const value = overridable(valueWritable, withDefaults?.onValueChange);
 	const valueStr = derived(value, (v) => v.join(''));
 
-	const ids = { ...generateDefaultIds(idParts), ...withDefaults.ids };
+	const ids = { ...generateIds(idParts), ...withDefaults.ids };
 
 	const root = builder(name(), {
 		stores: value,

--- a/src/lib/builders/pin-input/create.ts
+++ b/src/lib/builders/pin-input/create.ts
@@ -4,7 +4,6 @@ import {
 	createElHelpers,
 	disabledAttr,
 	executeCallbacks,
-	generateId,
 	hiddenInputAttrs,
 	isBrowser,
 	isHTMLElement,
@@ -21,6 +20,7 @@ import { tick } from 'svelte';
 import { derived, get, readonly, writable } from 'svelte/store';
 import type { PinInputEvents } from './events.js';
 import type { CreatePinInputProps } from './types.js';
+import { generateDefaultIds } from '../../internal/helpers/id';
 
 const { name, selector } = createElHelpers<'input' | 'hidden-input'>('pin-input');
 
@@ -46,19 +46,20 @@ const defaults = {
 	defaultValue: [],
 } satisfies Defaults<CreatePinInputProps>;
 
+const idParts = ['root'] as const;
+export type PinInputIdParts = (typeof idParts)[number];
+
 export function createPinInput(props?: CreatePinInputProps) {
 	const withDefaults = { ...defaults, ...props } satisfies CreatePinInputProps;
 
-	const options = toWritableStores(omit(withDefaults, 'value'));
+	const options = toWritableStores(omit(withDefaults, 'value', 'ids'));
 	const { placeholder, disabled, type, name: nameStore } = options;
 
 	const valueWritable = withDefaults.value ?? writable(withDefaults.defaultValue);
 	const value = overridable(valueWritable, withDefaults?.onValueChange);
 	const valueStr = derived(value, (v) => v.join(''));
 
-	const ids = {
-		root: generateId(),
-	};
+	const ids = { ...generateDefaultIds(idParts), ...withDefaults.ids };
 
 	const root = builder(name(), {
 		stores: value,

--- a/src/lib/builders/pin-input/types.ts
+++ b/src/lib/builders/pin-input/types.ts
@@ -1,7 +1,7 @@
-import type { ChangeFn } from '$lib/internal/helpers/index.js';
-import type { BuilderReturn } from '$lib/internal/types.js';
+import type { ChangeFn, IdObj } from '$lib/internal/helpers/index.js';
+import type { BuilderReturn, Expand } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
-import type { createPinInput } from './create.js';
+import type { PinInputIdParts, createPinInput } from './create.js';
 export type { PinInputComponentEvents } from './events.js';
 
 export type CreatePinInputProps = {
@@ -55,6 +55,11 @@ export type CreatePinInputProps = {
 	 * @see https://melt-ui.com/docs/controlled#change-functions
 	 */
 	onValueChange?: ChangeFn<string[]>;
+
+	/**
+	 * Optionally override the default ids we assign to the elements
+	 */
+	ids?: Expand<IdObj<PinInputIdParts>>;
 };
 
 export type PinInput = BuilderReturn<typeof createPinInput>;

--- a/src/lib/builders/pin-input/types.ts
+++ b/src/lib/builders/pin-input/types.ts
@@ -1,5 +1,5 @@
 import type { ChangeFn, IdObj } from '$lib/internal/helpers/index.js';
-import type { BuilderReturn, Expand } from '$lib/internal/types.js';
+import type { BuilderReturn } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
 import type { PinInputIdParts, createPinInput } from './create.js';
 export type { PinInputComponentEvents } from './events.js';
@@ -59,7 +59,7 @@ export type CreatePinInputProps = {
 	/**
 	 * Optionally override the default ids we assign to the elements
 	 */
-	ids?: Expand<IdObj<PinInputIdParts>>;
+	ids?: IdObj<PinInputIdParts>;
 };
 
 export type PinInput = BuilderReturn<typeof createPinInput>;

--- a/src/lib/builders/popover/create.ts
+++ b/src/lib/builders/popover/create.ts
@@ -46,8 +46,8 @@ const defaults = {
 type PopoverParts = 'trigger' | 'content' | 'arrow' | 'close';
 const { name } = createElHelpers<PopoverParts>('popover');
 
-const idParts = ['trigger', 'content'] as const;
-export type PopoverIdParts = (typeof idParts)[number];
+export const popoverIdParts = ['trigger', 'content'] as const;
+export type PopoverIdParts = typeof popoverIdParts;
 
 export function createPopover(args?: CreatePopoverProps) {
 	const withDefaults = { ...defaults, ...args } satisfies CreatePopoverProps;
@@ -71,30 +71,30 @@ export function createPopover(args?: CreatePopoverProps) {
 
 	const activeTrigger = writable<HTMLElement | null>(null);
 
-	const ids = { ...generateIds(idParts), ...withDefaults.ids };
+	const ids = toWritableStores({ ...generateIds(popoverIdParts), ...withDefaults.ids });
 
 	onMount(() => {
-		activeTrigger.set(document.getElementById(ids.trigger));
+		activeTrigger.set(document.getElementById(get(ids.trigger)));
 	});
 
 	function handleClose() {
 		open.set(false);
-		const triggerEl = document.getElementById(ids.trigger);
+		const triggerEl = document.getElementById(get(ids.trigger));
 		handleFocus({ prop: get(closeFocus), defaultEl: triggerEl });
 	}
 
 	const isVisible = derivedVisible({ open, activeTrigger, forceVisible });
 
 	const content = builder(name('content'), {
-		stores: [isVisible, portal],
-		returned: ([$isVisible, $portal]) => {
+		stores: [isVisible, portal, ids.content],
+		returned: ([$isVisible, $portal, $contentId]) => {
 			return {
 				hidden: $isVisible && isBrowser ? undefined : true,
 				tabindex: -1,
 				style: styleToString({
 					display: $isVisible ? undefined : 'none',
 				}),
-				id: ids.content,
+				id: $contentId,
 				'data-state': $isVisible ? 'open' : 'closed',
 				'data-portal': $portal ? '' : undefined,
 			};
@@ -171,15 +171,15 @@ export function createPopover(args?: CreatePopoverProps) {
 	}
 
 	const trigger = builder(name('trigger'), {
-		stores: open,
-		returned: ($open) => {
+		stores: [open, ids.content, ids.trigger],
+		returned: ([$open, $contentId, $triggerId]) => {
 			return {
 				role: 'button',
 				'aria-haspopup': 'dialog',
 				'aria-expanded': $open,
 				'data-state': $open ? 'open' : 'closed',
-				'aria-controls': ids.content,
-				id: ids.trigger,
+				'aria-controls': $contentId,
+				id: $triggerId,
 			} as const;
 		},
 		action: (node: HTMLElement): MeltActionReturn<PopoverEvents['trigger']> => {
@@ -243,7 +243,7 @@ export function createPopover(args?: CreatePopoverProps) {
 		if ($open) {
 			if (!$activeTrigger) {
 				tick().then(() => {
-					const triggerEl = document.getElementById(ids.trigger);
+					const triggerEl = document.getElementById(get(ids.trigger));
 					if (!isHTMLElement(triggerEl)) return;
 					activeTrigger.set(triggerEl);
 				});
@@ -253,7 +253,7 @@ export function createPopover(args?: CreatePopoverProps) {
 				unsubs.push(removeScroll());
 			}
 
-			const triggerEl = $activeTrigger ?? document.getElementById(ids.trigger);
+			const triggerEl = $activeTrigger ?? document.getElementById(get(ids.trigger));
 			handleFocus({ prop: get(openFocus), defaultEl: triggerEl });
 		}
 

--- a/src/lib/builders/popover/create.ts
+++ b/src/lib/builders/popover/create.ts
@@ -24,7 +24,7 @@ import { get, writable } from 'svelte/store';
 import { executeCallbacks } from '../../internal/helpers/callbacks.js';
 import type { PopoverEvents } from './events.js';
 import type { CreatePopoverProps } from './types.js';
-import { generateDefaultIds } from '../../internal/helpers/id';
+import { generateIds } from '../../internal/helpers/id';
 
 const defaults = {
 	positioning: {
@@ -71,7 +71,7 @@ export function createPopover(args?: CreatePopoverProps) {
 
 	const activeTrigger = writable<HTMLElement | null>(null);
 
-	const ids = { ...generateDefaultIds(idParts), ...withDefaults.ids };
+	const ids = { ...generateIds(idParts), ...withDefaults.ids };
 
 	onMount(() => {
 		activeTrigger.set(document.getElementById(ids.trigger));

--- a/src/lib/builders/popover/create.ts
+++ b/src/lib/builders/popover/create.ts
@@ -4,7 +4,6 @@ import {
 	createElHelpers,
 	derivedVisible,
 	effect,
-	generateId,
 	getPortalDestination,
 	handleFocus,
 	isBrowser,
@@ -25,6 +24,7 @@ import { get, writable } from 'svelte/store';
 import { executeCallbacks } from '../../internal/helpers/callbacks.js';
 import type { PopoverEvents } from './events.js';
 import type { CreatePopoverProps } from './types.js';
+import { generateDefaultIds } from '../../internal/helpers/id';
 
 const defaults = {
 	positioning: {
@@ -46,10 +46,13 @@ const defaults = {
 type PopoverParts = 'trigger' | 'content' | 'arrow' | 'close';
 const { name } = createElHelpers<PopoverParts>('popover');
 
+const idParts = ['trigger', 'content'] as const;
+export type PopoverIdParts = (typeof idParts)[number];
+
 export function createPopover(args?: CreatePopoverProps) {
 	const withDefaults = { ...defaults, ...args } satisfies CreatePopoverProps;
 
-	const options = toWritableStores(omit(withDefaults, 'open'));
+	const options = toWritableStores(omit(withDefaults, 'open', 'ids'));
 	const {
 		positioning,
 		arrowSize,
@@ -68,10 +71,7 @@ export function createPopover(args?: CreatePopoverProps) {
 
 	const activeTrigger = writable<HTMLElement | null>(null);
 
-	const ids = {
-		content: generateId(),
-		trigger: generateId(),
-	};
+	const ids = { ...generateDefaultIds(idParts), ...withDefaults.ids };
 
 	onMount(() => {
 		activeTrigger.set(document.getElementById(ids.trigger));

--- a/src/lib/builders/popover/types.ts
+++ b/src/lib/builders/popover/types.ts
@@ -1,8 +1,8 @@
 import type { FloatingConfig } from '$lib/internal/actions/index.js';
-import type { ChangeFn, FocusProp } from '$lib/internal/helpers/index.js';
+import type { ChangeFn, FocusProp, IdObj } from '$lib/internal/helpers/index.js';
 import type { Writable } from 'svelte/store';
-import type { createPopover } from './create.js';
-import type { BuilderReturn } from '$lib/internal/types.js';
+import type { PopoverIdParts, createPopover } from './create.js';
+import type { BuilderReturn, Expand } from '$lib/internal/types.js';
 export type { PopoverComponentEvents } from './events.js';
 
 export type CreatePopoverProps = {
@@ -95,6 +95,11 @@ export type CreatePopoverProps = {
 	 * on close.
 	 */
 	closeFocus?: FocusProp;
+
+	/**
+	 * Optionally override the default ids we assign to the elements
+	 */
+	ids?: Expand<IdObj<PopoverIdParts>>;
 };
 
 export type Popover = BuilderReturn<typeof createPopover>;

--- a/src/lib/builders/popover/types.ts
+++ b/src/lib/builders/popover/types.ts
@@ -1,8 +1,8 @@
 import type { FloatingConfig } from '$lib/internal/actions/index.js';
 import type { ChangeFn, FocusProp, IdObj } from '$lib/internal/helpers/index.js';
+import type { BuilderReturn } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
 import type { PopoverIdParts, createPopover } from './create.js';
-import type { BuilderReturn, Expand } from '$lib/internal/types.js';
 export type { PopoverComponentEvents } from './events.js';
 
 export type CreatePopoverProps = {
@@ -99,7 +99,7 @@ export type CreatePopoverProps = {
 	/**
 	 * Optionally override the default ids we assign to the elements
 	 */
-	ids?: Expand<IdObj<PopoverIdParts>>;
+	ids?: IdObj<PopoverIdParts>;
 };
 
 export type Popover = BuilderReturn<typeof createPopover>;

--- a/src/lib/builders/slider/create.ts
+++ b/src/lib/builders/slider/create.ts
@@ -7,7 +7,6 @@ import {
 	disabledAttr,
 	effect,
 	executeCallbacks,
-	generateId,
 	getElementByMeltId,
 	isBrowser,
 	isHTMLElement,
@@ -22,6 +21,7 @@ import type { MeltActionReturn } from '$lib/internal/types.js';
 import { derived, get, writable } from 'svelte/store';
 import type { SliderEvents } from './events.js';
 import type { CreateSliderProps } from './types.js';
+import { generateDefaultIds } from '../../internal/helpers/id';
 
 const defaults = {
 	defaultValue: [],
@@ -34,10 +34,15 @@ const defaults = {
 
 const { name } = createElHelpers('slider');
 
+const idParts = ['root'] as const;
+export type SliderIdParts = (typeof idParts)[number];
+
 export const createSlider = (props?: CreateSliderProps) => {
 	const withDefaults = { ...defaults, ...props } satisfies CreateSliderProps;
 
-	const options = toWritableStores(omit(withDefaults, 'value', 'onValueChange', 'defaultValue'));
+	const options = toWritableStores(
+		omit(withDefaults, 'value', 'onValueChange', 'defaultValue', 'ids')
+	);
 	const { min, max, step, orientation, disabled } = options;
 
 	const valueWritable = withDefaults.value ?? writable(withDefaults.defaultValue);
@@ -47,9 +52,7 @@ export const createSlider = (props?: CreateSliderProps) => {
 	const currentThumbIndex = writable<number>(0);
 	const activeThumb = writable<{ thumb: HTMLElement; index: number } | null>(null);
 
-	const ids = {
-		root: generateId(),
-	};
+	const ids = { ...generateDefaultIds(idParts), ...withDefaults.ids };
 
 	const root = builder(name(), {
 		stores: [disabled, orientation],

--- a/src/lib/builders/slider/create.ts
+++ b/src/lib/builders/slider/create.ts
@@ -16,12 +16,12 @@ import {
 	styleToString,
 	toWritableStores,
 } from '$lib/internal/helpers/index.js';
-import { add, sub, div, mul } from './helpers.js';
 import type { MeltActionReturn } from '$lib/internal/types.js';
 import { derived, get, writable } from 'svelte/store';
-import type { SliderEvents } from './events.js';
-import type { CreateSliderProps } from './types.js';
 import { generateIds } from '../../internal/helpers/id';
+import type { SliderEvents } from './events.js';
+import { add, div, mul, sub } from './helpers.js';
+import type { CreateSliderProps } from './types.js';
 
 const defaults = {
 	defaultValue: [],
@@ -34,15 +34,10 @@ const defaults = {
 
 const { name } = createElHelpers('slider');
 
-export const sliderIdParts = ['root'] as const;
-export type SliderIdParts = typeof sliderIdParts;
-
 export const createSlider = (props?: CreateSliderProps) => {
 	const withDefaults = { ...defaults, ...props } satisfies CreateSliderProps;
 
-	const options = toWritableStores(
-		omit(withDefaults, 'value', 'onValueChange', 'defaultValue', 'ids')
-	);
+	const options = toWritableStores(omit(withDefaults, 'value', 'onValueChange', 'defaultValue'));
 	const { min, max, step, orientation, disabled } = options;
 
 	const valueWritable = withDefaults.value ?? writable(withDefaults.defaultValue);
@@ -52,17 +47,17 @@ export const createSlider = (props?: CreateSliderProps) => {
 	const currentThumbIndex = writable<number>(0);
 	const activeThumb = writable<{ thumb: HTMLElement; index: number } | null>(null);
 
-	const ids = toWritableStores({ ...generateIds(sliderIdParts), ...withDefaults.ids });
+	const meltIds = generateIds(['root']);
 
 	const root = builder(name(), {
-		stores: [disabled, orientation, ids.root],
-		returned: ([$disabled, $orientation, $rootId]) => {
+		stores: [disabled, orientation],
+		returned: ([$disabled, $orientation]) => {
 			return {
 				disabled: disabledAttr($disabled),
 				'aria-disabled': ariaDisabledAttr($disabled),
 				'data-orientation': $orientation,
 				style: $disabled ? undefined : 'touch-action: none;',
-				'data-melt-id': $rootId,
+				'data-melt-id': meltIds.root,
 			};
 		},
 	});
@@ -125,7 +120,7 @@ export const createSlider = (props?: CreateSliderProps) => {
 	};
 
 	const getAllThumbs = () => {
-		const root = getElementByMeltId(get(ids.root));
+		const root = getElementByMeltId(meltIds.root);
 		if (!root) return null;
 
 		return Array.from(root.querySelectorAll('[data-melt-part="thumb"]')).filter(
@@ -431,7 +426,7 @@ export const createSlider = (props?: CreateSliderProps) => {
 	);
 
 	return {
-		ids,
+		ids: meltIds,
 		elements: {
 			root,
 			thumb,

--- a/src/lib/builders/slider/create.ts
+++ b/src/lib/builders/slider/create.ts
@@ -21,7 +21,7 @@ import type { MeltActionReturn } from '$lib/internal/types.js';
 import { derived, get, writable } from 'svelte/store';
 import type { SliderEvents } from './events.js';
 import type { CreateSliderProps } from './types.js';
-import { generateDefaultIds } from '../../internal/helpers/id';
+import { generateIds } from '../../internal/helpers/id';
 
 const defaults = {
 	defaultValue: [],
@@ -52,7 +52,7 @@ export const createSlider = (props?: CreateSliderProps) => {
 	const currentThumbIndex = writable<number>(0);
 	const activeThumb = writable<{ thumb: HTMLElement; index: number } | null>(null);
 
-	const ids = { ...generateDefaultIds(idParts), ...withDefaults.ids };
+	const ids = { ...generateIds(idParts), ...withDefaults.ids };
 
 	const root = builder(name(), {
 		stores: [disabled, orientation],

--- a/src/lib/builders/slider/create.ts
+++ b/src/lib/builders/slider/create.ts
@@ -34,8 +34,8 @@ const defaults = {
 
 const { name } = createElHelpers('slider');
 
-const idParts = ['root'] as const;
-export type SliderIdParts = (typeof idParts)[number];
+export const sliderIdParts = ['root'] as const;
+export type SliderIdParts = typeof sliderIdParts;
 
 export const createSlider = (props?: CreateSliderProps) => {
 	const withDefaults = { ...defaults, ...props } satisfies CreateSliderProps;
@@ -52,17 +52,17 @@ export const createSlider = (props?: CreateSliderProps) => {
 	const currentThumbIndex = writable<number>(0);
 	const activeThumb = writable<{ thumb: HTMLElement; index: number } | null>(null);
 
-	const ids = { ...generateIds(idParts), ...withDefaults.ids };
+	const ids = toWritableStores({ ...generateIds(sliderIdParts), ...withDefaults.ids });
 
 	const root = builder(name(), {
-		stores: [disabled, orientation],
-		returned: ([$disabled, $orientation]) => {
+		stores: [disabled, orientation, ids.root],
+		returned: ([$disabled, $orientation, $rootId]) => {
 			return {
 				disabled: disabledAttr($disabled),
 				'aria-disabled': ariaDisabledAttr($disabled),
 				'data-orientation': $orientation,
 				style: $disabled ? undefined : 'touch-action: none;',
-				'data-melt-id': ids.root,
+				'data-melt-id': $rootId,
 			};
 		},
 	});
@@ -125,7 +125,7 @@ export const createSlider = (props?: CreateSliderProps) => {
 	};
 
 	const getAllThumbs = () => {
-		const root = getElementByMeltId(ids.root);
+		const root = getElementByMeltId(get(ids.root));
 		if (!root) return null;
 
 		return Array.from(root.querySelectorAll('[data-melt-part="thumb"]')).filter(

--- a/src/lib/builders/slider/types.ts
+++ b/src/lib/builders/slider/types.ts
@@ -1,7 +1,7 @@
-import type { ChangeFn, IdObj } from '$lib/internal/helpers/index.js';
+import type { ChangeFn } from '$lib/internal/helpers/index.js';
 import type { BuilderReturn } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
-import type { SliderIdParts, createSlider } from './create.js';
+import type { createSlider } from './create.js';
 export type { SliderComponentEvents } from './events.js';
 export type CreateSliderProps = {
 	/**
@@ -58,11 +58,6 @@ export type CreateSliderProps = {
 	 * @default false
 	 */
 	disabled?: boolean;
-
-	/**
-	 * Optionally override the default ids we generate for the slider.
-	 */
-	ids?: IdObj<SliderIdParts>;
 };
 
 export type Slider = BuilderReturn<typeof createSlider>;

--- a/src/lib/builders/slider/types.ts
+++ b/src/lib/builders/slider/types.ts
@@ -1,7 +1,7 @@
-import type { BuilderReturn } from '$lib/internal/types.js';
+import type { BuilderReturn, Expand } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
-import type { createSlider } from './create.js';
-import type { ChangeFn } from '$lib/internal/helpers/index.js';
+import type { SliderIdParts, createSlider } from './create.js';
+import type { ChangeFn, IdObj } from '$lib/internal/helpers/index.js';
 export type { SliderComponentEvents } from './events.js';
 export type CreateSliderProps = {
 	/**
@@ -58,6 +58,11 @@ export type CreateSliderProps = {
 	 * @default false
 	 */
 	disabled?: boolean;
+
+	/**
+	 * Optionally override the default ids we generate for the slider.
+	 */
+	ids?: Expand<IdObj<SliderIdParts>>;
 };
 
 export type Slider = BuilderReturn<typeof createSlider>;

--- a/src/lib/builders/slider/types.ts
+++ b/src/lib/builders/slider/types.ts
@@ -1,7 +1,7 @@
-import type { BuilderReturn, Expand } from '$lib/internal/types.js';
+import type { ChangeFn, IdObj } from '$lib/internal/helpers/index.js';
+import type { BuilderReturn } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
 import type { SliderIdParts, createSlider } from './create.js';
-import type { ChangeFn, IdObj } from '$lib/internal/helpers/index.js';
 export type { SliderComponentEvents } from './events.js';
 export type CreateSliderProps = {
 	/**
@@ -62,7 +62,7 @@ export type CreateSliderProps = {
 	/**
 	 * Optionally override the default ids we generate for the slider.
 	 */
-	ids?: Expand<IdObj<SliderIdParts>>;
+	ids?: IdObj<SliderIdParts>;
 };
 
 export type Slider = BuilderReturn<typeof createSlider>;

--- a/src/lib/builders/tags-input/create.ts
+++ b/src/lib/builders/tags-input/create.ts
@@ -21,7 +21,7 @@ import { focusInput, highlightText, setSelectedFromEl } from './helpers.js';
 import type { CreateTagsInputProps, Tag, TagProps } from './types.js';
 import { tick } from 'svelte';
 import type { TagsInputEvents } from './events.js';
-import { generateDefaultIds } from '../../internal/helpers/id';
+import { generateIds } from '../../internal/helpers/id';
 
 const defaults = {
 	placeholder: '',
@@ -50,7 +50,7 @@ export function createTagsInput(props?: CreateTagsInputProps) {
 	const withDefaults = { ...defaults, ...props } satisfies CreateTagsInputProps;
 
 	// UUID for specific containers
-	const ids = { ...generateDefaultIds(idParts), ...withDefaults.ids };
+	const ids = { ...generateIds(idParts), ...withDefaults.ids };
 
 	const options = toWritableStores(omit(withDefaults, 'tags', 'ids'));
 	const {

--- a/src/lib/builders/tags-input/create.ts
+++ b/src/lib/builders/tags-input/create.ts
@@ -43,16 +43,12 @@ const defaults = {
 type TagsInputParts = '' | 'tag' | 'delete-trigger' | 'edit' | 'input';
 const { name, attribute, selector } = createElHelpers<TagsInputParts>('tags-input');
 
-export const tagInputIdParts = ['root', 'input'] as const;
-export type TagsInputIdParts = typeof tagInputIdParts;
-
 export function createTagsInput(props?: CreateTagsInputProps) {
 	const withDefaults = { ...defaults, ...props } satisfies CreateTagsInputProps;
 
-	// UUID for specific containers
-	const ids = toWritableStores({ ...generateIds(tagInputIdParts), ...withDefaults.ids });
+	const meltIds = generateIds(['root', 'input']);
 
-	const options = toWritableStores(omit(withDefaults, 'tags', 'ids'));
+	const options = toWritableStores(omit(withDefaults, 'tags'));
 	const {
 		placeholder,
 		disabled,
@@ -230,10 +226,10 @@ export function createTagsInput(props?: CreateTagsInputProps) {
 	}
 
 	const root = builder(name(''), {
-		stores: [disabled, ids.root],
-		returned: ([$disabled, $rootId]) => {
+		stores: [disabled],
+		returned: ([$disabled]) => {
 			return {
-				'data-melt-id': $rootId,
+				'data-melt-id': meltIds.root,
 				'data-disabled': disabledAttr($disabled),
 				disabled: disabledAttr($disabled),
 			} as const;
@@ -246,7 +242,7 @@ export function createTagsInput(props?: CreateTagsInputProps) {
 					if (!isHTMLElement(target)) return;
 					if (target.hasAttribute(attribute())) {
 						e.preventDefault();
-						focusInput(get(ids.input));
+						focusInput(meltIds.input);
 					}
 				})
 			);
@@ -258,10 +254,10 @@ export function createTagsInput(props?: CreateTagsInputProps) {
 	});
 
 	const input = builder(name('input'), {
-		stores: [disabled, placeholder, ids.input],
-		returned: ([$disabled, $placeholder, $inputId]) => {
+		stores: [disabled, placeholder],
+		returned: ([$disabled, $placeholder]) => {
 			return {
-				'data-melt-id': $inputId,
+				'data-melt-id': meltIds.input,
 				'data-disabled': disabledAttr($disabled),
 				disabled: disabledAttr($disabled),
 				placeholder: $placeholder,
@@ -269,7 +265,7 @@ export function createTagsInput(props?: CreateTagsInputProps) {
 		},
 		action: (node: HTMLInputElement): MeltActionReturn<TagsInputEvents['input']> => {
 			const getTagsInfo = (id: string) => {
-				const rootEl = getElementByMeltId(get(ids.root));
+				const rootEl = getElementByMeltId(meltIds.root);
 
 				let tagsEl: Array<Element> = [];
 				let selectedIndex = -1;
@@ -296,13 +292,13 @@ export function createTagsInput(props?: CreateTagsInputProps) {
 			const unsub = executeCallbacks(
 				addMeltEventListener(node, 'focus', () => {
 					// Set data-focus on root and input
-					const rootEl = getElementByMeltId(get(ids.root));
+					const rootEl = getElementByMeltId(meltIds.root);
 					if (rootEl) rootEl.setAttribute('data-focus', '');
 					node.setAttribute('data-focus', '');
 				}),
 				addMeltEventListener(node, 'blur', async () => {
 					// Clear data-focus from root and input
-					const rootEl = getElementByMeltId(get(ids.root));
+					const rootEl = getElementByMeltId(meltIds.root);
 					if (rootEl) rootEl.removeAttribute('data-focus');
 					node.removeAttribute('data-focus');
 
@@ -365,7 +361,7 @@ export function createTagsInput(props?: CreateTagsInputProps) {
 
 							if (nextIndex === -1 || nextIndex >= tagsEl.length) {
 								selected.set(null);
-								focusInput(get(ids.input), 'start');
+								focusInput(meltIds.input, 'start');
 							} else {
 								setSelectedFromEl(tagsEl[nextIndex], selected);
 							}
@@ -378,7 +374,7 @@ export function createTagsInput(props?: CreateTagsInputProps) {
 							// Jump to the input
 							e.preventDefault();
 							selected.set(null);
-							focusInput(get(ids.input));
+							focusInput(meltIds.input);
 						} else if (e.key === kbd.DELETE) {
 							// Delete this tag and move to the next element of tag or input
 							e.preventDefault();
@@ -388,7 +384,7 @@ export function createTagsInput(props?: CreateTagsInputProps) {
 
 							if (nextIndex === -1 || nextIndex >= tagsEl.length) {
 								selected.set(null);
-								focusInput(get(ids.input));
+								focusInput(meltIds.input);
 							} else {
 								setSelectedFromEl(tagsEl[nextIndex], selected);
 							}
@@ -408,7 +404,7 @@ export function createTagsInput(props?: CreateTagsInputProps) {
 							} else {
 								if (nextIndex === -1 || nextIndex >= tagsEl.length) {
 									selected.set(null);
-									focusInput(get(ids.input), 'start');
+									focusInput(meltIds.input, 'start');
 								} else {
 									setSelectedFromEl(tagsEl[nextIndex], selected);
 								}
@@ -520,7 +516,7 @@ export function createTagsInput(props?: CreateTagsInputProps) {
 					if ($editing && $editing.id !== getElProps().id) return;
 
 					// Focus on the input and set this as the selected tag
-					focusInput(get(ids.input));
+					focusInput(meltIds.input);
 					e.preventDefault();
 					setSelectedFromEl(node, selected);
 					editing.set(null);
@@ -531,7 +527,7 @@ export function createTagsInput(props?: CreateTagsInputProps) {
 					if ($editing && $editing.id === getElProps().id) return;
 
 					// Focus on the input and set this as the selected tag
-					focusInput(get(ids.input));
+					focusInput(meltIds.input);
 					e.preventDefault();
 					setSelectedFromEl(node, selected);
 					editing.set(null);
@@ -599,7 +595,7 @@ export function createTagsInput(props?: CreateTagsInputProps) {
 				const id = node.getAttribute('data-tag-id') ?? '';
 
 				removeTag({ id, value });
-				focusInput(get(ids.input));
+				focusInput(meltIds.input);
 			}
 			const unsub = executeCallbacks(
 				addMeltEventListener(node, 'click', (e) => {
@@ -663,7 +659,7 @@ export function createTagsInput(props?: CreateTagsInputProps) {
 					// Stop editing, reset the value to the original and clear an invalid state
 					editing.set(null);
 					node.textContent = getElProps().value;
-					getElementByMeltId(get(ids.root))?.removeAttribute('data-invalid-edit');
+					getElementByMeltId(meltIds.root)?.removeAttribute('data-invalid-edit');
 					node.removeAttribute('data-invalid-edit');
 				}),
 				addMeltEventListener(node, 'keydown', async (e) => {
@@ -682,9 +678,9 @@ export function createTagsInput(props?: CreateTagsInputProps) {
 						if (isInputValid(value) && (await updateTag(t, true))) {
 							node.textContent = t.value;
 							editValue.set('');
-							focusInput(get(ids.input));
+							focusInput(meltIds.input);
 						} else {
-							getElementByMeltId(get(ids.root))?.setAttribute('data-invalid-edit', '');
+							getElementByMeltId(meltIds.root)?.setAttribute('data-invalid-edit', '');
 							node.setAttribute('data-invalid-edit', '');
 						}
 					} else if (e.key === kbd.ESCAPE) {
@@ -694,7 +690,7 @@ export function createTagsInput(props?: CreateTagsInputProps) {
 						node.textContent = getElProps().value;
 						editValue.set('');
 						setSelectedFromEl(node, selected);
-						focusInput(get(ids.input));
+						focusInput(meltIds.input);
 					}
 				}),
 				addMeltEventListener(node, 'input', () => {
@@ -723,18 +719,18 @@ export function createTagsInput(props?: CreateTagsInputProps) {
 	// Flip the data-invalid attribute based upon the inputInvalid store
 	effect(inputInvalid, ($inputInvalid) => {
 		if ($inputInvalid) {
-			getElementByMeltId(get(ids.root))?.setAttribute('data-invalid', '');
-			getElementByMeltId(get(ids.input))?.setAttribute('data-invalid', '');
+			getElementByMeltId(meltIds.root)?.setAttribute('data-invalid', '');
+			getElementByMeltId(meltIds.input)?.setAttribute('data-invalid', '');
 		} else {
-			getElementByMeltId(get(ids.root))?.removeAttribute('data-invalid');
-			getElementByMeltId(get(ids.input))?.removeAttribute('data-invalid');
+			getElementByMeltId(meltIds.root)?.removeAttribute('data-invalid');
+			getElementByMeltId(meltIds.input)?.removeAttribute('data-invalid');
 		}
 	});
 
 	// When the input valid changes, clear any potential invalid states
 	effect(editValue, () => {
 		if (!isBrowser) return;
-		getElementByMeltId(get(ids.root))?.removeAttribute('data-invalid-edit');
+		getElementByMeltId(meltIds.root)?.removeAttribute('data-invalid-edit');
 
 		const invalidEl = Array.from(
 			document.querySelectorAll(selector('edit') + '[data-invalid-edit]')
@@ -745,7 +741,7 @@ export function createTagsInput(props?: CreateTagsInputProps) {
 	});
 
 	return {
-		ids,
+		ids: meltIds,
 		elements: {
 			root,
 			input,

--- a/src/lib/builders/tags-input/create.ts
+++ b/src/lib/builders/tags-input/create.ts
@@ -21,6 +21,7 @@ import { focusInput, highlightText, setSelectedFromEl } from './helpers.js';
 import type { CreateTagsInputProps, Tag, TagProps } from './types.js';
 import { tick } from 'svelte';
 import type { TagsInputEvents } from './events.js';
+import { generateDefaultIds } from '../../internal/helpers/id';
 
 const defaults = {
 	placeholder: '',
@@ -42,16 +43,16 @@ const defaults = {
 type TagsInputParts = '' | 'tag' | 'delete-trigger' | 'edit' | 'input';
 const { name, attribute, selector } = createElHelpers<TagsInputParts>('tags-input');
 
+const idParts = ['root', 'input'] as const;
+export type TagsInputIdParts = (typeof idParts)[number];
+
 export function createTagsInput(props?: CreateTagsInputProps) {
 	const withDefaults = { ...defaults, ...props } satisfies CreateTagsInputProps;
 
 	// UUID for specific containers
-	const ids = {
-		root: generateId(),
-		input: generateId(),
-	};
+	const ids = { ...generateDefaultIds(idParts), ...withDefaults.ids };
 
-	const options = toWritableStores(omit(withDefaults, 'tags'));
+	const options = toWritableStores(omit(withDefaults, 'tags', 'ids'));
 	const {
 		placeholder,
 		disabled,

--- a/src/lib/builders/tags-input/types.ts
+++ b/src/lib/builders/tags-input/types.ts
@@ -1,7 +1,7 @@
-import type { BuilderReturn } from '$lib/internal/types.js';
+import type { BuilderReturn, Expand } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
-import type { createTagsInput } from './create.js';
-import type { ChangeFn } from '$lib/internal/helpers/index.js';
+import type { TagsInputIdParts, createTagsInput } from './create.js';
+import type { ChangeFn, IdObj } from '$lib/internal/helpers/index.js';
 export type { TagsInputComponentEvents } from './events.js';
 export type CreateTagsInputProps = {
 	placeholder?: string;
@@ -48,6 +48,11 @@ export type CreateTagsInputProps = {
 	 * @param tag The tag to be updated
 	 */
 	update?: UpdateTag;
+
+	/**
+	 * Optionally override the default ids we apply to the elements.
+	 */
+	ids?: Expand<IdObj<TagsInputIdParts>>;
 };
 
 export type Blur = 'nothing' | 'add' | 'clear';

--- a/src/lib/builders/tags-input/types.ts
+++ b/src/lib/builders/tags-input/types.ts
@@ -1,7 +1,7 @@
-import type { BuilderReturn, Expand } from '$lib/internal/types.js';
+import type { ChangeFn, IdObj } from '$lib/internal/helpers/index.js';
+import type { BuilderReturn } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
 import type { TagsInputIdParts, createTagsInput } from './create.js';
-import type { ChangeFn, IdObj } from '$lib/internal/helpers/index.js';
 export type { TagsInputComponentEvents } from './events.js';
 export type CreateTagsInputProps = {
 	placeholder?: string;
@@ -52,7 +52,7 @@ export type CreateTagsInputProps = {
 	/**
 	 * Optionally override the default ids we apply to the elements.
 	 */
-	ids?: Expand<IdObj<TagsInputIdParts>>;
+	ids?: IdObj<TagsInputIdParts>;
 };
 
 export type Blur = 'nothing' | 'add' | 'clear';

--- a/src/lib/builders/tags-input/types.ts
+++ b/src/lib/builders/tags-input/types.ts
@@ -1,7 +1,7 @@
-import type { ChangeFn, IdObj } from '$lib/internal/helpers/index.js';
+import type { ChangeFn } from '$lib/internal/helpers/index.js';
 import type { BuilderReturn } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
-import type { TagsInputIdParts, createTagsInput } from './create.js';
+import type { createTagsInput } from './create.js';
 export type { TagsInputComponentEvents } from './events.js';
 export type CreateTagsInputProps = {
 	placeholder?: string;
@@ -48,11 +48,6 @@ export type CreateTagsInputProps = {
 	 * @param tag The tag to be updated
 	 */
 	update?: UpdateTag;
-
-	/**
-	 * Optionally override the default ids we apply to the elements.
-	 */
-	ids?: IdObj<TagsInputIdParts>;
 };
 
 export type Blur = 'nothing' | 'add' | 'clear';

--- a/src/lib/builders/tooltip/create.ts
+++ b/src/lib/builders/tooltip/create.ts
@@ -5,7 +5,6 @@ import {
 	createElHelpers,
 	effect,
 	executeCallbacks,
-	generateId,
 	getPortalDestination,
 	isBrowser,
 	isTouch,
@@ -24,6 +23,7 @@ import type { MeltActionReturn } from '$lib/internal/types.js';
 import { derived, get, writable, type Writable } from 'svelte/store';
 import type { TooltipEvents } from './events.js';
 import type { CreateTooltipProps } from './types.js';
+import { generateDefaultIds } from '../../internal/helpers/id';
 
 const defaults = {
 	positioning: {
@@ -47,10 +47,13 @@ const { name } = createElHelpers<TooltipParts>('tooltip');
 // Store a global map to get the currently open tooltip.
 const groupMap = new Map<string | true, Writable<boolean>>();
 
+const idParts = ['trigger', 'content'] as const;
+export type TooltipIdParts = (typeof idParts)[number];
+
 export function createTooltip(props?: CreateTooltipProps) {
 	const withDefaults = { ...defaults, ...props } satisfies CreateTooltipProps;
 
-	const options = toWritableStores(omit(withDefaults, 'open'));
+	const options = toWritableStores(omit(withDefaults, 'open', 'ids'));
 	const {
 		positioning,
 		arrowSize,
@@ -70,10 +73,7 @@ export function createTooltip(props?: CreateTooltipProps) {
 	type OpenReason = 'pointer' | 'focus';
 	const openReason = writable<null | OpenReason>(null);
 
-	const ids = {
-		content: generateId(),
-		trigger: generateId(),
-	} as const;
+	const ids = { ...generateDefaultIds(idParts), ...withDefaults.ids };
 
 	let clickedTrigger = false;
 

--- a/src/lib/builders/tooltip/create.ts
+++ b/src/lib/builders/tooltip/create.ts
@@ -47,8 +47,8 @@ const { name } = createElHelpers<TooltipParts>('tooltip');
 // Store a global map to get the currently open tooltip.
 const groupMap = new Map<string | true, Writable<boolean>>();
 
-const idParts = ['trigger', 'content'] as const;
-export type TooltipIdParts = (typeof idParts)[number];
+export const tooltipIdParts = ['trigger', 'content'] as const;
+export type TooltipIdParts = typeof tooltipIdParts;
 
 export function createTooltip(props?: CreateTooltipProps) {
 	const withDefaults = { ...defaults, ...props } satisfies CreateTooltipProps;
@@ -73,13 +73,13 @@ export function createTooltip(props?: CreateTooltipProps) {
 	type OpenReason = 'pointer' | 'focus';
 	const openReason = writable<null | OpenReason>(null);
 
-	const ids = { ...generateIds(idParts), ...withDefaults.ids };
+	const ids = toWritableStores({ ...generateIds(tooltipIdParts), ...withDefaults.ids });
 
 	let clickedTrigger = false;
 
 	const getEl = (part: keyof typeof ids) => {
 		if (!isBrowser) return null;
-		return document.getElementById(ids[part]);
+		return document.getElementById(get(ids[part]));
 	};
 
 	let openTimeout: number | null = null;
@@ -127,10 +127,11 @@ export function createTooltip(props?: CreateTooltipProps) {
 	}
 
 	const trigger = builder(name('trigger'), {
-		returned: () => {
+		stores: [ids.content, ids.trigger],
+		returned: ([$contentId, $triggerId]) => {
 			return {
-				'aria-describedby': ids.content,
-				id: ids.trigger,
+				'aria-describedby': $contentId,
+				id: $triggerId,
 			};
 		},
 		action: (node: HTMLElement): MeltActionReturn<TooltipEvents['trigger']> => {
@@ -187,8 +188,8 @@ export function createTooltip(props?: CreateTooltipProps) {
 	});
 
 	const content = builder(name('content'), {
-		stores: [isVisible, portal],
-		returned: ([$isVisible, $portal]) => {
+		stores: [isVisible, portal, ids.content],
+		returned: ([$isVisible, $portal, $contentId]) => {
 			return {
 				role: 'tooltip',
 				hidden: $isVisible ? undefined : true,
@@ -196,7 +197,7 @@ export function createTooltip(props?: CreateTooltipProps) {
 				style: styleToString({
 					display: $isVisible ? undefined : 'none',
 				}),
-				id: ids.content,
+				id: $contentId,
 				'data-portal': $portal ? '' : undefined,
 			};
 		},

--- a/src/lib/builders/tooltip/create.ts
+++ b/src/lib/builders/tooltip/create.ts
@@ -23,7 +23,7 @@ import type { MeltActionReturn } from '$lib/internal/types.js';
 import { derived, get, writable, type Writable } from 'svelte/store';
 import type { TooltipEvents } from './events.js';
 import type { CreateTooltipProps } from './types.js';
-import { generateDefaultIds } from '../../internal/helpers/id';
+import { generateIds } from '../../internal/helpers/id';
 
 const defaults = {
 	positioning: {
@@ -73,7 +73,7 @@ export function createTooltip(props?: CreateTooltipProps) {
 	type OpenReason = 'pointer' | 'focus';
 	const openReason = writable<null | OpenReason>(null);
 
-	const ids = { ...generateDefaultIds(idParts), ...withDefaults.ids };
+	const ids = { ...generateIds(idParts), ...withDefaults.ids };
 
 	let clickedTrigger = false;
 

--- a/src/lib/builders/tooltip/types.ts
+++ b/src/lib/builders/tooltip/types.ts
@@ -1,8 +1,8 @@
 import type { FloatingConfig } from '$lib/internal/actions/index.js';
-import type { BuilderReturn, Expand } from '$lib/internal/types.js';
+import type { ChangeFn, IdObj } from '$lib/internal/helpers/index.js';
+import type { BuilderReturn } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
 import type { TooltipIdParts, createTooltip } from './create.js';
-import type { ChangeFn, IdObj } from '$lib/internal/helpers/index.js';
 export type { TooltipComponentEvents } from './events.js';
 export type CreateTooltipProps = {
 	positioning?: FloatingConfig;
@@ -32,7 +32,7 @@ export type CreateTooltipProps = {
 	/**
 	 * Optionally override the default ids we assign to the elements
 	 */
-	ids?: Expand<IdObj<TooltipIdParts>>;
+	ids?: IdObj<TooltipIdParts>;
 };
 
 export type Tooltip = BuilderReturn<typeof createTooltip>;

--- a/src/lib/builders/tooltip/types.ts
+++ b/src/lib/builders/tooltip/types.ts
@@ -1,8 +1,8 @@
 import type { FloatingConfig } from '$lib/internal/actions/index.js';
-import type { BuilderReturn } from '$lib/internal/types.js';
+import type { BuilderReturn, Expand } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
-import type { createTooltip } from './create.js';
-import type { ChangeFn } from '$lib/internal/helpers/index.js';
+import type { TooltipIdParts, createTooltip } from './create.js';
+import type { ChangeFn, IdObj } from '$lib/internal/helpers/index.js';
 export type { TooltipComponentEvents } from './events.js';
 export type CreateTooltipProps = {
 	positioning?: FloatingConfig;
@@ -28,6 +28,11 @@ export type CreateTooltipProps = {
 	 * @default 'body'
 	 */
 	portal?: HTMLElement | string | null;
+
+	/**
+	 * Optionally override the default ids we assign to the elements
+	 */
+	ids?: Expand<IdObj<TooltipIdParts>>;
 };
 
 export type Tooltip = BuilderReturn<typeof createTooltip>;

--- a/src/lib/builders/tree/create.ts
+++ b/src/lib/builders/tree/create.ts
@@ -11,14 +11,13 @@ import {
 	last,
 	overridable,
 	styleToString,
-	toWritableStores,
 } from '$lib/internal/helpers';
 import type { Defaults, MeltActionReturn } from '$lib/internal/types';
-import { derived, get, writable, type Writable } from 'svelte/store';
+import { derived, writable, type Writable } from 'svelte/store';
 
+import { generateIds } from '../../internal/helpers/id';
 import type { TreeEvents } from './events';
 import type { CreateTreeViewProps, TreeParts } from './types';
-import { generateIds } from '../../internal/helpers/id';
 
 const defaults = {
 	forceVisible: false,
@@ -33,9 +32,6 @@ const ATTRS = {
 };
 
 const { name } = createElHelpers<TreeParts>('tree-view');
-
-export const treeIdParts = ['tree'] as const;
-export type TreeIdParts = typeof treeIdParts;
 
 export function createTreeView(args?: CreateTreeViewProps) {
 	const withDefaults = { ...defaults, ...args };
@@ -71,14 +67,13 @@ export function createTreeView(args?: CreateTreeViewProps) {
 		return (itemId: string) => $expanded.includes(itemId);
 	});
 
-	const ids = toWritableStores({ ...generateIds(treeIdParts), ...withDefaults.ids });
+	const metaIds = generateIds(['tree']);
 
 	const rootTree = builder(name(), {
-		stores: [ids.tree],
-		returned: ([$treeId]) => {
+		returned: () => {
 			return {
 				role: 'tree',
-				'data-melt-id': $treeId,
+				'data-melt-id': metaIds.tree,
 			} as const;
 		},
 	});
@@ -127,7 +122,7 @@ export function createTreeView(args?: CreateTreeViewProps) {
 						return;
 					}
 
-					const rootEl = getElementByMeltId(get(ids.tree));
+					const rootEl = getElementByMeltId(metaIds.tree);
 					if (!rootEl || !isHTMLElement(node) || node.getAttribute('role') !== 'treeitem') {
 						return;
 					}
@@ -282,7 +277,7 @@ export function createTreeView(args?: CreateTreeViewProps) {
 
 	function getItems(): HTMLElement[] {
 		let items = [] as HTMLElement[];
-		const rootEl = getElementByMeltId(get(ids.tree));
+		const rootEl = getElementByMeltId(metaIds.tree);
 		if (!rootEl) return items;
 
 		// Select all 'treeitem' li elements within our root element.
@@ -325,7 +320,7 @@ export function createTreeView(args?: CreateTreeViewProps) {
 	}
 
 	return {
-		ids,
+		ids: metaIds,
 		elements: {
 			tree: rootTree,
 			item,

--- a/src/lib/builders/tree/create.ts
+++ b/src/lib/builders/tree/create.ts
@@ -17,7 +17,7 @@ import { derived, writable, type Writable } from 'svelte/store';
 
 import type { TreeEvents } from './events';
 import type { CreateTreeViewProps, TreeParts } from './types';
-import { generateDefaultIds } from '../../internal/helpers/id';
+import { generateIds } from '../../internal/helpers/id';
 
 const defaults = {
 	forceVisible: false,
@@ -70,7 +70,7 @@ export function createTreeView(args?: CreateTreeViewProps) {
 		return (itemId: string) => $expanded.includes(itemId);
 	});
 
-	const ids = { ...generateDefaultIds(idParts), ...withDefaults.ids };
+	const ids = { ...generateIds(idParts), ...withDefaults.ids };
 
 	const rootTree = builder(name(), {
 		returned: () => {

--- a/src/lib/builders/tree/create.ts
+++ b/src/lib/builders/tree/create.ts
@@ -3,7 +3,6 @@ import {
 	builder,
 	createElHelpers,
 	executeCallbacks,
-	generateId,
 	getElementByMeltId,
 	isHTMLElement,
 	isHidden,
@@ -18,6 +17,7 @@ import { derived, writable, type Writable } from 'svelte/store';
 
 import type { TreeEvents } from './events';
 import type { CreateTreeViewProps, TreeParts } from './types';
+import { generateDefaultIds } from '../../internal/helpers/id';
 
 const defaults = {
 	forceVisible: false,
@@ -32,6 +32,9 @@ const ATTRS = {
 };
 
 const { name } = createElHelpers<TreeParts>('tree-view');
+
+const idParts = ['tree'] as const;
+export type TreeIdParts = (typeof idParts)[number];
 
 export function createTreeView(args?: CreateTreeViewProps) {
 	const withDefaults = { ...defaults, ...args };
@@ -67,9 +70,7 @@ export function createTreeView(args?: CreateTreeViewProps) {
 		return (itemId: string) => $expanded.includes(itemId);
 	});
 
-	const ids = {
-		tree: generateId(),
-	};
+	const ids = { ...generateDefaultIds(idParts), ...withDefaults.ids };
 
 	const rootTree = builder(name(), {
 		returned: () => {

--- a/src/lib/builders/tree/types.ts
+++ b/src/lib/builders/tree/types.ts
@@ -1,6 +1,6 @@
-import type { ChangeFn, IdObj } from '$lib/internal/helpers';
+import type { ChangeFn } from '$lib/internal/helpers';
 import type { Writable } from 'svelte/store';
-import type { TreeIdParts, createTreeView } from './create';
+import type { createTreeView } from './create';
 
 export type CreateTreeViewProps = {
 	forceVisible?: boolean;
@@ -26,11 +26,6 @@ export type CreateTreeViewProps = {
 	 * @see https://melt-ui.com/docs/controlled#change-functions
 	 */
 	onExpandedChange?: ChangeFn<string[]>;
-
-	/**
-	 * Optionally override the default ids we assign to the elements
-	 */
-	ids?: IdObj<TreeIdParts>;
 };
 
 export type TreeParts = 'label' | 'item' | 'group';

--- a/src/lib/builders/tree/types.ts
+++ b/src/lib/builders/tree/types.ts
@@ -1,6 +1,7 @@
-import type { ChangeFn } from '$lib/internal/helpers';
+import type { ChangeFn, IdObj } from '$lib/internal/helpers';
 import type { Writable } from 'svelte/store';
-import type { createTreeView } from './create';
+import type { TreeIdParts, createTreeView } from './create';
+import type { Expand } from '$lib/internal/types';
 
 export type CreateTreeViewProps = {
 	forceVisible?: boolean;
@@ -26,6 +27,11 @@ export type CreateTreeViewProps = {
 	 * @see https://melt-ui.com/docs/controlled#change-functions
 	 */
 	onExpandedChange?: ChangeFn<string[]>;
+
+	/**
+	 * Optionally override the default ids we assign to the elements
+	 */
+	ids?: Expand<IdObj<TreeIdParts>>;
 };
 
 export type TreeParts = 'label' | 'item' | 'group';

--- a/src/lib/builders/tree/types.ts
+++ b/src/lib/builders/tree/types.ts
@@ -1,7 +1,6 @@
 import type { ChangeFn, IdObj } from '$lib/internal/helpers';
 import type { Writable } from 'svelte/store';
 import type { TreeIdParts, createTreeView } from './create';
-import type { Expand } from '$lib/internal/types';
 
 export type CreateTreeViewProps = {
 	forceVisible?: boolean;
@@ -31,7 +30,7 @@ export type CreateTreeViewProps = {
 	/**
 	 * Optionally override the default ids we assign to the elements
 	 */
-	ids?: Expand<IdObj<TreeIdParts>>;
+	ids?: IdObj<TreeIdParts>;
 };
 
 export type TreeParts = 'label' | 'item' | 'group';

--- a/src/lib/internal/helpers/id.ts
+++ b/src/lib/internal/helpers/id.ts
@@ -10,7 +10,7 @@ export function generateId(): string {
 
 export type IdObj<T extends string> = Expand<{ [K in T]: string }>;
 
-export function generateDefaultIds<T extends readonly string[]>(args: T): IdObj<T[number]> {
+export function generateIds<T extends readonly string[]>(args: T): IdObj<T[number]> {
 	return args.reduce((acc, curr) => {
 		acc[curr as keyof IdObj<T[number]>] = generateId() as IdObj<T[number]>[keyof IdObj<T[number]>];
 		return acc;

--- a/src/lib/internal/helpers/id.ts
+++ b/src/lib/internal/helpers/id.ts
@@ -8,11 +8,15 @@ export function generateId(): string {
 	return nanoid(10);
 }
 
-export type IdObj<T extends string> = Expand<{ [K in T]: string }>;
+export type IdObj<T extends readonly string[]> = Expand<{ [K in T[number]]: string }>;
 
-export function generateIds<T extends readonly string[]>(args: T): IdObj<T[number]> {
+export function generateIds<T extends readonly string[]>(args: T): IdObj<T> {
 	return args.reduce((acc, curr) => {
-		acc[curr as keyof IdObj<T[number]>] = generateId() as IdObj<T[number]>[keyof IdObj<T[number]>];
+		acc[curr as keyof IdObj<T>] = generateId() as IdObj<T>[keyof IdObj<T>];
 		return acc;
-	}, {} as IdObj<T[number]>);
+	}, {} as IdObj<T>);
+}
+
+export function stringifiedIdObjType<T extends readonly string[]>(args: T): string {
+	return `Record<${args.map((arg) => `"${arg}"`).join(' | ')}, string>`;
 }

--- a/src/lib/internal/helpers/id.ts
+++ b/src/lib/internal/helpers/id.ts
@@ -7,3 +7,12 @@ import { nanoid } from 'nanoid/non-secure';
 export function generateId(): string {
 	return nanoid(10);
 }
+
+export type IdObj<T extends string> = Expand<{ [K in T]: string }>;
+
+export function generateDefaultIds<T extends readonly string[]>(args: T): IdObj<T[number]> {
+	return args.reduce((acc, curr) => {
+		acc[curr as keyof IdObj<T[number]>] = generateId() as IdObj<T[number]>[keyof IdObj<T[number]>];
+		return acc;
+	}, {} as IdObj<T[number]>);
+}


### PR DESCRIPTION
Any builder where we apply default ids now exposes an `ids` prop which can be used to override those generated ids.

Related to #542 