### PR TITLE
fix: prevent safari from minimizing when esc on dialogs

### DIFF
--- a/.changeset/itchy-drinks-taste.md
+++ b/.changeset/itchy-drinks-taste.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+Fix: prevent safari from minimizing when esc on dialogs

--- a/src/lib/internal/actions/escape-keydown/action.ts
+++ b/src/lib/internal/actions/escape-keydown/action.ts
@@ -55,6 +55,8 @@ export const useEscapeKeydown = (node: HTMLElement, config: EscapeKeydownConfig 
 			return;
 		}
 
+		e.preventDefault();
+
 		// If an ignore function is passed, check if it returns true
 		if (options.ignore) {
 			if (isFunction(options.ignore)) {

--- a/src/lib/internal/actions/popper/action.ts
+++ b/src/lib/internal/actions/popper/action.ts
@@ -80,8 +80,7 @@ export const usePopper: Action<HTMLElement, PopperArgs> = (popperElement, args) 
 		callbacks.push(
 			useEscapeKeydown(popperElement, {
 				enabled: open,
-				handler: (e: KeyboardEvent) => {
-					if (e.defaultPrevented) return;
+				handler: () => {
 					open.set(false);
 				},
 				...opts.escapeKeydown,


### PR DESCRIPTION
fixes: #702 