### PR TITLE
Fix: clickoutside handler

### DIFF
--- a/.changeset/early-dolphins-provide.md
+++ b/.changeset/early-dolphins-provide.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+"outside clicks" now trigger on `pointerdown` instead of `pointerup`

--- a/src/lib/internal/actions/click-outside/action.ts
+++ b/src/lib/internal/actions/click-outside/action.ts
@@ -7,6 +7,7 @@ import { addEventListener } from '$lib/internal/helpers/event.js';
 import { get } from 'svelte/store';
 import { isFunction } from '$lib/internal/helpers/is.js';
 import type { ClickOutsideConfig } from './types.js';
+import { executeCallbacks } from '$lib/internal/helpers/callbacks.js';
 
 /**
  * Creates a readable store that tracks the latest PointerEvent that occurred on the document.
@@ -14,22 +15,31 @@ import type { ClickOutsideConfig } from './types.js';
  * @returns A function to unsubscribe from the event listener and stop tracking pointer events.
  */
 const documentClickStore = readable<PointerEvent | undefined>(undefined, (set): (() => void) => {
+	let targetElement: EventTarget | null = null;
+
 	/**
 	 * Event handler for pointerdown events on the document.
 	 * Updates the store's value with the latest PointerEvent and then resets it to undefined.
 	 */
-	function clicked(event: PointerEvent | undefined) {
-		set(event);
-
-		// New subscriptions will not trigger immediately
-		set(undefined);
+	function handlePointerUp(event: PointerEvent | undefined) {
+		if (targetElement === event?.target) {
+			// the `pointerup` target is the same as the `pointerdown` target
+			set(event);
+			// New subscriptions will not trigger immediately
+			set(undefined);
+		} else {
+			set(undefined);
+		}
 	}
 
-	// Adds a pointerdown event listener to the document, calling the clicked function when triggered.
-	const unsubscribe = addEventListener(document, 'pointerup', clicked, {
-		passive: false,
-		capture: true,
-	});
+	function handlePointerDown(event: PointerEvent) {
+		targetElement = event.target;
+	}
+
+	const unsubscribe = executeCallbacks(
+		addEventListener(document, 'pointerup', handlePointerUp, { passive: false, capture: true }),
+		addEventListener(document, 'pointerdown', handlePointerDown, { passive: false, capture: true })
+	);
 
 	// Returns a function to unsubscribe from the event listener and stop tracking pointer events.
 	return unsubscribe;


### PR DESCRIPTION
Closes: #750

Previously, we were triggering an outside click on `pointerup` instead of `pointerdown` causing unexpected behavior when doing things like selecting text within a dialog. If you clicked inside and drug outside to select a bunch of stuff, the dialog would close. This is no longer an issue.