### PR TITLE
Prevent TOC content from being unreachable (overflow below screen edge)

### DIFF
--- a/src/routes/docs/builders/[name]/+page.svelte
+++ b/src/routes/docs/builders/[name]/+page.svelte
@@ -49,7 +49,7 @@
 		<!-- <DocsPager /> -->
 	</div>
 	<div class="hidden text-sm xl:block">
-		<div class="fixed top-16 h-[calc(100vh-4rem)] overflow-visible pt-6">
+		<div class="fixed top-16 h-[calc(100vh-4rem)] overflow-x-visible overflow-y-auto pt-6">
 			{#key $page.url.pathname}
 				<TOC />
 			{/key}

--- a/src/routes/docs/builders/[name]/+page.svelte
+++ b/src/routes/docs/builders/[name]/+page.svelte
@@ -49,7 +49,7 @@
 		<!-- <DocsPager /> -->
 	</div>
 	<div class="hidden text-sm xl:block">
-		<div class="fixed top-16 h-[calc(100vh-4rem)] overflow-x-visible overflow-y-auto pt-6">
+		<div class="fixed top-16 h-[calc(100vh-4rem)] overflow-y-auto overflow-x-visible py-6 pr-4">
 			{#key $page.url.pathname}
 				<TOC />
 			{/key}


### PR DESCRIPTION
Changed `overflow-visible` to `overflow-x-visible overflow-y-auto` to prevent TOC content (Calendar builder and maybe more?) from overflowing at the bottom of the screen and become unreachable. (1920x1080px screen)

Screenshot :
![image](https://github.com/melt-ui/melt-ui/assets/90099349/72eba2e9-6a5d-4cef-9b2b-f98e3fcc97a7)
