### PR TITLE
Fix: Dialog layout shift when using svelte transitions

### DIFF
--- a/src/docs/previews/dialog/alert/css/index.svelte
+++ b/src/docs/previews/dialog/alert/css/index.svelte
@@ -17,6 +17,7 @@
 		states: { open },
 	} = createDialog({
 		role: 'alertdialog',
+		forceVisible: true,
 	});
 </script>
 

--- a/src/docs/previews/dialog/alert/tailwind/index.svelte
+++ b/src/docs/previews/dialog/alert/tailwind/index.svelte
@@ -17,6 +17,7 @@
 		states: { open },
 	} = createDialog({
 		role: 'alertdialog',
+		forceVisible: true,
 	});
 </script>
 

--- a/src/docs/previews/dialog/controlled/css/index.svelte
+++ b/src/docs/previews/dialog/controlled/css/index.svelte
@@ -20,6 +20,7 @@
 		states: { open },
 	} = createDialog({
 		open: customOpen,
+		forceVisible: true,
 	});
 </script>
 

--- a/src/docs/previews/dialog/controlled/tailwind/index.svelte
+++ b/src/docs/previews/dialog/controlled/tailwind/index.svelte
@@ -20,6 +20,7 @@
 		states: { open },
 	} = createDialog({
 		open: customOpen,
+		forceVisible: true,
 	});
 </script>
 

--- a/src/docs/previews/dialog/drawer/css/index.svelte
+++ b/src/docs/previews/dialog/drawer/css/index.svelte
@@ -15,7 +15,9 @@
 			portalled,
 		},
 		states: { open },
-	} = createDialog();
+	} = createDialog({
+		forceVisible: true,
+	});
 </script>
 
 <button use:melt={$trigger} class="trigger"> View Notifications </button>

--- a/src/docs/previews/dialog/main/tailwind/index.svelte
+++ b/src/docs/previews/dialog/main/tailwind/index.svelte
@@ -17,7 +17,7 @@
 		},
 		states: { open },
 	} = createDialog({
-		forceVisible: false,
+		forceVisible: true,
 	});
 </script>
 

--- a/src/docs/previews/dialog/nested/css/index.svelte
+++ b/src/docs/previews/dialog/nested/css/index.svelte
@@ -15,7 +15,9 @@
 			portalled,
 		},
 		states: { open },
-	} = createDialog();
+	} = createDialog({
+		forceVisible: true,
+	});
 
 	const {
 		elements: {
@@ -28,7 +30,9 @@
 			portalled: portalledNested,
 		},
 		states: { open: openNested },
-	} = createDialog();
+	} = createDialog({
+		forceVisible: true,
+	});
 </script>
 
 <button use:melt={$trigger} class="trigger"> Open Dialog </button>

--- a/src/docs/previews/dialog/nested/tailwind/index.svelte
+++ b/src/docs/previews/dialog/nested/tailwind/index.svelte
@@ -15,7 +15,7 @@
 			portalled,
 		},
 		states: { open },
-	} = createDialog();
+	} = createDialog({ forceVisible: true });
 
 	const {
 		elements: {
@@ -28,7 +28,7 @@
 			portalled: portalledNested,
 		},
 		states: { open: openNested },
-	} = createDialog();
+	} = createDialog({ forceVisible: true });
 </script>
 
 <button

--- a/src/lib/builders/dialog/create.ts
+++ b/src/lib/builders/dialog/create.ts
@@ -89,25 +89,6 @@ export function createDialog(props?: CreateDialogProps) {
 
 	let unsubScroll = noop;
 
-	// function onOpenChange(props: { curr: boolean; next: boolean }) {
-	// 	const next = withDefaults.onOpenChange ? withDefaults.onOpenChange(props) : props.next;
-	// 	if (next) return next;
-	// 	const modalEl = document.getElementById(get(ids.portalled));
-	// 	if (!modalEl) {
-	// 		console.log('no modal el');
-	// 		return next;
-	// 	}
-	// 	supportClosingAnimation(
-	// 		modalEl,
-	// 		() => {
-	// 			open.set(false);
-	// 			console.log('animation end just set open to false');
-	// 		},
-	// 		clearScrollLocks
-	// 	);
-	// 	return next;
-	// }
-
 	function handleOpen(e: Event) {
 		const el = e.currentTarget;
 		const triggerEl = e.currentTarget;
@@ -367,6 +348,8 @@ export function createDialog(props?: CreateDialogProps) {
 		}
 
 		return () => {
+			// we only want to remove the scroll lock if the dialog is not forced visible
+			// otherwise the scroll removal is handled in the `destroy` of the `content` builder
 			if (!get(forceVisible)) {
 				unsubScroll();
 			}


### PR DESCRIPTION
This PR fixes an issue where the layout would shift due to the scrollbar being re-added before the outro animation/transition was complete.

It does not address/attempt to address the issue for those _not_ using `forceVisible`, as this will require extra effort and thought into how we're handling `display: none` depending on `open`.

### What changed?

Previously, regardless of `forceVisible`, we were removing the scroll as soon as `open = true`, and adding it back as soon as `open = false`.

Now, we still remove it as soon as `open = true`, however, for those using `forceVisible`, since the content conditionally rendered based on the value of `open`, we're unsubbing from the scroll removal in the `destroy` of the `content`, which is called _after_ all transitions/animations have completed. 

 