### PR TITLE
Added plugin tailwind-scrollbar with examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
 		"svelte-preprocess": "^5.0.4",
 		"svelte-sequential-preprocessor": "^2.0.1",
 		"tailwind-merge": "^1.14.0",
+		"tailwind-scrollbar": "^3.0.5",
 		"tailwind-variants": "^0.1.8",
 		"tailwindcss": "^3.3.3",
 		"tslib": "^2.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,6 +241,9 @@ devDependencies:
   tailwind-merge:
     specifier: ^1.14.0
     version: 1.14.0
+  tailwind-scrollbar:
+    specifier: ^3.0.5
+    version: 3.0.5(tailwindcss@3.3.3)
   tailwind-variants:
     specifier: ^0.1.8
     version: 0.1.8(tailwindcss@3.3.3)
@@ -258,7 +261,7 @@ devDependencies:
     version: 4.1.2
   vite:
     specifier: ^4.4.7
-    version: 4.4.7(@types/node@20.3.1)(less@4.1.3)
+    version: 4.4.7(@types/node@20.9.0)(less@4.1.3)
   vitest:
     specifier: ^0.33.0
     version: 0.33.0(happy-dom@10.5.2)(jsdom@22.1.0)(less@4.1.3)
@@ -2263,7 +2266,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 20.3.1
+      '@types/node': 20.9.0
       '@types/yargs': 16.0.5
       chalk: 4.1.2
     dev: true
@@ -2275,7 +2278,7 @@ packages:
       '@jest/schemas': 29.6.0
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 20.3.1
+      '@types/node': 20.9.0
       '@types/yargs': 17.0.24
       chalk: 4.1.2
     dev: true
@@ -3511,7 +3514,7 @@ packages:
       remark-slug: 6.1.0
       rollup: 3.25.2
       typescript: 5.1.6
-      vite: 4.4.7(@types/node@20.3.1)(less@4.1.3)
+      vite: 4.4.7(@types/node@20.9.0)(less@4.1.3)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -4202,7 +4205,7 @@ packages:
       svelte: 4.0.0
       sveltedoc-parser: 4.2.1
       ts-dedent: 2.2.0
-      vite: 4.4.7(@types/node@20.3.1)(less@4.1.3)
+      vite: 4.4.7(@types/node@20.9.0)(less@4.1.3)
     transitivePeerDependencies:
       - '@preact/preset-vite'
       - encoding
@@ -4243,7 +4246,7 @@ packages:
       '@storybook/svelte': 7.3.2(svelte@4.0.0)
       '@storybook/svelte-vite': 7.3.2(svelte@4.0.0)(typescript@5.1.6)(vite@4.4.7)
       svelte: 4.0.0
-      vite: 4.4.7(@types/node@20.3.1)(less@4.1.3)
+      vite: 4.4.7(@types/node@20.9.0)(less@4.1.3)
     transitivePeerDependencies:
       - '@preact/preset-vite'
       - encoding
@@ -4415,7 +4418,7 @@ packages:
       sirv: 2.0.2
       svelte: 4.0.0
       undici: 5.22.1
-      vite: 4.4.7(@types/node@20.3.1)(less@4.1.3)
+      vite: 4.4.7(@types/node@20.9.0)(less@4.1.3)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4448,7 +4451,7 @@ packages:
       '@sveltejs/vite-plugin-svelte': 2.4.2(svelte@4.0.0)(vite@4.4.7)
       debug: 4.3.4
       svelte: 4.0.0
-      vite: 4.4.7(@types/node@20.3.1)(less@4.1.3)
+      vite: 4.4.7(@types/node@20.9.0)(less@4.1.3)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4467,7 +4470,7 @@ packages:
       magic-string: 0.30.0
       svelte: 4.0.0
       svelte-hmr: 0.15.2(svelte@4.0.0)
-      vite: 4.4.7(@types/node@20.3.1)(less@4.1.3)
+      vite: 4.4.7(@types/node@20.9.0)(less@4.1.3)
       vitefu: 0.2.4(vite@4.4.7)
     transitivePeerDependencies:
       - supports-color
@@ -4591,7 +4594,7 @@ packages:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
     dependencies:
       '@types/connect': 3.4.35
-      '@types/node': 20.3.1
+      '@types/node': 20.9.0
     dev: true
 
   /@types/chai-subset@1.3.3:
@@ -4607,7 +4610,7 @@ packages:
   /@types/connect@3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
-      '@types/node': 20.3.1
+      '@types/node': 20.9.0
     dev: true
 
   /@types/cookie@0.5.1:
@@ -4617,7 +4620,7 @@ packages:
   /@types/cross-spawn@6.0.2:
     resolution: {integrity: sha512-KuwNhp3eza+Rhu8IFI5HUXRP0LIhqH5cAjubUvGXXthh4YYBuP2ntwEX+Cz8GJoZUHlKo247wPWOfA9LYEq4cw==}
     dependencies:
-      '@types/node': 20.3.1
+      '@types/node': 20.9.0
     dev: true
 
   /@types/debug@4.1.8:
@@ -4663,7 +4666,7 @@ packages:
   /@types/express-serve-static-core@4.17.35:
     resolution: {integrity: sha512-wALWQwrgiB2AWTT91CB62b6Yt0sNHpznUXeZEcnPU3DRdlDIz74x8Qg1UUYKSVFi+va5vKOLYRBI1bRKiLLKIg==}
     dependencies:
-      '@types/node': 20.3.1
+      '@types/node': 20.9.0
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
       '@types/send': 0.17.1
@@ -4685,7 +4688,7 @@ packages:
   /@types/graceful-fs@4.1.6:
     resolution: {integrity: sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==}
     dependencies:
-      '@types/node': 20.3.1
+      '@types/node': 20.9.0
     dev: true
 
   /@types/hast@2.3.4:
@@ -4771,7 +4774,7 @@ packages:
   /@types/node-fetch@2.6.4:
     resolution: {integrity: sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==}
     dependencies:
-      '@types/node': 20.3.1
+      '@types/node': 20.9.0
       form-data: 3.0.1
     dev: true
 
@@ -4789,8 +4792,10 @@ packages:
       undici-types: 5.26.5
     dev: true
 
