### PR TITLE
Fix: Close on ESC in Select prevents closing Dialog 

### DIFF
--- a/src/lib/builders/listbox/create.ts
+++ b/src/lib/builders/listbox/create.ts
@@ -261,6 +261,7 @@ export function createListbox<
 				'aria-expanded': $open,
 				'aria-labelledby': $labelId,
 				// autocomplete: 'off',
+				'data-state': $open ? 'open' : 'closed',
 				id: $triggerId,
 				role: 'combobox',
 				disabled: disabledAttr($disabled),

--- a/src/lib/builders/listbox/create.ts
+++ b/src/lib/builders/listbox/create.ts
@@ -444,6 +444,7 @@ export function createListbox<
 				id: $menuId,
 				role: 'listbox',
 				style: styleToString({ display: $isVisible ? undefined : 'none' }),
+				'data-state': $isVisible ? 'open' : 'closed',
 			} as const;
 		},
 		action: (node: HTMLElement): MeltActionReturn<ListboxEvents['menu']> => {

--- a/src/lib/internal/actions/escape-keydown/action.ts
+++ b/src/lib/internal/actions/escape-keydown/action.ts
@@ -51,7 +51,7 @@ export const useEscapeKeydown = (node: HTMLElement, config: EscapeKeydownConfig 
 		if (!e || !isEnabled()) return;
 		const target = e.target;
 
-		if (!isHTMLElement(target) || target.closest('[data-escapee]') !== node) {
+		if (!isHTMLElement(target) || target.closest("[data-escapee][data-state='open']") !== node) {
 			return;
 		}
 


### PR DESCRIPTION
closes #700 

Tweaked `useEscapeKeydown` to check for the node closest to the target that has both `data-escapee` and is open (`data-state='open'`).  This allows Dialog to close when the Select inside it is already closed (without the user needing to click away/removing focus from Select's trigger) and other similar cases with nested escape-able elements