### PR TITLE
Fix: Date Picker popover prop reactivity

### DIFF
--- a/.changeset/fifty-cats-collect.md
+++ b/.changeset/fifty-cats-collect.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+Fix: Date Pickers option store reactivity

--- a/src/lib/builders/date-picker/create.ts
+++ b/src/lib/builders/date-picker/create.ts
@@ -121,26 +121,6 @@ export function createDatePicker(props?: CreateDatePickerProps) {
 		calendar.options.maxValue.set($maxValue);
 	});
 
-	effect([options.positioning], ([$positioning]) => {
-		popover.options.positioning.set($positioning);
-	});
-
-	effect([options.forceVisible], ([$forceVisible]) => {
-		popover.options.forceVisible.set($forceVisible);
-	});
-
-	effect([options.closeOnEscape], ([$closeOnEscape]) => {
-		popover.options.closeOnEscape.set($closeOnEscape);
-	});
-
-	effect([options.closeOnOutsideClick], ([$closeOnOutsideClick]) => {
-		popover.options.closeOnOutsideClick.set($closeOnOutsideClick);
-	});
-
-	effect([options.preventScroll], ([$preventScroll]) => {
-		popover.options.preventScroll.set($preventScroll);
-	});
-
 	const dateFieldOptions = omit(
 		dateField.options,
 		'locale',
@@ -206,10 +186,10 @@ export function createDatePicker(props?: CreateDatePickerProps) {
 			...calendar.helpers,
 		},
 		options: {
-			...popover.options,
 			...dateFieldOptions,
 			...calendarOptions,
 			...options,
+			...popover.options,
 		},
 		ids: {
 			dateField: dateField.ids,

--- a/src/lib/builders/date-picker/create.ts
+++ b/src/lib/builders/date-picker/create.ts
@@ -121,6 +121,26 @@ export function createDatePicker(props?: CreateDatePickerProps) {
 		calendar.options.maxValue.set($maxValue);
 	});
 
+	effect([options.positioning], ([$positioning]) => {
+		popover.options.positioning.set($positioning);
+	});
+
+	effect([options.forceVisible], ([$forceVisible]) => {
+		popover.options.forceVisible.set($forceVisible);
+	});
+
+	effect([options.closeOnEscape], ([$closeOnEscape]) => {
+		popover.options.closeOnEscape.set($closeOnEscape);
+	});
+
+	effect([options.closeOnOutsideClick], ([$closeOnOutsideClick]) => {
+		popover.options.closeOnOutsideClick.set($closeOnOutsideClick);
+	});
+
+	effect([options.preventScroll], ([$preventScroll]) => {
+		popover.options.preventScroll.set($preventScroll);
+	});
+
 	const dateFieldOptions = omit(
 		dateField.options,
 		'locale',

--- a/src/lib/builders/date-range-picker/create.ts
+++ b/src/lib/builders/date-range-picker/create.ts
@@ -135,26 +135,6 @@ export function createDateRangePicker(props?: CreateDateRangePickerProps) {
 		calendar.options.maxValue.set($maxValue);
 	});
 
-	effect([options.positioning], ([$positioning]) => {
-		popover.options.positioning.set($positioning);
-	});
-
-	effect([options.forceVisible], ([$forceVisible]) => {
-		popover.options.forceVisible.set($forceVisible);
-	});
-
-	effect([options.closeOnEscape], ([$closeOnEscape]) => {
-		popover.options.closeOnEscape.set($closeOnEscape);
-	});
-
-	effect([options.closeOnOutsideClick], ([$closeOnOutsideClick]) => {
-		popover.options.closeOnOutsideClick.set($closeOnOutsideClick);
-	});
-
-	effect([options.preventScroll], ([$preventScroll]) => {
-		popover.options.preventScroll.set($preventScroll);
-	});
-
 	effect([popover.states.open], ([$open]) => {
 		if (!$open) {
 			const $value = get(value);
@@ -209,10 +189,10 @@ export function createDateRangePicker(props?: CreateDateRangePickerProps) {
 			...calendar.helpers,
 		},
 		options: {
-			...popover.options,
 			...rangeFieldOptions,
 			...rangeCalendarOptions,
 			...options,
+			...popover.options,
 		},
 		ids: {
 			rangeField: rangeField.ids,

--- a/src/lib/builders/date-range-picker/create.ts
+++ b/src/lib/builders/date-range-picker/create.ts
@@ -135,6 +135,26 @@ export function createDateRangePicker(props?: CreateDateRangePickerProps) {
 		calendar.options.maxValue.set($maxValue);
 	});
 
+	effect([options.positioning], ([$positioning]) => {
+		popover.options.positioning.set($positioning);
+	});
+
+	effect([options.forceVisible], ([$forceVisible]) => {
+		popover.options.forceVisible.set($forceVisible);
+	});
+
+	effect([options.closeOnEscape], ([$closeOnEscape]) => {
+		popover.options.closeOnEscape.set($closeOnEscape);
+	});
+
+	effect([options.closeOnOutsideClick], ([$closeOnOutsideClick]) => {
+		popover.options.closeOnOutsideClick.set($closeOnOutsideClick);
+	});
+
+	effect([options.preventScroll], ([$preventScroll]) => {
+		popover.options.preventScroll.set($preventScroll);
+	});
+
 	effect([popover.states.open], ([$open]) => {
 		if (!$open) {
 			const $value = get(value);


### PR DESCRIPTION
Closes: #777 

Fixes reactivity issues when updating certain `option` stores related to the date picker.

Ideally in the near future, I can determine a better way to handle passing these stores around and improve the composability.