-  /@types/node@20.3.1:
-    resolution: {integrity: sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg==}
+  /@types/node@20.9.0:
+    resolution: {integrity: sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==}
+    dependencies:
+      undici-types: 5.26.5
     dev: true
 
   /@types/normalize-package-data@2.4.1:
@@ -4845,14 +4850,14 @@ packages:
     resolution: {integrity: sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==}
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 20.3.1
+      '@types/node': 20.9.0
     dev: true
 
   /@types/serve-static@1.15.1:
     resolution: {integrity: sha512-NUo5XNiAdULrJENtJXZZ3fHtfMolzZwczzBbnAeBbqBwG+LaG6YaJtuwzwGSQZ2wsCrxjEhNNjAkKigy3n8teQ==}
     dependencies:
       '@types/mime': 3.0.1
-      '@types/node': 20.3.1
+      '@types/node': 20.9.0
     dev: true
 
   /@types/stack-utils@2.0.1:
@@ -8472,7 +8477,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.1
       '@types/graceful-fs': 4.1.6
-      '@types/node': 20.3.1
+      '@types/node': 20.9.0
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -8525,7 +8530,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 20.3.1
+      '@types/node': 20.9.0
     dev: true
 
   /jest-regex-util@29.4.3:
@@ -8538,7 +8543,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.1
-      '@types/node': 20.3.1
+      '@types/node': 20.9.0
       chalk: 4.1.2
       ci-info: 3.8.0
       graceful-fs: 4.2.11
