### PR TITLE
Fix: Key events in Select don't work in Safari

### DIFF
--- a/.changeset/purple-pumpkins-sit.md
+++ b/.changeset/purple-pumpkins-sit.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+Fix: Key events in Select don't work in Safari

--- a/src/lib/builders/listbox/create.ts
+++ b/src/lib/builders/listbox/create.ts
@@ -271,6 +271,7 @@ export function createListbox<
 
 			const unsubscribe = executeCallbacks(
 				addMeltEventListener(node, 'click', () => {
+					node.focus(); // Fix for safari not adding focus on trigger
 					const $open = get(open);
 					if ($open) {
 						closeMenu();


### PR DESCRIPTION
closes #740