### PR TITLE
Fix/calendar keyboard navigation

### DIFF
--- a/src/lib/builders/calendar/create.ts
+++ b/src/lib/builders/calendar/create.ts
@@ -957,7 +957,8 @@ import { generateIds } from '../../internal/helpers/id'
 			 * of the array.
 			 */
 
-			// shift the calendar back a month
+			// shift the calendar back a month unless previous month is disabled
+			if (get(isPrevButtonDisabled)) return;
 
 			const $months = get(months);
 			const firstMonth = $months[0].value;
@@ -994,6 +995,9 @@ import { generateIds } from '../../internal/helpers/id'
 			 * month, and then starting at the beginning of that array,
 			 * shift focus by the nextIndex amount.
 			 */
+
+			// shift the calendar forward a month unless next month is disabled
+			if (get(isNextButtonDisabled)) return;
 
 			const $months = get(months);
 			const firstMonth = $months[0].value;

--- a/src/tests/calendar/Calendar.spec.ts
+++ b/src/tests/calendar/Calendar.spec.ts
@@ -410,32 +410,50 @@ describe('Calendar', () => {
 
 		// five keypresses to get to February 1980
 		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		expect(getByTestId('month-0-date-8')).toHaveFocus();
 		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		expect(getByTestId('month-0-date-15')).toHaveFocus();
 		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		expect(getByTestId('month-0-date-22')).toHaveFocus();
 		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		expect(getByTestId('month-0-date-29')).toHaveFocus();
 		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		expect(getByTestId('month-0-date-5')).toHaveFocus();
 		expect(heading).toHaveTextContent('February 1980');
 
 		// four keypresses to get to March 1980
 		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		expect(getByTestId('month-0-date-12')).toHaveFocus();
 		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		expect(getByTestId('month-0-date-19')).toHaveFocus();
 		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		expect(getByTestId('month-0-date-26')).toHaveFocus();
 		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		expect(getByTestId('month-0-date-4')).toHaveFocus();
 		expect(heading).toHaveTextContent('March 1980');
 
 		// four keypresses to get to April 1980
 		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		expect(getByTestId('month-0-date-11')).toHaveFocus();
 		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		expect(getByTestId('month-0-date-18')).toHaveFocus();
 		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		expect(getByTestId('month-0-date-25')).toHaveFocus();
 		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		expect(getByTestId('month-0-date-1')).toHaveFocus();
 		expect(heading).toHaveTextContent('April 1980');
 
 		// should be five keypresses to get to May 1980, but we're at the max value
 		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		expect(getByTestId('month-0-date-8')).toHaveFocus();
 		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		expect(getByTestId('month-0-date-15')).toHaveFocus();
 		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		expect(getByTestId('month-0-date-22')).toHaveFocus();
 		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		expect(getByTestId('month-0-date-29')).toHaveFocus();
 		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		expect(getByTestId('month-0-date-29')).toHaveFocus();
 		expect(heading).toHaveTextContent('April 1980');
 
 		// again for good measure
@@ -444,6 +462,7 @@ describe('Calendar', () => {
 		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
 		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
 		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		expect(getByTestId('month-0-date-29')).toHaveFocus();
 		expect(heading).toHaveTextContent('April 1980');
 	});
 

--- a/src/tests/calendar/Calendar.spec.ts
+++ b/src/tests/calendar/Calendar.spec.ts
@@ -394,6 +394,59 @@ describe('Calendar', () => {
 		expect(heading).toHaveTextContent('April 1980');
 	});
 
+	test('calendar does not navigate after maxValue (with keyboard)', async () => {
+		const user = userEvent.setup();
+		const { getByTestId } = render(CalendarTest, {
+			defaultValue: calendarDate,
+			maxValue: new CalendarDate(1980, 4, 1),
+		});
+
+		const firstDayInMonth = getByTestId('month-0-date-1');
+		firstDayInMonth.focus();
+		expect(firstDayInMonth).toHaveFocus();
+
+		const heading = getByTestId('heading');
+		expect(heading).toHaveTextContent('January 1980');
+
+		// five keypresses to get to February 1980
+		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		expect(heading).toHaveTextContent('February 1980');
+
+		// four keypresses to get to March 1980
+		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		expect(heading).toHaveTextContent('March 1980');
+
+		// four keypresses to get to April 1980
+		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		expect(heading).toHaveTextContent('April 1980');
+
+		// should be five keypresses to get to May 1980, but we're at the max value
+		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		expect(heading).toHaveTextContent('April 1980');
+
+		// again for good measure
+		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		await user.keyboard(`{${kbd.ARROW_DOWN}}`);
+		expect(heading).toHaveTextContent('April 1980');
+	});
+
 	test('multiple select default Value', async () => {
 		const day1 = new CalendarDate(1980, 1, 2);
 		const day2 = new CalendarDate(1980, 1, 5);


### PR DESCRIPTION
this should do the trick, but...

unfortunately, I could not get the test to work. I'm not really sure why. based on the `toHaveFocus()` tests it seems like pressing the down arrow key works great at first, you get:

- 1 January
- 8 January
- 15 January
- 22 January
- 29 January

and then I would expect to see:
- 5 February

but for some reason the focused date is instead:
- 5 January

no idea why... am I doing something stupid @huntabyte?

so for that reason the added test is not working yet. if I figure out how to do it correctly, the test should pass with this patch and fail without.

the change itself is working as intended in the dev preview