@@ -8549,7 +8554,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 20.3.1
+      '@types/node': 20.9.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -8558,7 +8563,7 @@ packages:
     resolution: {integrity: sha512-NcrQnevGoSp4b5kg+akIpthoAFHxPBcb5P6mYPY0fUNT+sSvmtu6jlkEle3anczUKIKEbMxFimk9oTP/tpIPgA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@types/node': 20.3.1
+      '@types/node': 20.9.0
       jest-util: 29.6.2
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -11835,6 +11840,15 @@ packages:
     resolution: {integrity: sha512-3mFKyCo/MBcgyOTlrY8T7odzZFx+w+qKSMAmdFzRvqBfLlSigU6TZnlFHK0lkMwj9Bj8OYU+9yW9lmGuS0QEnQ==}
     dev: true
 
+  /tailwind-scrollbar@3.0.5(tailwindcss@3.3.3):
+    resolution: {integrity: sha512-0ZwxTivevqq9BY9fRP9zDjHl7Tu+J5giBGbln+0O1R/7nHtBUKnjQcA1aTIhK7Oyjp6Uc/Dj6/dn8Dq58k5Uww==}
+    engines: {node: '>=12.13.0'}
+    peerDependencies:
+      tailwindcss: 3.x
+    dependencies:
+      tailwindcss: 3.3.3
+    dev: true
+
   /tailwind-variants@0.1.8(tailwindcss@3.3.3):
     resolution: {integrity: sha512-U4wzqr3GN1lvHU4XKJ0Th7Rn007SKB4cLqU0eed4bUEiydw/83G48EQ8MPo2VwEiuFOGcL1IAlAHU81wxDB9fQ==}
     engines: {node: '>=16.x', pnpm: '>=7.x'}
@@ -12562,7 +12576,7 @@ packages:
       vfile-message: 3.1.4
     dev: true
 
-  /vite-node@0.33.0(@types/node@20.3.1)(less@4.1.3):
+  /vite-node@0.33.0(@types/node@20.9.0)(less@4.1.3):
     resolution: {integrity: sha512-19FpHYbwWWxDr73ruNahC+vtEdza52kA90Qb3La98yZ0xULqV8A5JLNPUff0f5zID4984tW7l3DH2przTJUZSw==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
@@ -12572,7 +12586,7 @@ packages:
       mlly: 1.4.0
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 4.4.7(@types/node@20.3.1)(less@4.1.3)
+      vite: 4.4.7(@types/node@20.9.0)(less@4.1.3)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -12584,7 +12598,7 @@ packages:
       - terser
     dev: true
 
-  /vite@4.4.7(@types/node@20.3.1)(less@4.1.3):
+  /vite@4.4.7(@types/node@20.9.0)(less@4.1.3):
     resolution: {integrity: sha512-6pYf9QJ1mHylfVh39HpuSfMPojPSKVxZvnclX1K1FyZ1PXDOcLBibdq5t1qxJSnL63ca8Wf4zts6mD8u8oc9Fw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -12612,7 +12626,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 20.3.1
+      '@types/node': 20.9.0
       esbuild: 0.18.17
       less: 4.1.3
       postcss: 8.4.27
@@ -12629,7 +12643,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 4.4.7(@types/node@20.3.1)(less@4.1.3)
+      vite: 4.4.7(@types/node@20.9.0)(less@4.1.3)
     dev: true
 
   /vitest@0.33.0(happy-dom@10.5.2)(jsdom@22.1.0)(less@4.1.3):
@@ -12665,7 +12679,7 @@ packages:
     dependencies:
       '@types/chai': 4.3.5
       '@types/chai-subset': 1.3.3
-      '@types/node': 20.3.1
+      '@types/node': 20.9.0
       '@vitest/expect': 0.33.0
       '@vitest/runner': 0.33.0
       '@vitest/snapshot': 0.33.0
@@ -12686,8 +12700,8 @@ packages:
       strip-literal: 1.0.1
       tinybench: 2.5.0
       tinypool: 0.6.0
-      vite: 4.4.7(@types/node@20.3.1)(less@4.1.3)
-      vite-node: 0.33.0(@types/node@20.3.1)(less@4.1.3)
+      vite: 4.4.7(@types/node@20.9.0)(less@4.1.3)
+      vite-node: 0.33.0(@types/node@20.9.0)(less@4.1.3)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less

--- a/src/app.postcss
+++ b/src/app.postcss
@@ -15,7 +15,7 @@ body {
 
 @layer components {
 	.link {
-		@apply underline decoration-white/50 underline-offset-4 opacity-75 active:translate-y-px hocus:decoration-magnum-500 hocus:opacity-100;
+		@apply underline decoration-white/50 underline-offset-4 opacity-75 hocus:decoration-magnum-500 hocus:opacity-100 active:translate-y-px;
 	}
 }
 

--- a/src/docs/components/file-tabs/tab.svelte
+++ b/src/docs/components/file-tabs/tab.svelte
@@ -10,8 +10,8 @@
 <button
 	use:melt={$trigger(tab)}
 	class="border-neutral-700/50 bg-neutral-700/30 px-3 py-2 text-neutral-400
-        opacity-90 transition even:border-l first-of-type:rounded-tl-md last-of-type:border-r hover:opacity-100
-        focus-visible:!border-magnum-400 focus-visible:!text-magnum-400 focus-visible:!ring-0 data-[state=active]:bg-[#1E1E1E] data-[state=active]:py-2 data-[state=active]:text-magnum-600 data-[state=active]:opacity-100 data-[state=inactive]:hover:bg-neutral-700/40"
+        opacity-90 transition even:border-l first-of-type:rounded-tl-md last-of-type:border-r data-[state=active]:bg-[#1E1E1E]
+        data-[state=active]:py-2 data-[state=active]:text-magnum-600 data-[state=active]:opacity-100 hover:opacity-100 data-[state=inactive]:hover:bg-neutral-700/40 focus-visible:!border-magnum-400 focus-visible:!text-magnum-400 focus-visible:!ring-0"
 >
 	<div class="flex items-center gap-2 px-1">
 		<span class="font-mono text-xs font-semibold">{tab}</span>

--- a/src/docs/components/preview-style-select.svelte
+++ b/src/docs/components/preview-style-select.svelte
@@ -39,9 +39,9 @@
 >
 	{#each options as o}
 		<li
-			class="relative cursor-pointer rounded-md py-1 pl-8 pr-4 text-neutral-400 outline-none focus:!text-magnum-400
-			data-[disabled]:pointer-events-none data-[disabled]:cursor-not-allowed data-[selected]:text-magnum-600
-			data-[disabled]:line-through"
+			class="relative cursor-pointer rounded-md py-1 pl-8 pr-4 text-neutral-400 outline-none data-[disabled]:pointer-events-none
+			data-[disabled]:cursor-not-allowed data-[selected]:text-magnum-600 data-[disabled]:line-through
+			focus:!text-magnum-400"
 			use:melt={$option({ ...o })}
 		>
 			{#if $isSelected(o.value)}

--- a/src/docs/components/tabs/tab.svelte
+++ b/src/docs/components/tabs/tab.svelte
@@ -11,8 +11,8 @@
 <button
 	use:melt={$trigger(tab)}
 	class="rounded-lg border border-transparent bg-neutral-800 px-3 py-2 text-neutral-400 transition
-        hover:opacity-100 focus-visible:!border-magnum-400 focus-visible:!text-magnum-400 focus-visible:!ring-0
-        data-[state=active]:border-magnum-700 data-[state=active]:py-2 data-[state=active]:text-magnum-600 data-[state=active]:opacity-100"
+        data-[state=active]:border-magnum-700 data-[state=active]:py-2 data-[state=active]:text-magnum-600 data-[state=active]:opacity-100
+        hover:opacity-100 focus-visible:!border-magnum-400 focus-visible:!text-magnum-400 focus-visible:!ring-0"
 >
 	<div class="flex items-center gap-2 px-1">
 		{#if tab === 'npm'}

--- a/src/docs/previews/accordion/disabled/tailwind/index.svelte
+++ b/src/docs/previews/accordion/disabled/tailwind/index.svelte
@@ -55,7 +55,7 @@
 						'flex flex-1 cursor-pointer items-center justify-between ',
 						'bg-white px-5 py-5 text-base font-medium leading-none',
 						'text-black transition-colors hover:bg-neutral-100 focus:!ring-0',
-						'focus-visible:text-magnum-800 data-[disabled]:cursor-not-allowed data-[disabled]:text-neutral-400',
+						'data-[disabled]:cursor-not-allowed data-[disabled]:text-neutral-400 focus-visible:text-magnum-800',
 						i !== 0 && 'border-t border-t-neutral-300',
 					)}
 				>

--- a/src/docs/previews/calendar/main/tailwind/LocaleCombobox.svelte
+++ b/src/docs/previews/calendar/main/tailwind/LocaleCombobox.svelte
@@ -96,8 +96,8 @@
 						use:melt={$option({ value: $inputValue, label: $inputValue })}
 						class="relative cursor-pointer scroll-my-2 rounded-md py-2 pl-4 pr-4
 			text-sm
-			hover:bg-magnum-100 data-[highlighted]:bg-magnum-200
-				data-[highlighted]:text-magnum-900 data-[disabled]:opacity-50"
+			data-[highlighted]:bg-magnum-200 data-[highlighted]:text-magnum-900
+				data-[disabled]:opacity-50 hover:bg-magnum-100"
 					>
 						{#if $isSelected($inputValue)}
 							<div class="check absolute left-2 top-1/2 z-10 text-magnum-900">
@@ -115,8 +115,8 @@
 						use:melt={$option(locale)}
 						class="relative cursor-pointer scroll-my-2 rounded-md py-2 pl-4 pr-4
 				text-sm
-				hover:bg-magnum-100 data-[highlighted]:bg-magnum-200
-					data-[highlighted]:text-magnum-900 data-[disabled]:opacity-50"
+				data-[highlighted]:bg-magnum-200 data-[highlighted]:text-magnum-900
+					data-[disabled]:opacity-50 hover:bg-magnum-100"
 					>
 						{#if $isSelected(locale.value)}
 							<div class="check absolute left-2 top-1/2 z-10 text-magnum-900">

--- a/src/docs/previews/calendar/main/tailwind/index.svelte
+++ b/src/docs/previews/calendar/main/tailwind/index.svelte
@@ -107,7 +107,7 @@
 	}
 
 	[data-melt-calendar-cell] {
-		@apply flex h-6 w-6 cursor-pointer select-none items-center justify-center rounded-lg p-4 hover:bg-magnum-100 focus:ring focus:ring-magnum-400 data-[outside-visible-months]:pointer-events-none data-[outside-visible-months]:cursor-default data-[range-highlighted]:bg-magnum-200 data-[selected]:bg-magnum-300 data-[selected]:text-magnum-900 data-[disabled]:opacity-40 data-[outside-visible-months]:opacity-40 data-[outside-visible-months]:hover:bg-transparent;
+		@apply flex h-6 w-6 cursor-pointer select-none items-center justify-center rounded-lg p-4 data-[outside-visible-months]:pointer-events-none data-[outside-visible-months]:cursor-default data-[range-highlighted]:bg-magnum-200 data-[selected]:bg-magnum-300 data-[selected]:text-magnum-900 data-[disabled]:opacity-40 data-[outside-visible-months]:opacity-40 hover:bg-magnum-100 data-[outside-visible-months]:hover:bg-transparent focus:ring focus:ring-magnum-400;
 	}
 
 	[data-melt-calendar-cell][data-outside-month='true'][data-outside-visible-months='true'] {

--- a/src/docs/previews/calendar/monthSelect/tailwind/MonthSelect.svelte
+++ b/src/docs/previews/calendar/monthSelect/tailwind/MonthSelect.svelte
@@ -63,10 +63,10 @@
 			{#each Object.entries(months) as [value, label]}
 				<div
 					class="relative cursor-pointer rounded-lg py-1 pl-8 pr-4 text-neutral-100
-		hover:bg-neutral-700 focus:z-10
-		focus:text-white
-							data-[highlighted]:bg-neutral-600 data-[highlighted]:text-white
-							data-[disabled]:opacity-50"
+		data-[highlighted]:bg-neutral-600 data-[highlighted]:text-white
+		data-[disabled]:opacity-50
+							hover:bg-neutral-700 focus:z-10
+							focus:text-white"
 					use:melt={$option({ value, label })}
 				>
 					<div class="check {$isSelected(value) ? 'block' : 'hidden'}">

--- a/src/docs/previews/collapsible/main/tailwind/index.svelte
+++ b/src/docs/previews/collapsible/main/tailwind/index.svelte
@@ -20,8 +20,8 @@
 		<button
 			use:melt={$trigger}
 			class="relative h-6 w-6 place-items-center rounded-md bg-white text-sm
-			  text-magnum-800 shadow hover:opacity-75 data-[disabled]:cursor-not-allowed
-			  data-[disabled]:opacity-75"
+			  text-magnum-800 shadow data-[disabled]:cursor-not-allowed data-[disabled]:opacity-75
+			  hover:opacity-75"
 			aria-label="Toggle"
 		>
 			<div class="abs-center">

--- a/src/docs/previews/combobox/main/tailwind/index.svelte
+++ b/src/docs/previews/combobox/main/tailwind/index.svelte
@@ -134,9 +134,9 @@
 				<li
 					use:melt={$option(toOption(manga))}
 					class="relative cursor-pointer scroll-my-2 rounded-md py-2 pl-4 pr-4
-				hover:bg-magnum-100
-				data-[highlighted]:bg-magnum-200 data-[highlighted]:text-magnum-900
-					data-[disabled]:opacity-50"
+				data-[highlighted]:bg-magnum-200
+				data-[highlighted]:text-magnum-900 data-[disabled]:opacity-50
+					hover:bg-magnum-100"
 				>
 					{#if $isSelected(manga)}
 						<div class="check absolute left-2 top-1/2 z-10 text-magnum-900">

--- a/src/docs/previews/date-field/main/tailwind/LocaleCombobox.svelte
+++ b/src/docs/previews/date-field/main/tailwind/LocaleCombobox.svelte
@@ -96,8 +96,8 @@
 						use:melt={$option({ value: $inputValue, label: $inputValue })}
 						class="relative cursor-pointer scroll-my-2 rounded-md py-2 pl-4 pr-4
 			text-sm
-			hover:bg-magnum-100 data-[highlighted]:bg-magnum-200
-				data-[highlighted]:text-magnum-900 data-[disabled]:opacity-50"
+			data-[highlighted]:bg-magnum-200 data-[highlighted]:text-magnum-900
+				data-[disabled]:opacity-50 hover:bg-magnum-100"
 					>
 						{#if $isSelected($inputValue)}
 							<div class="check absolute left-2 top-1/2 z-10 text-magnum-900">
@@ -115,8 +115,8 @@
 						use:melt={$option(locale)}
 						class="relative cursor-pointer scroll-my-2 rounded-md py-2 pl-4 pr-4
 				text-sm
-				hover:bg-magnum-100 data-[highlighted]:bg-magnum-200
-					data-[highlighted]:text-magnum-900 data-[disabled]:opacity-50"
+				data-[highlighted]:bg-magnum-200 data-[highlighted]:text-magnum-900
+					data-[disabled]:opacity-50 hover:bg-magnum-100"
 					>
 						{#if $isSelected(locale.value)}
 							<div class="check absolute left-2 top-1/2 z-10 text-magnum-900">

--- a/src/docs/previews/date-picker/main/tailwind/LocaleCombobox.svelte
+++ b/src/docs/previews/date-picker/main/tailwind/LocaleCombobox.svelte
@@ -96,8 +96,8 @@
 						use:melt={$option({ value: $inputValue, label: $inputValue })}
 						class="relative cursor-pointer scroll-my-2 rounded-md py-2 pl-4 pr-4
 			text-sm
-			hover:bg-magnum-100 data-[highlighted]:bg-magnum-200
-				data-[highlighted]:text-magnum-900 data-[disabled]:opacity-50"
+			data-[highlighted]:bg-magnum-200 data-[highlighted]:text-magnum-900
+				data-[disabled]:opacity-50 hover:bg-magnum-100"
 					>
 						{#if $isSelected($inputValue)}
 							<div class="check absolute left-2 top-1/2 z-10 text-magnum-900">
@@ -115,8 +115,8 @@
 						use:melt={$option(locale)}
 						class="relative cursor-pointer scroll-my-2 rounded-md py-2 pl-4 pr-4
 				text-sm
-				hover:bg-magnum-100 data-[highlighted]:bg-magnum-200
-					data-[highlighted]:text-magnum-900 data-[disabled]:opacity-50"
+				data-[highlighted]:bg-magnum-200 data-[highlighted]:text-magnum-900
+					data-[disabled]:opacity-50 hover:bg-magnum-100"
 					>
 						{#if $isSelected(locale.value)}
 							<div class="check absolute left-2 top-1/2 z-10 text-magnum-900">

--- a/src/docs/previews/date-range-field/main/tailwind/LocaleCombobox.svelte
+++ b/src/docs/previews/date-range-field/main/tailwind/LocaleCombobox.svelte
@@ -96,8 +96,8 @@
 						use:melt={$option({ value: $inputValue, label: $inputValue })}
 						class="relative cursor-pointer scroll-my-2 rounded-md py-2 pl-4 pr-4
 			text-sm
-			hover:bg-magnum-100 data-[highlighted]:bg-magnum-200
-				data-[highlighted]:text-magnum-900 data-[disabled]:opacity-50"
+			data-[highlighted]:bg-magnum-200 data-[highlighted]:text-magnum-900
+				data-[disabled]:opacity-50 hover:bg-magnum-100"
 					>
 						{#if $isSelected($inputValue)}
 							<div class="check absolute left-2 top-1/2 z-10 text-magnum-900">
@@ -115,8 +115,8 @@
 						use:melt={$option(locale)}
 						class="relative cursor-pointer scroll-my-2 rounded-md py-2 pl-4 pr-4
 				text-sm
-				hover:bg-magnum-100 data-[highlighted]:bg-magnum-200
-					data-[highlighted]:text-magnum-900 data-[disabled]:opacity-50"
+				data-[highlighted]:bg-magnum-200 data-[highlighted]:text-magnum-900
+					data-[disabled]:opacity-50 hover:bg-magnum-100"
 					>
 						{#if $isSelected(locale.value)}
 							<div class="check absolute left-2 top-1/2 z-10 text-magnum-900">

--- a/src/docs/previews/date-range-picker/main/tailwind/LocaleCombobox.svelte
+++ b/src/docs/previews/date-range-picker/main/tailwind/LocaleCombobox.svelte
@@ -96,8 +96,8 @@
 						use:melt={$option({ value: $inputValue, label: $inputValue })}
 						class="relative cursor-pointer scroll-my-2 rounded-md py-2 pl-4 pr-4
 			text-sm
-			hover:bg-magnum-100 data-[highlighted]:bg-magnum-200
-				data-[highlighted]:text-magnum-900 data-[disabled]:opacity-50"
+			data-[highlighted]:bg-magnum-200 data-[highlighted]:text-magnum-900
+				data-[disabled]:opacity-50 hover:bg-magnum-100"
 					>
 						{#if $isSelected($inputValue)}
 							<div class="check absolute left-2 top-1/2 z-10 text-magnum-900">
@@ -115,8 +115,8 @@
 						use:melt={$option(locale)}
 						class="relative cursor-pointer scroll-my-2 rounded-md py-2 pl-4 pr-4
 				text-sm
-				hover:bg-magnum-100 data-[highlighted]:bg-magnum-200
-					data-[highlighted]:text-magnum-900 data-[disabled]:opacity-50"
+				data-[highlighted]:bg-magnum-200 data-[highlighted]:text-magnum-900
+					data-[disabled]:opacity-50 hover:bg-magnum-100"
 					>
 						{#if $isSelected(locale.value)}
 							<div class="check absolute left-2 top-1/2 z-10 text-magnum-900">

--- a/src/docs/previews/menubar/main/tailwind/index.svelte
+++ b/src/docs/previews/menubar/main/tailwind/index.svelte
@@ -305,7 +305,7 @@
 
 	.trigger {
 		@apply inline-flex items-center justify-center rounded-md bg-white px-3 py-2;
-		@apply text-magnum-900 transition-colors hover:bg-white/90 data-[highlighted]:outline-none;
+		@apply text-magnum-900 transition-colors data-[highlighted]:outline-none hover:bg-white/90;
 		@apply overflow-visible data-[highlighted]:bg-magnum-200 data-[highlighted]:ring-magnum-400 !important;
 		@apply !cursor-default text-sm font-medium leading-none focus:z-30 focus:ring;
 	}

--- a/src/docs/previews/pagination/main/tailwind/index.svelte
+++ b/src/docs/previews/pagination/main/tailwind/index.svelte
@@ -24,8 +24,8 @@
 	<div class="flex items-center gap-2">
 		<button
 			class="grid h-8 items-center rounded-md bg-white px-3 text-sm text-magnum-900 shadow-sm
-			hover:opacity-75 disabled:cursor-not-allowed disabled:opacity-50 data-[selected]:bg-magnum-900
-			data-[selected]:text-white"
+			data-[selected]:bg-magnum-900 data-[selected]:text-white hover:opacity-75 disabled:cursor-not-allowed
+			disabled:opacity-50"
 			use:melt={$prevButton}><ChevronLeft class="square-4" /></button
 		>
 		{#each $pages as page (page.key)}
@@ -34,16 +34,16 @@
 			{:else}
 				<button
 					class="grid h-8 items-center rounded-md bg-white px-3 text-sm text-magnum-900 shadow-sm
-					hover:opacity-75 disabled:cursor-not-allowed disabled:opacity-50 data-[selected]:bg-magnum-900
-				data-[selected]:text-white"
+					data-[selected]:bg-magnum-900 data-[selected]:text-white hover:opacity-75 disabled:cursor-not-allowed
+				disabled:opacity-50"
 					use:melt={$pageTrigger(page)}>{page.value}</button
 				>
 			{/if}
 		{/each}
 		<button
 			class="grid h-8 items-center rounded-md bg-white px-3 text-sm text-magnum-900 shadow-sm
-			hover:opacity-75 disabled:cursor-not-allowed disabled:opacity-50 data-[selected]:bg-magnum-900
-		data-[selected]:text-white"
+			data-[selected]:bg-magnum-900 data-[selected]:text-white hover:opacity-75 disabled:cursor-not-allowed
+		disabled:opacity-50"
 			use:melt={$nextButton}><ChevronRight class="square-4" /></button
 		>
 	</div>

--- a/src/docs/previews/range-calendar/main/tailwind/LocaleCombobox.svelte
+++ b/src/docs/previews/range-calendar/main/tailwind/LocaleCombobox.svelte
@@ -96,8 +96,8 @@
 						use:melt={$option({ value: $inputValue, label: $inputValue })}
 						class="relative cursor-pointer scroll-my-2 rounded-md py-2 pl-4 pr-4
 			text-sm
-			hover:bg-magnum-100 data-[highlighted]:bg-magnum-200
-				data-[highlighted]:text-magnum-900 data-[disabled]:opacity-50"
+			data-[highlighted]:bg-magnum-200 data-[highlighted]:text-magnum-900
+				data-[disabled]:opacity-50 hover:bg-magnum-100"
 					>
 						{#if $isSelected($inputValue)}
 							<div class="check absolute left-2 top-1/2 z-10 text-magnum-900">
@@ -115,8 +115,8 @@
 						use:melt={$option(locale)}
 						class="relative cursor-pointer scroll-my-2 rounded-md py-2 pl-4 pr-4
 				text-sm
-				hover:bg-magnum-100 data-[highlighted]:bg-magnum-200
-					data-[highlighted]:text-magnum-900 data-[disabled]:opacity-50"
+				data-[highlighted]:bg-magnum-200 data-[highlighted]:text-magnum-900
+					data-[disabled]:opacity-50 hover:bg-magnum-100"
 					>
 						{#if $isSelected(locale.value)}
 							<div class="check absolute left-2 top-1/2 z-10 text-magnum-900">

--- a/src/docs/previews/range-calendar/main/tailwind/index.svelte
+++ b/src/docs/previews/range-calendar/main/tailwind/index.svelte
@@ -108,7 +108,7 @@
 	}
 
 	[data-melt-calendar-cell] {
-		@apply flex h-6 w-6 cursor-pointer select-none items-center justify-center rounded-lg p-4 hover:bg-magnum-100 focus:ring focus:ring-magnum-400 data-[outside-month]:pointer-events-none data-[outside-visible-months]:pointer-events-none data-[outside-month]:cursor-default data-[outside-visible-months]:cursor-default data-[highlighted]:bg-magnum-200 data-[range-highlighted]:bg-magnum-200 data-[selected]:bg-magnum-300 data-[selected]:text-magnum-900 data-[disabled]:opacity-40 data-[outside-month]:opacity-40 data-[outside-visible-months]:opacity-40 data-[outside-month]:hover:bg-transparent data-[outside-visible-months]:hover:bg-transparent;
+		@apply flex h-6 w-6 cursor-pointer select-none items-center justify-center rounded-lg p-4 data-[outside-month]:pointer-events-none data-[outside-visible-months]:pointer-events-none data-[outside-month]:cursor-default data-[outside-visible-months]:cursor-default data-[highlighted]:bg-magnum-200 data-[range-highlighted]:bg-magnum-200 data-[selected]:bg-magnum-300 data-[selected]:text-magnum-900 data-[disabled]:opacity-40 data-[outside-month]:opacity-40 data-[outside-visible-months]:opacity-40 hover:bg-magnum-100 data-[outside-month]:hover:bg-transparent data-[outside-visible-months]:hover:bg-transparent focus:ring focus:ring-magnum-400;
 	}
 
 	[data-melt-calendar-cell][data-outside-month='true'][data-outside-visible-months='true'] {

--- a/src/docs/previews/select/keyboard/tailwind/index.svelte
+++ b/src/docs/previews/select/keyboard/tailwind/index.svelte
@@ -75,9 +75,9 @@
 					{#each arr as item}
 						<div
 							class="relative cursor-pointer rounded-lg py-1 pl-8 pr-4 text-neutral-800
-							focus:z-10 focus:text-magnum-700
-						data-[highlighted]:bg-magnum-50 data-[selected]:bg-magnum-100
-						data-[highlighted]:text-magnum-900 data-[selected]:text-magnum-900"
+							data-[highlighted]:bg-magnum-50 data-[selected]:bg-magnum-100
+						data-[highlighted]:text-magnum-900 data-[selected]:text-magnum-900
+						focus:z-10 focus:text-magnum-700"
 							use:melt={$option({ value: item, label: item })}
 						>
 							<div class="check {$isSelected(item) ? 'block' : 'hidden'}">

--- a/src/docs/previews/select/main/tailwind/index.svelte
+++ b/src/docs/previews/select/main/tailwind/index.svelte
@@ -53,10 +53,10 @@
 					{#each arr as item}
 						<div
 							class="relative cursor-pointer rounded-lg py-1 pl-8 pr-4 text-neutral-800
-							hover:bg-magnum-100 focus:z-10
-							focus:text-magnum-700
 							data-[highlighted]:bg-magnum-200 data-[highlighted]:text-magnum-900
-							data-[disabled]:opacity-50"
+							data-[disabled]:opacity-50
+							hover:bg-magnum-100 focus:z-10
+							focus:text-magnum-700"
 							use:melt={$option({ value: item, label: item })}
 						>
 							<div class="check {$isSelected(item) ? 'block' : 'hidden'}">

--- a/src/docs/previews/select/multi/tailwind/index.svelte
+++ b/src/docs/previews/select/multi/tailwind/index.svelte
@@ -52,9 +52,9 @@
 					{#each arr as item}
 						<div
 							class="relative cursor-pointer rounded-lg py-1 pl-8 pr-4 text-neutral-800
-							focus:z-10 focus:text-magnum-700
-						data-[highlighted]:bg-magnum-50 data-[selected]:bg-magnum-100
-						data-[highlighted]:text-magnum-900 data-[selected]:text-magnum-900"
+							data-[highlighted]:bg-magnum-50 data-[selected]:bg-magnum-100
+						data-[highlighted]:text-magnum-900 data-[selected]:text-magnum-900
+						focus:z-10 focus:text-magnum-700"
 							use:melt={$option({ value: item, label: item })}
 						>
 							<div class="check {$isSelected(item) ? 'block' : 'hidden'}">

--- a/src/docs/previews/table-of-contents/main/tailwind/tree.svelte
+++ b/src/docs/previews/table-of-contents/main/tailwind/tree.svelte
@@ -19,7 +19,7 @@
 					href="#{heading.id}"
 					use:melt={$item(heading.id)}
 					class="inline-flex items-center justify-center gap-1 text-neutral-500 no-underline transition-colors
-					 hover:!text-magnum-600 data-[active]:text-magnum-700"
+					 data-[active]:text-magnum-700 hover:!text-magnum-600"
 				>
 					<!--
 						Along with the heading title, the original heading node

--- a/src/docs/previews/tags-input/main/tailwind/index.svelte
+++ b/src/docs/previews/tags-input/main/tailwind/index.svelte
@@ -47,7 +47,7 @@
 			use:melt={$input}
 			type="text"
 			placeholder="Enter tags..."
-			class="min-w-[4.5rem] shrink grow basis-0 border-0 text-black outline-none focus:!ring-0 data-[invalid]:text-red-500"
+			class="min-w-[4.5rem] shrink grow basis-0 border-0 text-black outline-none data-[invalid]:text-red-500 focus:!ring-0"
 		/>
 	</div>
 </div>

--- a/src/docs/previews/toggle/main/tailwind/index.svelte
+++ b/src/docs/previews/toggle/main/tailwind/index.svelte
@@ -11,9 +11,9 @@
 	use:melt={$root}
 	aria-label="Toggle italic"
 	class="grid h-9 w-9 place-items-center items-center justify-center rounded-md
-	bg-white text-base leading-4 text-magnum-800 shadow-lg hover:bg-magnum-100
-    data-[disabled]:cursor-not-allowed data-[state=on]:bg-magnum-200
-    data-[state=on]:text-magnum-900"
+	bg-white text-base leading-4 text-magnum-800 shadow-lg data-[disabled]:cursor-not-allowed
+    data-[state=on]:bg-magnum-200 data-[state=on]:text-magnum-900
+    hover:bg-magnum-100"
 >
 	<Italic class="square-4" />
 </button>

--- a/src/routes/(landing-ui)/tags-input.svelte
+++ b/src/routes/(landing-ui)/tags-input.svelte
@@ -46,8 +46,8 @@
 			use:melt={$input}
 			type="text"
 			placeholder="Enter tags..."
-			class="min-w-[4rem] shrink grow basis-0 border-0 text-black outline-none focus:!ring-0
-      data-[invalid]:text-red-500"
+			class="min-w-[4rem] shrink grow basis-0 border-0 text-black outline-none data-[invalid]:text-red-500
+      focus:!ring-0"
 		/>
 	</div>
 </div>

--- a/src/routes/docs/+layout.svelte
+++ b/src/routes/docs/+layout.svelte
@@ -8,8 +8,8 @@
 
 <div class="container flex-1 items-start md:grid md:grid-cols-[220px_minmax(0,1fr)] md:gap-6">
 	<aside
-		class="fixed top-16 z-30 -ml-2 hidden h-[calc(100vh-4rem)] w-full shrink-0
-		flex-col overflow-y-auto pb-2 md:sticky md:flex"
+		class="fixed top-16 z-30 -ml-2 hidden h-[calc(100vh-4rem)] w-full
+		shrink-0 flex-col overflow-y-auto pb-2 scrollbar scrollbar-track-neutral-700 scrollbar-thumb-magnum-400 scrollbar-thumb-rounded-full scrollbar-w-2 md:sticky md:flex"
 	>
 		<div class="py-6 pr-6 lg:py-8">
 			<SidebarNav />

--- a/src/routes/docs/builders/[name]/+page.svelte
+++ b/src/routes/docs/builders/[name]/+page.svelte
@@ -49,7 +49,9 @@
 		<!-- <DocsPager /> -->
 	</div>
 	<div class="hidden text-sm xl:block">
-		<div class="fixed top-16 h-[calc(100vh-4rem)] overflow-visible pt-6">
+		<div
+			class="fixed top-16 h-[calc(100vh-4rem)] overflow-y-auto overflow-x-visible py-6 pr-4 scrollbar-thin scrollbar-track-neutral-700 scrollbar-thumb-magnum-400 scrollbar-thumb-rounded-full"
+		>
 			{#key $page.url.pathname}
 				<TOC />
 			{/key}

--- a/src/stories/Collapsible/Collapsible.svelte
+++ b/src/stories/Collapsible/Collapsible.svelte
@@ -29,8 +29,8 @@
 			<button
 				use:melt={$trigger}
 				class="relative h-6 w-6 place-items-center rounded-full bg-white text-sm text-magnum-700
-				shadow-lg hover:opacity-75
-				data-[disabled]:cursor-not-allowed data-[disabled]:opacity-75"
+				shadow-lg data-[disabled]:cursor-not-allowed
+				data-[disabled]:opacity-75 hover:opacity-75"
 			>
 				<div class="abs-center">
 					{#if $open}

--- a/src/tests/calendar/CalendarMultiTest.svelte
+++ b/src/tests/calendar/CalendarMultiTest.svelte
@@ -146,7 +146,7 @@
 	}
 
 	.cell {
-		@apply flex h-6 w-6 cursor-pointer select-none items-center justify-center rounded p-4 hover:bg-magnum-100 focus:ring focus:ring-magnum-400 data-[outside-month]:pointer-events-none data-[outside-month]:cursor-default data-[range-highlighted]:bg-magnum-200 data-[selected]:bg-magnum-300 data-[disabled]:opacity-40 data-[outside-month]:opacity-40 data-[outside-month]:hover:bg-transparent;
+		@apply flex h-6 w-6 cursor-pointer select-none items-center justify-center rounded p-4 data-[outside-month]:pointer-events-none data-[outside-month]:cursor-default data-[range-highlighted]:bg-magnum-200 data-[selected]:bg-magnum-300 data-[disabled]:opacity-40 data-[outside-month]:opacity-40 hover:bg-magnum-100 data-[outside-month]:hover:bg-transparent focus:ring focus:ring-magnum-400;
 	}
 
 	.segment {

--- a/src/tests/calendar/CalendarTest.svelte
+++ b/src/tests/calendar/CalendarTest.svelte
@@ -149,7 +149,7 @@
 	}
 
 	.cell {
-		@apply flex h-6 w-6 cursor-pointer select-none items-center justify-center rounded p-4 hover:bg-magnum-100 focus:ring focus:ring-magnum-400 data-[outside-month]:pointer-events-none data-[outside-month]:cursor-default data-[range-highlighted]:bg-magnum-200 data-[selected]:bg-magnum-300 data-[disabled]:opacity-40 data-[outside-month]:opacity-40 data-[outside-month]:hover:bg-transparent;
+		@apply flex h-6 w-6 cursor-pointer select-none items-center justify-center rounded p-4 data-[outside-month]:pointer-events-none data-[outside-month]:cursor-default data-[range-highlighted]:bg-magnum-200 data-[selected]:bg-magnum-300 data-[disabled]:opacity-40 data-[outside-month]:opacity-40 hover:bg-magnum-100 data-[outside-month]:hover:bg-transparent focus:ring focus:ring-magnum-400;
 	}
 
 	.segment {

--- a/src/tests/date-picker/DatePickerTest.svelte
+++ b/src/tests/date-picker/DatePickerTest.svelte
@@ -189,7 +189,7 @@
 	}
 
 	.cell {
-		@apply flex h-6 w-6 cursor-pointer select-none items-center justify-center rounded p-4 hover:bg-magnum-100 focus:ring focus:ring-magnum-400 data-[outside-month]:pointer-events-none data-[outside-month]:cursor-default data-[range-highlighted]:bg-magnum-200 data-[selected]:bg-magnum-300 data-[disabled]:opacity-40 data-[outside-month]:opacity-40 data-[outside-month]:hover:bg-transparent;
+		@apply flex h-6 w-6 cursor-pointer select-none items-center justify-center rounded p-4 data-[outside-month]:pointer-events-none data-[outside-month]:cursor-default data-[range-highlighted]:bg-magnum-200 data-[selected]:bg-magnum-300 data-[disabled]:opacity-40 data-[outside-month]:opacity-40 hover:bg-magnum-100 data-[outside-month]:hover:bg-transparent focus:ring focus:ring-magnum-400;
 	}
 
 	.segment {

--- a/src/tests/dropdown-menu/DropdownMenuForceVisibleTest.svelte
+++ b/src/tests/dropdown-menu/DropdownMenuForceVisibleTest.svelte
@@ -143,7 +143,7 @@
 		@apply inline-flex h-9 w-9 items-center justify-center rounded-full bg-white;
 		@apply text-magnum-900 transition-colors hover:bg-white/90;
 		@apply data-[highlighted]:ring-magnum-400 data-[highlighted]:ring-offset-2 !important;
-		@apply p-0 text-sm font-medium focus:ring data-[highlighted]:outline-none;
+		@apply p-0 text-sm font-medium data-[highlighted]:outline-none focus:ring;
 	}
 	.check {
 		@apply absolute left-2 top-1/2 text-magnum-500;

--- a/src/tests/dropdown-menu/DropdownMenuTest.svelte
+++ b/src/tests/dropdown-menu/DropdownMenuTest.svelte
@@ -136,7 +136,7 @@
 		@apply inline-flex h-9 w-9 items-center justify-center rounded-full bg-white;
 		@apply text-magnum-900 transition-colors hover:bg-white/90;
 		@apply data-[highlighted]:ring-magnum-400 data-[highlighted]:ring-offset-2 !important;
-		@apply p-0 text-sm font-medium focus:ring data-[highlighted]:outline-none;
+		@apply p-0 text-sm font-medium data-[highlighted]:outline-none focus:ring;
 	}
 	.check {
 		@apply absolute left-2 top-1/2 text-magnum-500;

--- a/src/tests/range-calendar/RangeCalendarTest.svelte
+++ b/src/tests/range-calendar/RangeCalendarTest.svelte
@@ -145,7 +145,7 @@
 	}
 
 	.cell {
-		@apply flex h-6 w-6 cursor-pointer select-none items-center justify-center rounded p-4 hover:bg-magnum-100 focus:ring focus:ring-magnum-400 data-[outside-month]:pointer-events-none data-[outside-month]:cursor-default data-[range-highlighted]:bg-magnum-200 data-[selected]:bg-magnum-300 data-[disabled]:opacity-40 data-[outside-month]:opacity-40 data-[outside-month]:hover:bg-transparent;
+		@apply flex h-6 w-6 cursor-pointer select-none items-center justify-center rounded p-4 data-[outside-month]:pointer-events-none data-[outside-month]:cursor-default data-[range-highlighted]:bg-magnum-200 data-[selected]:bg-magnum-300 data-[disabled]:opacity-40 data-[outside-month]:opacity-40 hover:bg-magnum-100 data-[outside-month]:hover:bg-transparent focus:ring focus:ring-magnum-400;
 	}
 
 	.segment {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from 'tailwindcss';
 import plugin from 'tailwindcss/plugin';
 import typography from '@tailwindcss/typography';
+import tailwindScrollbar from 'tailwind-scrollbar';
 
 export default {
 	content: ['./src/**/*.{html,js,svelte,ts}'],
@@ -103,5 +104,6 @@ export default {
 				{ values: theme('spacing') }
 			);
 		}),
+		tailwindScrollbar({ nocompatible: true }),
 	],
 } satisfies Config;


### PR DESCRIPTION
Added pretty scrollbars to some inner components with [tailwind-scrollbar](https://github.com/adoxography/tailwind-scrollbar) plugin.

Two examples : sidebar nav and TOC (see [Calendar builder](https://www.melt-ui.com/docs/builders/calendar) for scrollable TOC) :

- Sidebar uses `scrollbar scrollbar-w-2`
- TOC uses `scrollbar-thin`

I prefer the sidebar one (pretty much the same on Chromium based browser, but nicer on Firefox).

Check the doc for more info on the plugin : https://adoxography.github.io/tailwind-scrollbar/examples

Screenshots : 

Chrome :
![image](https://github.com/melt-ui/melt-ui/assets/90099349/868db766-b29e-4d8a-b333-31ea541833a3)

Firefox :
![image](https://github.com/melt-ui/melt-ui/assets/90099349/67847c87-afc2-483a-9f9f-686d7e6c2616)