### PR TITLE
Slider: add `data-value` attribute to `tick` and `thumb`

### DIFF
--- a/src/docs/data/builders/slider.ts
+++ b/src/docs/data/builders/slider.ts
@@ -130,6 +130,10 @@ const thumb = elementSchema('thumb', {
 			name: 'data-melt-slider-thumb',
 			value: ATTRS.MELT('slider thumb'),
 		},
+		{
+			name: 'data-value',
+			value: 'The current value of the thumb.',
+		},
 	],
 	events: sliderEvents['thumb'],
 });
@@ -142,8 +146,12 @@ const tick = elementSchema('tick', {
 			value: ATTRS.MELT('slider tick'),
 		},
 		{
+			name: 'data-value',
+			value: "The value at the tick's position.",
+		},
+		{
 			name: 'data-bounded',
-			value: "Present when a tick is inside the `value`'s bounds.",
+			value: "Present when the tick is inside the active range.",
 		},
 	],
 });

--- a/src/docs/data/builders/slider.ts
+++ b/src/docs/data/builders/slider.ts
@@ -151,7 +151,7 @@ const tick = elementSchema('tick', {
 		},
 		{
 			name: 'data-bounded',
-			value: "Present when the tick is inside the active range.",
+			value: 'Present when the tick is inside the active range.',
 		},
 	],
 });

--- a/src/lib/builders/slider/create.ts
+++ b/src/lib/builders/slider/create.ts
@@ -327,6 +327,7 @@ export const createSlider = (props?: CreateSliderProps) => {
 
 				return {
 					'data-bounded': bounded ? true : undefined,
+					'data-value': tickValue,
 					style: styleToString(style),
 				};
 			};

--- a/src/lib/builders/slider/create.ts
+++ b/src/lib/builders/slider/create.ts
@@ -460,7 +460,7 @@ export const createSlider = (props?: CreateSliderProps) => {
 
 		if ($value.some((v) => !isValidValue(v))) {
 			value.update((prev) => {
-				return [...prev].map(gcv);
+				return prev.map(gcv);
 			});
 		}
 	});

--- a/src/lib/builders/slider/create.ts
+++ b/src/lib/builders/slider/create.ts
@@ -172,13 +172,15 @@ export const createSlider = (props?: CreateSliderProps) => {
 					currentThumbIndex.update((prev) => prev + 1);
 				}
 
-				const thumbPosition = `${$position($value[index])}%`;
+				const thumbValue = $value[index];
+				const thumbPosition = `${$position(thumbValue)}%`;
 				return {
 					role: 'slider',
 					'aria-valuemin': $min,
 					'aria-valuemax': $max,
-					'aria-valuenow': $value[index],
+					'aria-valuenow': thumbValue,
 					'data-melt-part': 'thumb',
+					'data-value': thumbValue,
 					style: styleToString({
 						position: 'absolute',
 						...($orientation === 'horizontal'


### PR DESCRIPTION
This PR adds the `data-value` attributes to the `tick`. This improves customizability, like only showing certain ticks, for example. I also added `data-value` to the `thumb` for consistency (I'm aware `aria-valuenow` exists, just thought it'd be nice to be consistent).