### PR TITLE
chore: remove unnecessary attributes in calendar

### DIFF
--- a/.changeset/afraid-chefs-talk.md
+++ b/.changeset/afraid-chefs-talk.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+Calendars: remove unnecessary cell attributes in favor of `melt` attribute

--- a/src/docs/data/builders/calendar.ts
+++ b/src/docs/data/builders/calendar.ts
@@ -383,10 +383,6 @@ const cell = elementSchema('cell', {
 			value: 'Present when the date is focused.',
 		},
 		{
-			name: 'data-calendar-cell',
-			value: ATTRS.MELT('cell'),
-		},
-		{
 			name: 'data-melt-calendar-cell',
 			value: ATTRS.MELT('cell'),
 		},

--- a/src/docs/data/builders/range-calendar.ts
+++ b/src/docs/data/builders/range-calendar.ts
@@ -389,10 +389,6 @@ const cell = elementSchema('cell', {
 			value: 'Present when the date is focused.',
 		},
 		{
-			name: 'data-calendar-cell',
-			value: ATTRS.MELT('cell'),
-		},
-		{
 			name: 'data-melt-calendar-cell',
 			value: ATTRS.MELT('cell'),
 		},

--- a/src/lib/builders/calendar/create.ts
+++ b/src/lib/builders/calendar/create.ts
@@ -463,9 +463,6 @@ export function createCalendar<
 					'data-outside-visible-months': isOutsideVisibleMonths ? '' : undefined,
 					'data-focused': isFocusedDate ? '' : undefined,
 					tabindex: isFocusedDate ? 0 : isOutsideMonth || isDisabled ? undefined : -1,
-					// We share some selection logic between this and the range calendar
-					// so we use a common data attr that isn't a `melt` attr
-					'data-calendar-cell': '',
 				} as const;
 			};
 		},

--- a/src/lib/builders/range-calendar/create.ts
+++ b/src/lib/builders/range-calendar/create.ts
@@ -478,9 +478,6 @@ export function createRangeCalendar<T extends DateValue = DateValue>(
 					'data-focused': isFocusedDate ? '' : undefined,
 					'data-highlighted': isHighlighted ? '' : undefined,
 					tabindex: isFocusedDate ? 0 : isOutsideMonth || isDisabled ? undefined : -1,
-					// We share selection logic between this & the calendar builder
-					// so we aren't using the `melt` attr to select
-					'data-calendar-cell': '',
 				} as const;
 			};
 		},

--- a/src/lib/internal/helpers/date/calendar.ts
+++ b/src/lib/internal/helpers/date/calendar.ts
@@ -159,7 +159,7 @@ export function createMonths(props: SetMonthProps) {
 export function getSelectableCells(calendarId: string) {
 	const node = document.getElementById(calendarId);
 	if (!node) return [];
-	const selectableSelector = `[data-calendar-cell]:not([data-disabled]):not([data-outside-visible-months])`;
+	const selectableSelector = `[data-melt-calendar-cell]:not([data-disabled]):not([data-outside-visible-months])`;
 
 	return Array.from(node.querySelectorAll(selectableSelector)).filter((el): el is HTMLElement =>
 		isHTMLElement(el)


### PR DESCRIPTION
Removes an unnecessary data attribute applied to the calendar cells.