### PR TITLE
fix: `ids` prop is not `Partial`

### DIFF
--- a/.changeset/happy-rings-cover.md
+++ b/.changeset/happy-rings-cover.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+fix: `ids` prop is not `Partial`

--- a/src/lib/builders/calendar/create.ts
+++ b/src/lib/builders/calendar/create.ts
@@ -667,7 +667,6 @@ export function createCalendar<
 	 * ```svelte
 	 * <script>
 	 * 	import { createCalendar } from '@melt-ui/svelte';
-	 * 	import { generateIds } from '../../internal/helpers/id'
 	 * 	const { { ... }, helpers: { nextPage } } = createCalendar()
 	 * </script>
 	 *

--- a/src/lib/builders/calendar/create.ts
+++ b/src/lib/builders/calendar/create.ts
@@ -667,7 +667,7 @@ export function createCalendar<
 	 * ```svelte
 	 * <script>
 	 * 	import { createCalendar } from '@melt-ui/svelte';
-import { generateIds } from '../../internal/helpers/id'
+	 * 	import { generateIds } from '../../internal/helpers/id'
 	 * 	const { { ... }, helpers: { nextPage } } = createCalendar()
 	 * </script>
 	 *

--- a/src/lib/builders/dialog/types.ts
+++ b/src/lib/builders/dialog/types.ts
@@ -35,7 +35,7 @@ export type CreateDialogProps = {
 	/**
 	 * Optionally override the default ids we assign to the elements
 	 */
-	ids?: IdObj<DialogIdParts>;
+	ids?: Partial<IdObj<DialogIdParts>>;
 };
 
 export type Dialog = BuilderReturn<typeof createDialog>;

--- a/src/lib/builders/link-preview/types.ts
+++ b/src/lib/builders/link-preview/types.ts
@@ -92,7 +92,7 @@ export type CreateLinkPreviewProps = {
 	/**
 	 * Optionally override the default ids we assign to the elements
 	 */
-	ids?: IdObj<LinkPreviewIdParts>;
+	ids?: Partial<IdObj<LinkPreviewIdParts>>;
 };
 
 export type LinkPreview = BuilderReturn<typeof createLinkPreview>;

--- a/src/lib/builders/listbox/types.ts
+++ b/src/lib/builders/listbox/types.ts
@@ -162,7 +162,7 @@ export type CreateListboxProps<
 	/**
 	 * Optionally override the default ids we assign to the elements
 	 */
-	ids?: IdObj<ListboxIdParts>;
+	ids?: Partial<IdObj<ListboxIdParts>>;
 };
 
 export type ListboxOptionProps<Value = unknown> = ListboxOption<Value> & {

--- a/src/lib/builders/menu/types.ts
+++ b/src/lib/builders/menu/types.ts
@@ -114,7 +114,7 @@ export type _CreateMenuProps = {
 	/**
 	 * Optionally override the default ids we assign to the elements
 	 */
-	ids?: IdObj<_MenuIdParts>;
+	ids?: Partial<IdObj<_MenuIdParts>>;
 };
 
 export type _CreateSubmenuProps = Pick<
@@ -184,7 +184,7 @@ export type _MenuBuilderOptions = {
 	 */
 	removeScroll: boolean;
 
-	ids?: Expand<IdObj<_MenuIdParts>>;
+	ids?: Partial<IdObj<_MenuIdParts>>;
 };
 
 export type _MenuParts =

--- a/src/lib/builders/menubar/types.ts
+++ b/src/lib/builders/menubar/types.ts
@@ -21,7 +21,7 @@ export type CreateMenubarProps = {
 	/**
 	 * Optionally override the default ids we assign to the elements
 	 */
-	ids?: IdObj<MenubarIdParts>;
+	ids?: Partial<IdObj<MenubarIdParts>>;
 };
 export type CreateMenubarMenuProps = _Menu['builder'];
 export type CreateMenubarSubmenuProps = _Menu['submenu'];

--- a/src/lib/builders/pin-input/types.ts
+++ b/src/lib/builders/pin-input/types.ts
@@ -59,7 +59,7 @@ export type CreatePinInputProps = {
 	/**
 	 * Optionally override the default ids we assign to the elements
 	 */
-	ids?: IdObj<PinInputIdParts>;
+	ids?: Partial<IdObj<PinInputIdParts>>;
 };
 
 export type PinInput = BuilderReturn<typeof createPinInput>;

--- a/src/lib/builders/popover/types.ts
+++ b/src/lib/builders/popover/types.ts
@@ -99,7 +99,7 @@ export type CreatePopoverProps = {
 	/**
 	 * Optionally override the default ids we assign to the elements
 	 */
-	ids?: IdObj<PopoverIdParts>;
+	ids?: Partial<IdObj<PopoverIdParts>>;
 };
 
 export type Popover = BuilderReturn<typeof createPopover>;

--- a/src/lib/builders/tooltip/types.ts
+++ b/src/lib/builders/tooltip/types.ts
@@ -32,7 +32,7 @@ export type CreateTooltipProps = {
 	/**
 	 * Optionally override the default ids we assign to the elements
 	 */
-	ids?: IdObj<TooltipIdParts>;
+	ids?: Partial<IdObj<TooltipIdParts>>;
 };
 
 export type Tooltip = BuilderReturn<typeof createTooltip>;

--- a/src/lib/internal/helpers/id.ts
+++ b/src/lib/internal/helpers/id.ts
@@ -8,7 +8,7 @@ export function generateId(): string {
 	return nanoid(10);
 }
 
-export type IdObj<T extends readonly string[]> = Expand<{ [K in T[number]]: string }>;
+export type IdObj<T extends readonly string[]> = Expand<{ [K in T[number]]?: string }>;
 
 export function generateIds<T extends readonly string[]>(args: T): IdObj<T> {
 	return args.reduce((acc, curr) => {

--- a/src/lib/internal/helpers/id.ts
+++ b/src/lib/internal/helpers/id.ts
@@ -8,7 +8,7 @@ export function generateId(): string {
 	return nanoid(10);
 }
 
-export type IdObj<T extends readonly string[]> = Expand<{ [K in T[number]]?: string }>;
+export type IdObj<T extends readonly string[]> = Expand<{ [K in T[number]]: string }>;
 
 export function generateIds<T extends readonly string[]>(args: T): IdObj<T> {
 	return args.reduce((acc, curr) => {


### PR DESCRIPTION
To override ids on some components, you have to provide ids for all elements. This PR fixes that by making the `ids` prop `Partial`.