### PR TITLE
Docs: Dialog fixes

### DIFF
--- a/src/docs/content/builders/dialog.md
+++ b/src/docs/content/builders/dialog.md
@@ -21,7 +21,8 @@ At a high level, the anatomy of a dialog looks like this:
 <script lang="ts">
 	import { createDialog, melt } from '@melt-ui/svelte'
 	const {
-		elements: { trigger, portalled, overlay, content, title, description, close, open }
+		elements: { trigger, portalled, overlay, content, title, description, close },
+		states: { open }
 	} = createDialog()
 </script>
 

--- a/src/docs/content/builders/dialog.md
+++ b/src/docs/content/builders/dialog.md
@@ -21,8 +21,7 @@ At a high level, the anatomy of a dialog looks like this:
 <script lang="ts">
 	import { createDialog, melt } from '@melt-ui/svelte'
 	const {
-		elements: { trigger, portalled, overlay, content, title, description, close },
-		states: { open }
+		elements: { trigger, portalled, overlay, content, title, description, close }
 	} = createDialog()
 </script>
 

--- a/src/docs/data/builders/dialog.ts
+++ b/src/docs/data/builders/dialog.ts
@@ -36,6 +36,10 @@ const builder = builderSchema(BUILDER_NAME, {
 			description: 'The builder store used to create the dialog trigger.',
 		},
 		{
+			name: 'portalled',
+			description: 'The builder store used to create the portalled dialog container.',
+		},
+		{
 			name: 'overlay',
 			description: 'The builder store used to create the dialog overlay.',
 		},


### PR DESCRIPTION
Closes #715 and another unreported issue (missing `portalled` element in the [API reference](https://www.melt-ui.com/docs/builders/dialog#:~:text=for%20the%20elements.-,Elements,-Open%20popover))