### PR TITLE
fix: timing issue with `handleFocus`

### DIFF
--- a/.changeset/green-worms-punch.md
+++ b/.changeset/green-worms-punch.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+fix: timing issue with `handleFocus`

--- a/src/lib/internal/helpers/focus.ts
+++ b/src/lib/internal/helpers/focus.ts
@@ -10,20 +10,22 @@ type HandleFocusArgs = {
 
 export function handleFocus(args: HandleFocusArgs): void {
 	const { prop, defaultEl } = args;
-	if (prop === undefined) {
-		sleep(1).then(() => defaultEl?.focus());
-		return;
-	}
+	sleep(1).then(() => {
+		if (prop === undefined) {
+			defaultEl?.focus();
+			return;
+		}
 
-	const returned = isFunction(prop) ? prop(defaultEl) : prop;
+		const returned = isFunction(prop) ? prop(defaultEl) : prop;
 
-	if (typeof returned === 'string') {
-		// Get el by selector, focus it
-		const el = document.querySelector(returned);
-		if (!isHTMLElement(el)) return;
-		sleep(1).then(() => el.focus());
-	} else if (isHTMLElement(returned)) {
-		// Focus it
-		sleep(1).then(() => returned.focus());
-	}
+		if (typeof returned === 'string') {
+			// Get el by selector, focus it
+			const el = document.querySelector(returned);
+			if (!isHTMLElement(el)) return;
+			el.focus();
+		} else if (isHTMLElement(returned)) {
+			// Focus it
+			returned.focus();
+		}
+	});
 }

--- a/src/tests/dropdown-menu/DropdownMenu.spec.ts
+++ b/src/tests/dropdown-menu/DropdownMenu.spec.ts
@@ -6,6 +6,7 @@ import { testKbd as kbd } from '../utils.js';
 import DropdownMenuTest from './DropdownMenuTest.svelte';
 import DropdownMenuForceVisible from './DropdownMenuForceVisibleTest.svelte';
 import type { CreateDropdownMenuProps } from '$lib';
+import { sleep } from '$lib/internal/helpers/sleep.js';
 
 const OPEN_KEYS = [kbd.ENTER, kbd.ARROW_DOWN, kbd.SPACE];
 
@@ -183,6 +184,7 @@ describe('Dropdown Menu (Default)', () => {
 		expect(menu).toBeVisible();
 		await user.keyboard(kbd.ESCAPE);
 		const closeFocus = getByTestId('closeFocus');
+		await sleep(1);
 		expect(closeFocus).toHaveFocus();
 	});
 

--- a/src/tests/popover/Popover.spec.ts
+++ b/src/tests/popover/Popover.spec.ts
@@ -4,6 +4,7 @@ import PopoverTest from './PopoverTest.svelte';
 import userEvent from '@testing-library/user-event';
 import type { CreatePopoverProps } from '$lib';
 import { testKbd as kbd } from '../utils';
+import { sleep } from '$lib/internal/helpers';
 
 function setup(props: CreatePopoverProps = {}) {
 	const user = userEvent.setup();
@@ -66,6 +67,7 @@ describe('Popover (Default)', () => {
 		await user.click(trigger);
 		await waitFor(() => expect(content).toBeVisible());
 		const openFocus = getByTestId('openFocus');
+		await sleep(1);
 		expect(openFocus).toHaveFocus();
 	});
 
@@ -81,6 +83,7 @@ describe('Popover (Default)', () => {
 		await user.keyboard(kbd.ESCAPE);
 		await waitFor(() => expect(content).not.toBeVisible());
 		const closeFocus = getByTestId('closeFocus');
+		await sleep(1);
 		expect(closeFocus).toHaveFocus();
 	});
 });


### PR DESCRIPTION
Since elements like the popover and other floating/conditionally visible elements do not exist in the DOM until after they are opened, there is a timing issue where it is possible that the element you wish to focus on open/close is not yet in the DOM which results in unexpected behavior.

This PR moves the execution of the `FocusTarget` function inside of the `sleep()` promise to ensure we give the DOM a chance to update before calling that function.