### PR TITLE
Use properly cased hidden input element name

### DIFF
--- a/src/docs/data/builders/select.ts
+++ b/src/docs/data/builders/select.ts
@@ -87,7 +87,7 @@ const builder = builderSchema(BUILDER_NAME, {
 			description: 'The builder store used to create the select options.',
 		},
 		{
-			name: 'hidden-input',
+			name: 'hiddenInput',
 			description: 'The builder store used to create the select hidden input.',
 		},
 		{


### PR DESCRIPTION
Fix wrong element name in the builder data of `Select` docs.