### PR TITLE
docs: Fix typo `positioning` → `placement`

### DIFF
--- a/src/docs/constants.ts
+++ b/src/docs/constants.ts
@@ -113,7 +113,7 @@ export const PROPS = {
 	}),
 	POSITIONING: (args: PropArgs = {}): Prop => ({
 		name: 'positioning',
-		default: args.default ?? 'positioning: "bottom"',
+		default: args.default ?? 'placement: "bottom"',
 		description: DESCRIPTIONS.FLOATING_CONFIG,
 		type: 'FloatingConfig',
 		longType: {


### PR DESCRIPTION
![image](https://github.com/melt-ui/melt-ui/assets/4117920/96a8e330-8011-4d11-b3cb-8d7b41518826)

The `positioning` prop takes a `FloatingConfig` object, which has a key called `placement`.