### PR TITLE
#736 Docs: missing elements in API reference for Context Menu

### DIFF
--- a/src/docs/data/builders/menu.ts
+++ b/src/docs/data/builders/menu.ts
@@ -91,6 +91,18 @@ function getMenuBuilderEls(name = 'menu') {
 			name: 'arrow',
 			description: `The builder store used to create the ${name} arrow.`,
 		},
+		{
+			name: 'item',
+			description: `The builder store used to create the ${name} item`,
+		},
+		{
+			name: 'group',
+			description: `The builder store used to group menu items together.It takes in a unique key to group menu items together.`,
+		},
+		{
+			name: 'groupLabel',
+			description: `The builder store used to create the group label for the ${name}.`,
+		},
 	];
 }
 

--- a/src/docs/data/builders/menu.ts
+++ b/src/docs/data/builders/menu.ts
@@ -97,7 +97,7 @@ function getMenuBuilderEls(name = 'menu') {
 		},
 		{
 			name: 'group',
-			description: `The builder store used to group menu items together.It takes in a unique key to group menu items together.`,
+			description: `The builder store used to group menu items together. It takes in a unique key to group menu items together.`,
 		},
 		{
 			name: 'groupLabel',


### PR DESCRIPTION
The Context Menu createContextMenu ) is missing 3 elements (item, group, groupLabel). Description I added as a placeholder. So please tell me a description of these elements so I can update them. I think there should be a preview component for these elements so should I open an issue?