### PR TITLE
Fix: listbox 'multiple' type

### DIFF
--- a/src/lib/builders/listbox/types.ts
+++ b/src/lib/builders/listbox/types.ts
@@ -136,7 +136,7 @@ export type CreateListboxProps<
 	 */
 	forceVisible?: boolean;
 
-	multiple?: Multiple;
+	multiple?: boolean;
 
 	/**
 	 * The name of the builder using listbox.


### PR DESCRIPTION
Without this change the only valid types for 'multiple' are either false or undefined.

Fixes: https://github.com/huntabyte/shadcn-svelte/issues/428