### PR TITLE
[Toast] - Swipe to close

### DIFF
--- a/.changeset/weak-dolphins-brake.md
+++ b/.changeset/weak-dolphins-brake.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+[Toast] - Swipe to close

--- a/src/docs/data/builders/toast.ts
+++ b/src/docs/data/builders/toast.ts
@@ -20,6 +20,24 @@ const OPTION_PROPS = [
 		default: "'foreground'",
 		description: 'The sensitivity of the toast for accessibility purposes.',
 	},
+	{
+		name: 'closeOnSwipe',
+		type: 'boolean',
+		default: 'true',
+		description: 'Whether the toast should be closed when the user swipes it.',
+	},
+	{
+		name: 'swipeDirection',
+		type: ["'up'", "'down'", "'left'", "'right'"],
+		default: "'right'",
+		description: 'The direction of the swipe gesture to close the toast.',
+	},
+	{
+		name: 'swipeThreshold',
+		type: 'number',
+		default: '50',
+		description: 'The minimum distance in pixels the swipe gesture must travel to close the toast.',
+	},
 ];
 
 const BUILDER_NAME = 'toast';

--- a/src/docs/previews/toast/main/tailwind/index.svelte
+++ b/src/docs/previews/toast/main/tailwind/index.svelte
@@ -88,3 +88,13 @@
 		</div>
 	{/each}
 </div>
+
+<style lang="postcss">
+	[data-melt-toast-content][data-swipe='move'] {
+		transform: translateX(var(--melt-toast-swipe-move-x));
+	}
+	[data-melt-toast-content][data-swipe='cancel'] {
+		transform: translateX(0);
+		transition: transform 200ms ease-out;
+	}
+</style>

--- a/src/docs/utils/transition.ts
+++ b/src/docs/utils/transition.ts
@@ -17,6 +17,7 @@ type FlyAndScaleOptions = {
 	start: number;
 	duration?: number;
 };
+
 export const flyAndScale = (node: HTMLElement, options: FlyAndScaleOptions): TransitionConfig => {
 	const style = getComputedStyle(node);
 	const transform = style.transform === 'none' ? '' : style.transform;
@@ -36,3 +37,30 @@ export const flyAndScale = (node: HTMLElement, options: FlyAndScaleOptions): Tra
 		easing: cubicOut,
 	};
 };
+export function split_css_unit(value: number | string): [number, string] {
+	const split = typeof value === 'string' && value.match(/^\s*(-?[\d.]+)([^\s]*)\s*$/);
+	return split ? [parseFloat(split[1]), split[2] || 'px'] : ([value, 'px'] as [number, string]);
+}
+
+export function customFly(
+	node: HTMLElement,
+	{ delay = 0, duration = 400, easing = cubicOut, x = 0, y = 0, opacity = 0 } = {}
+): TransitionConfig {
+	const style = getComputedStyle(node);
+	const target_opacity = +style.opacity;
+	const transform = style.transform === 'none' ? '' : style.transform;
+	const od = target_opacity * (1 - opacity);
+	const [xValue, xUnit] = split_css_unit(x);
+	const [yValue, yUnit] = split_css_unit(y);
+	const xDrag = node.style.getPropertyValue('--melt-toast-swipe-end-x');
+	return {
+		delay,
+		duration,
+		easing,
+		css: (t, u) => `
+			transform: ${transform} translate(${(1 - t) * xValue - Number(xDrag)}${xUnit}, ${
+			(1 - t) * yValue
+		}${yUnit});
+			opacity: ${target_opacity - od * u}`,
+	};
+}

--- a/src/docs/utils/transition.ts
+++ b/src/docs/utils/transition.ts
@@ -37,30 +37,3 @@ export const flyAndScale = (node: HTMLElement, options: FlyAndScaleOptions): Tra
 		easing: cubicOut,
 	};
 };
-export function split_css_unit(value: number | string): [number, string] {
-	const split = typeof value === 'string' && value.match(/^\s*(-?[\d.]+)([^\s]*)\s*$/);
-	return split ? [parseFloat(split[1]), split[2] || 'px'] : ([value, 'px'] as [number, string]);
-}
-
-export function customFly(
-	node: HTMLElement,
-	{ delay = 0, duration = 400, easing = cubicOut, x = 0, y = 0, opacity = 0 } = {}
-): TransitionConfig {
-	const style = getComputedStyle(node);
-	const target_opacity = +style.opacity;
-	const transform = style.transform === 'none' ? '' : style.transform;
-	const od = target_opacity * (1 - opacity);
-	const [xValue, xUnit] = split_css_unit(x);
-	const [yValue, yUnit] = split_css_unit(y);
-	const xDrag = node.style.getPropertyValue('--melt-toast-swipe-end-x');
-	return {
-		delay,
-		duration,
-		easing,
-		css: (t, u) => `
-			transform: ${transform} translate(${(1 - t) * xValue - Number(xDrag)}${xUnit}, ${
-			(1 - t) * yValue
-		}${yUnit});
-			opacity: ${target_opacity - od * u}`,
-	};
-}

--- a/src/lib/builders/toast/types.ts
+++ b/src/lib/builders/toast/types.ts
@@ -4,10 +4,28 @@ export type { ToastComponentEvents } from './events.js';
 export type EmptyType = Record<never, never>;
 
 export type CreateToasterProps = {
-	// Time in milliseconds before the toast is automatically closed.
-	// If set to 0, the toast will not be automatically closed.
+	/**
+	 * Time in milliseconds before the toast is automatically closed.
+	 * If set to 0, the toast will not be automatically closed.
+	 */
 	closeDelay?: number;
+
 	type?: 'foreground' | 'background';
+
+	/**
+	 * Whether the toast should be closed when the user swipes it.
+	 */
+	closeOnSwipe?: boolean;
+
+	/**
+	 * The direction of the swipe gesture to close the toast.
+	 */
+	swipeDirection?: SwipeDirection;
+
+	/**
+	 * The minimum distance in pixels the swipe gesture must travel to close the toast.
+	 */
+	swipeThreshold?: number;
 };
 
 export type AddToastProps<T = object> = CreateToasterProps & {
@@ -36,3 +54,5 @@ export type ToastsElements<T = object> = BuilderReturn<typeof createToaster<T>>[
 export type ToastsOptions<T = object> = BuilderReturn<typeof createToaster<T>>['options'];
 export type ToastsStates<T = object> = BuilderReturn<typeof createToaster<T>>['states'];
 export type ToastsHelpers<T = object> = BuilderReturn<typeof createToaster<T>>['helpers'];
+
+export type SwipeDirection = 'up' | 'down' | 'left' | 'right';


### PR DESCRIPTION
This PR adds the ability to swipe to close the toasts, and comes with 3 new props:

`closeOnSwipe` - Whether to close the toast on swipe (defaults to `true`)
`swipeDirection` - Which swipe direction should close the toast
`swipeThreshold` - The minimum amount of pixels that the gesture should cover before closing the toast.