### PR TITLE
fix: space to select select options

### DIFF
--- a/.changeset/rude-glasses-reflect.md
+++ b/.changeset/rude-glasses-reflect.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+fix: space to select select options

--- a/src/lib/builders/listbox/create.ts
+++ b/src/lib/builders/listbox/create.ts
@@ -19,6 +19,7 @@ import {
 	hiddenInputAttrs,
 	isBrowser,
 	isElementDisabled,
+	isHTMLButtonElement,
 	isHTMLElement,
 	isHTMLInputElement,
 	kbd,
@@ -302,7 +303,7 @@ export function createListbox<
 
 						// Clicking space on a button triggers a click event. We don't want to
 						// open the menu in this case, and we let the click handler handle it.
-						if (e.key === kbd.SPACE && node instanceof HTMLButtonElement) {
+						if (e.key === kbd.SPACE && isHTMLButtonElement(node)) {
 							return;
 						}
 
@@ -342,7 +343,7 @@ export function createListbox<
 						return;
 					}
 					// Pressing enter with a highlighted item should select it.
-					if (e.key === kbd.ENTER) {
+					if (e.key === kbd.ENTER || (e.key === kbd.SPACE && isHTMLButtonElement(node))) {
 						e.preventDefault();
 						const $highlightedItem = get(highlightedItem);
 						if ($highlightedItem) {

--- a/src/lib/internal/helpers/is.ts
+++ b/src/lib/internal/helpers/is.ts
@@ -20,6 +20,10 @@ export function isHTMLLabelElement(element: unknown): element is HTMLLabelElemen
 	return element instanceof HTMLLabelElement;
 }
 
+export function isHTMLButtonElement(element: unknown): element is HTMLButtonElement {
+	return element instanceof HTMLButtonElement;
+}
+
 export function isElementDisabled(element: HTMLElement): boolean {
 	const ariaDisabled = element.getAttribute('aria-disabled');
 	const disabled = element.getAttribute('disabled');


### PR DESCRIPTION
Closes: #729 as a patch fix for now.

In the future, maybe it's worth exploring rather than relying on if the element is truly a `<button />` or not and instead maybe accept a prop to the listbox builder for the specific type of listbox we're working with (combobox or select) to clean this up a bit.

Would cover those cases where someone is using say a `<div role="button />` instead of a `<button />`.