### PR TITLE
Rename `daysOfWeek` to `weekdays` & add `weekdayFormat` prop

### DIFF
--- a/.changeset/khaki-dryers-promise.md
+++ b/.changeset/khaki-dryers-promise.md
@@ -1,0 +1,7 @@
+---
+"@melt-ui/svelte": minor
+---
+
+- Calendars & Date Pickers: rename `daysOfWeek` to `weekdays` and add `weekdayFormat` prop (closes #782)
+
+

--- a/src/docs/content/builders/calendar.md
+++ b/src/docs/content/builders/calendar.md
@@ -45,7 +45,7 @@ we go.
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek },
+		states: { months, headingValue, weekdays },
 		helpers: { isDateDisabled, isDateUnavailable }
 	} = createCalendar()
 </script>
@@ -60,7 +60,7 @@ elements will be contained within it.
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek },
+		states: { months, headingValue, weekdays },
 		helpers: { isDateDisabled, isDateUnavailable }
 	} = createCalendar()
 </script>
@@ -79,7 +79,7 @@ buttons (`prevButton` & `nextButton`).
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek },
+		states: { months, headingValue, weekdays },
 		helpers: { isDateDisabled, isDateUnavailable }
 	} = createCalendar()
 </script>
@@ -143,8 +143,8 @@ export type Month = {
 
 Since we're taking the recommended approach of rendering the calendar grid using a table, we'll be
 using the `weeks` property of each month to render the rows of the table. We'll also use the
-`daysOfWeek` state to render the column headers of the table, which is an array of formatted day
-names according to the `locale` prop.
+`weekdays` state to render the column headers of the table, which is an array of formatted day names
+according to the `locale` prop.
 
 ```svelte showLineNumbers {19-29}
 <script lang="ts">
@@ -152,7 +152,7 @@ names according to the `locale` prop.
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek },
+		states: { months, headingValue, weekdays },
 		helpers: { isDateDisabled, isDateUnavailable }
 	} = createCalendar()
 </script>
@@ -169,7 +169,7 @@ names according to the `locale` prop.
 		<table use:melt={$grid}>
 			<thead aria-hidden="true">
 				<tr>
-					{#each $daysOfWeek as day}
+					{#each $weekdays as day}
 						<th>{day}</th>
 					{/each}
 				</tr>
@@ -190,7 +190,7 @@ Now we can finish off the calendar by rendering the weeks and days within each w
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek },
+		states: { months, headingValue, weekdays },
 		helpers: { isDateDisabled, isDateUnavailable }
 	} = createCalendar()
 </script>
@@ -207,7 +207,7 @@ Now we can finish off the calendar by rendering the weeks and days within each w
 		<table use:melt={$grid}>
 			<thead aria-hidden="true">
 				<tr>
-					{#each $daysOfWeek as day}
+					{#each $weekdays as day}
 						<th>{day}</th>
 					{/each}
 				</tr>

--- a/src/docs/content/builders/date-picker.md
+++ b/src/docs/content/builders/date-picker.md
@@ -68,7 +68,7 @@ the pieces we need:
 			segment,
 			trigger
 		},
-		states: { months, headingValue, daysOfWeek, segmentContents },
+		states: { months, headingValue, weekdays, segmentContents },
 		helpers: { isDateDisabled, isDateUnavailable }
 	} = createDatePicker()
 </script>
@@ -128,7 +128,7 @@ Once that's in place, we can setup our calendar, which will be contained within 
 			<table use:melt={$grid}>
 				<thead aria-hidden="true">
 					<tr>
-						{#each $daysOfWeek as day}
+						{#each $weekdays as day}
 							<th>
 								{$day}
 							</th>

--- a/src/docs/content/builders/date-range-picker.md
+++ b/src/docs/content/builders/date-range-picker.md
@@ -73,7 +73,7 @@ destructuring the pieces we need:
 			endSegment,
 			trigger
 		},
-		states: { months, headingValue, daysOfWeek, segmentContents },
+		states: { months, headingValue, weekdays, segmentContents },
 		helpers: { isDateDisabled, isDateUnavailable }
 	} = createDateRangePicker()
 </script>
@@ -145,7 +145,7 @@ Once that's in place, we can setup our calendar, which will be contained within 
 			<table use:melt={$grid}>
 				<thead aria-hidden="true">
 					<tr>
-						{#each $daysOfWeek as day}
+						{#each $weekdays as day}
 							<th>
 								{$day}
 							</th>

--- a/src/docs/content/builders/range-calendar.md
+++ b/src/docs/content/builders/range-calendar.md
@@ -45,7 +45,7 @@ more detail as we go.
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek },
+		states: { months, headingValue, weekdays },
 		helpers: { isDateDisabled, isDateUnavailable }
 	} = createRangeCalendar()
 </script>
@@ -60,7 +60,7 @@ elements will be contained within it.
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek },
+		states: { months, headingValue, weekdays },
 		helpers: { isDateDisabled, isDateUnavailable }
 	} = createRangeCalendar()
 </script>
@@ -79,7 +79,7 @@ buttons (`prevButton` & `nextButton`).
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek },
+		states: { months, headingValue, weekdays },
 		helpers: { isDateDisabled, isDateUnavailable }
 	} = createRangeCalendar()
 </script>
@@ -143,8 +143,8 @@ export type Month = {
 
 Since we're taking the recommended approach of rendering the calendar grid using a table, we'll be
 using the `weeks` property of each month to render the rows of the table. We'll also use the
-`daysOfWeek` state to render the column headers of the table, which is an array of formatted day
-names according to the `locale` prop.
+`weekdays` state to render the column headers of the table, which is an array of formatted day names
+according to the `locale` prop.
 
 ```svelte showLineNumbers {19-29}
 <script lang="ts">
@@ -152,7 +152,7 @@ names according to the `locale` prop.
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek },
+		states: { months, headingValue, weekdays },
 		helpers: { isDateDisabled, isDateUnavailable }
 	} = createRangeCalendar()
 </script>
@@ -169,7 +169,7 @@ names according to the `locale` prop.
 		<table use:melt={$grid}>
 			<thead aria-hidden="true">
 				<tr>
-					{#each $daysOfWeek as day}
+					{#each $weekdays as day}
 						<th>{day}</th>
 					{/each}
 				</tr>
@@ -190,7 +190,7 @@ Now we can finish off the calendar by rendering the weeks and days within each w
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek },
+		states: { months, headingValue, weekdays },
 		helpers: { isDateDisabled, isDateUnavailable }
 	} = createRangeCalendar()
 </script>
@@ -207,7 +207,7 @@ Now we can finish off the calendar by rendering the weeks and days within each w
 		<table use:melt={$grid}>
 			<thead aria-hidden="true">
 				<tr>
-					{#each $daysOfWeek as day}
+					{#each $weekdays as day}
 						<th>{day}</th>
 					{/each}
 				</tr>

--- a/src/docs/data/builders/calendar.ts
+++ b/src/docs/data/builders/calendar.ts
@@ -179,7 +179,7 @@ const builder = builderSchema(BUILDER_NAME, {
 			description: 'A readable store containing month objects for each month in the calendar.',
 		},
 		{
-			name: 'daysOfWeek',
+			name: 'weekdays',
 			type: 'Readable<string[]>',
 			description:
 				'A readable store containing the days of the week, formatted to the  `locale` prop.',

--- a/src/docs/data/builders/date-picker.ts
+++ b/src/docs/data/builders/date-picker.ts
@@ -181,7 +181,7 @@ const builder = builderSchema(BUILDER_NAME, {
 			description: 'A readable store containing month objects for each month in the calendar.',
 		},
 		{
-			name: 'daysOfWeek',
+			name: 'weekdays',
 			type: 'Readable<string[]>',
 			description:
 				'A readable store containing the days of the week, formatted to the  `locale` prop.',

--- a/src/docs/data/builders/date-range-picker.ts
+++ b/src/docs/data/builders/date-range-picker.ts
@@ -183,7 +183,7 @@ const builder = builderSchema(BUILDER_NAME, {
 			description: 'A readable store containing month objects for each month in the calendar.',
 		},
 		{
-			name: 'daysOfWeek',
+			name: 'weekdays',
 			type: 'Readable<string[]>',
 			description:
 				'A readable store containing the days of the week, formatted to the  `locale` prop.',

--- a/src/docs/data/builders/range-calendar.ts
+++ b/src/docs/data/builders/range-calendar.ts
@@ -173,7 +173,7 @@ const builder = builderSchema(BUILDER_NAME, {
 			description: 'A readable store containing month objects for each month in the calendar.',
 		},
 		{
-			name: 'daysOfWeek',
+			name: 'weekdays',
 			type: 'Readable<string[]>',
 			description:
 				'A readable store containing the days of the week, formatted to the  `locale` prop.',

--- a/src/docs/previews/calendar/changePh/tailwind/index.svelte
+++ b/src/docs/previews/calendar/changePh/tailwind/index.svelte
@@ -5,7 +5,7 @@
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek },
+		states: { months, headingValue, weekdays },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createCalendar({
 		defaultPlaceholder: new CalendarDate(2021, 2, 1),
@@ -29,7 +29,7 @@
 			<table use:melt={$grid}>
 				<thead aria-hidden="true">
 					<tr>
-						{#each $daysOfWeek as day}
+						{#each $weekdays as day}
 							<th>
 								<div>
 									{day}

--- a/src/docs/previews/calendar/changeValue/tailwind/index.svelte
+++ b/src/docs/previews/calendar/changeValue/tailwind/index.svelte
@@ -5,7 +5,7 @@
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek },
+		states: { months, headingValue, weekdays },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createCalendar({
 		defaultValue: new CalendarDate(2024, 1, 11),
@@ -29,7 +29,7 @@
 			<table use:melt={$grid}>
 				<thead aria-hidden="true">
 					<tr>
-						{#each $daysOfWeek as day}
+						{#each $weekdays as day}
 							<th>
 								<div>
 									{day}

--- a/src/docs/previews/calendar/disabled/tailwind/index.svelte
+++ b/src/docs/previews/calendar/disabled/tailwind/index.svelte
@@ -4,7 +4,7 @@
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek },
+		states: { months, headingValue, weekdays },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createCalendar({
 		isDateDisabled: (date) => {
@@ -30,7 +30,7 @@
 			<table use:melt={$grid}>
 				<thead aria-hidden="true">
 					<tr>
-						{#each $daysOfWeek as day}
+						{#each $weekdays as day}
 							<th>
 								<div>
 									{day}

--- a/src/docs/previews/calendar/fixedWeeks/tailwind/index.svelte
+++ b/src/docs/previews/calendar/fixedWeeks/tailwind/index.svelte
@@ -5,7 +5,7 @@
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek },
+		states: { months, headingValue, weekdays },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createCalendar({
 		defaultPlaceholder: new CalendarDate(2021, 2, 14),
@@ -30,7 +30,7 @@
 			<table use:melt={$grid}>
 				<thead aria-hidden="true">
 					<tr>
-						{#each $daysOfWeek as day}
+						{#each $weekdays as day}
 							<th>
 								<div>
 									{day}

--- a/src/docs/previews/calendar/limitSelectedA/tailwind/index.svelte
+++ b/src/docs/previews/calendar/limitSelectedA/tailwind/index.svelte
@@ -10,7 +10,7 @@
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek },
+		states: { months, headingValue, weekdays },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createCalendar({
 		defaultValue,
@@ -43,7 +43,7 @@
 			<table use:melt={$grid}>
 				<thead aria-hidden="true">
 					<tr>
-						{#each $daysOfWeek as day}
+						{#each $weekdays as day}
 							<th>
 								<div>
 									{day}

--- a/src/docs/previews/calendar/limitSelectedB/tailwind/index.svelte
+++ b/src/docs/previews/calendar/limitSelectedB/tailwind/index.svelte
@@ -10,7 +10,7 @@
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek },
+		states: { months, headingValue, weekdays },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createCalendar({
 		defaultValue,
@@ -43,7 +43,7 @@
 			<table use:melt={$grid}>
 				<thead aria-hidden="true">
 					<tr>
-						{#each $daysOfWeek as day}
+						{#each $weekdays as day}
 							<th>
 								<div>
 									{day}

--- a/src/docs/previews/calendar/locale/tailwind/index.svelte
+++ b/src/docs/previews/calendar/locale/tailwind/index.svelte
@@ -4,7 +4,7 @@
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek },
+		states: { months, headingValue, weekdays },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createCalendar({
 		locale: 'de',
@@ -28,7 +28,7 @@
 			<table use:melt={$grid}>
 				<thead aria-hidden="true">
 					<tr>
-						{#each $daysOfWeek as day}
+						{#each $weekdays as day}
 							<th>
 								<div>
 									{day}

--- a/src/docs/previews/calendar/main/tailwind/index.svelte
+++ b/src/docs/previews/calendar/main/tailwind/index.svelte
@@ -5,7 +5,7 @@
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek },
+		states: { months, headingValue, weekdays },
 		helpers: { isDateDisabled, isDateUnavailable },
 		options: { locale },
 	} = createCalendar();
@@ -37,7 +37,7 @@
 				<table use:melt={$grid}>
 					<thead aria-hidden="true">
 						<tr>
-							{#each $daysOfWeek as day}
+							{#each $weekdays as day}
 								<th>
 									<div>
 										{day}

--- a/src/docs/previews/calendar/minMax/tailwind/index.svelte
+++ b/src/docs/previews/calendar/minMax/tailwind/index.svelte
@@ -5,7 +5,7 @@
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek },
+		states: { months, headingValue, weekdays },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createCalendar({
 		defaultPlaceholder: new CalendarDate(2023, 1, 25),
@@ -31,7 +31,7 @@
 			<table use:melt={$grid}>
 				<thead aria-hidden="true">
 					<tr>
-						{#each $daysOfWeek as day}
+						{#each $weekdays as day}
 							<th>
 								<div>
 									{day}

--- a/src/docs/previews/calendar/monthSelect/tailwind/index.svelte
+++ b/src/docs/previews/calendar/monthSelect/tailwind/index.svelte
@@ -7,7 +7,7 @@
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek, placeholder },
+		states: { months, headingValue, weekdays, placeholder },
 		helpers: { isDateDisabled, isDateUnavailable, setMonth },
 	} = createCalendar({
 		fixedWeeks: true,
@@ -48,7 +48,7 @@
 				<table use:melt={$grid}>
 					<thead aria-hidden="true">
 						<tr>
-							{#each $daysOfWeek as day}
+							{#each $weekdays as day}
 								<th>
 									<div>
 										{day}

--- a/src/docs/previews/calendar/multipleMonths/tailwind/index.svelte
+++ b/src/docs/previews/calendar/multipleMonths/tailwind/index.svelte
@@ -4,7 +4,7 @@
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek },
+		states: { months, headingValue, weekdays },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createCalendar({
 		numberOfMonths: 2,
@@ -28,7 +28,7 @@
 			<table use:melt={$grid}>
 				<thead aria-hidden="true">
 					<tr>
-						{#each $daysOfWeek as day}
+						{#each $weekdays as day}
 							<th>
 								<div>
 									{day}

--- a/src/docs/previews/calendar/multipleSelect/tailwind/index.svelte
+++ b/src/docs/previews/calendar/multipleSelect/tailwind/index.svelte
@@ -5,7 +5,7 @@
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek },
+		states: { months, headingValue, weekdays },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createCalendar({
 		defaultPlaceholder: new CalendarDate(2023, 10, 1),
@@ -30,7 +30,7 @@
 			<table use:melt={$grid}>
 				<thead aria-hidden="true">
 					<tr>
-						{#each $daysOfWeek as day}
+						{#each $weekdays as day}
 							<th>
 								<div>
 									{day}

--- a/src/docs/previews/calendar/pagedNav/tailwind/index.svelte
+++ b/src/docs/previews/calendar/pagedNav/tailwind/index.svelte
@@ -4,7 +4,7 @@
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek },
+		states: { months, headingValue, weekdays },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createCalendar({
 		numberOfMonths: 2,
@@ -30,7 +30,7 @@
 			<table use:melt={$grid}>
 				<thead aria-hidden="true">
 					<tr>
-						{#each $daysOfWeek as day}
+						{#each $weekdays as day}
 							<th>
 								<div>
 									{day}

--- a/src/docs/previews/calendar/preventDeselect/tailwind/index.svelte
+++ b/src/docs/previews/calendar/preventDeselect/tailwind/index.svelte
@@ -5,7 +5,7 @@
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek },
+		states: { months, headingValue, weekdays },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createCalendar({
 		preventDeselect: true,
@@ -30,7 +30,7 @@
 			<table use:melt={$grid}>
 				<thead aria-hidden="true">
 					<tr>
-						{#each $daysOfWeek as day}
+						{#each $weekdays as day}
 							<th>
 								<div>
 									{day}

--- a/src/docs/previews/calendar/reactToVal/tailwind/index.svelte
+++ b/src/docs/previews/calendar/reactToVal/tailwind/index.svelte
@@ -7,7 +7,7 @@
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek, value },
+		states: { months, headingValue, weekdays, value },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createCalendar({
 		defaultPlaceholder: new CalendarDate(2023, 10, 1),
@@ -35,7 +35,7 @@
 			<table use:melt={$grid}>
 				<thead aria-hidden="true">
 					<tr>
-						{#each $daysOfWeek as day}
+						{#each $weekdays as day}
 							<th>
 								<div>
 									{day}

--- a/src/docs/previews/calendar/unavailable/tailwind/index.svelte
+++ b/src/docs/previews/calendar/unavailable/tailwind/index.svelte
@@ -5,7 +5,7 @@
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek },
+		states: { months, headingValue, weekdays },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createCalendar({
 		isDateUnavailable: (date) => {
@@ -31,7 +31,7 @@
 			<table use:melt={$grid}>
 				<thead aria-hidden="true">
 					<tr>
-						{#each $daysOfWeek as day}
+						{#each $weekdays as day}
 							<th>
 								<div>
 									{day}

--- a/src/docs/previews/date-picker/defaultPh/tailwind/index.svelte
+++ b/src/docs/previews/date-picker/defaultPh/tailwind/index.svelte
@@ -18,7 +18,7 @@
 			segment,
 			trigger,
 		},
-		states: { months, headingValue, daysOfWeek, segmentContents, open },
+		states: { months, headingValue, weekdays, segmentContents, open },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createDatePicker({
 		forceVisible: true,
@@ -61,7 +61,7 @@
 						<table use:melt={$grid}>
 							<thead aria-hidden="true">
 								<tr>
-									{#each $daysOfWeek as day}
+									{#each $weekdays as day}
 										<th>
 											<div>
 												{day}

--- a/src/docs/previews/date-picker/defaultValue/tailwind/index.svelte
+++ b/src/docs/previews/date-picker/defaultValue/tailwind/index.svelte
@@ -18,7 +18,7 @@
 			segment,
 			trigger,
 		},
-		states: { months, headingValue, daysOfWeek, segmentContents, open },
+		states: { months, headingValue, weekdays, segmentContents, open },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createDatePicker({
 		forceVisible: true,
@@ -61,7 +61,7 @@
 						<table use:melt={$grid}>
 							<thead aria-hidden="true">
 								<tr>
-									{#each $daysOfWeek as day}
+									{#each $weekdays as day}
 										<th>
 											<div>
 												{day}

--- a/src/docs/previews/date-picker/disabled/tailwind/index.svelte
+++ b/src/docs/previews/date-picker/disabled/tailwind/index.svelte
@@ -17,7 +17,7 @@
 			segment,
 			trigger,
 		},
-		states: { months, headingValue, daysOfWeek, segmentContents, open, value },
+		states: { months, headingValue, weekdays, segmentContents, open, value },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createDatePicker({
 		forceVisible: true,
@@ -64,7 +64,7 @@
 						<table use:melt={$grid}>
 							<thead aria-hidden="true">
 								<tr>
-									{#each $daysOfWeek as day}
+									{#each $weekdays as day}
 										<th>
 											<div>
 												{day}

--- a/src/docs/previews/date-picker/fixedWeeks/tailwind/index.svelte
+++ b/src/docs/previews/date-picker/fixedWeeks/tailwind/index.svelte
@@ -17,7 +17,7 @@
 			segment,
 			trigger,
 		},
-		states: { months, headingValue, daysOfWeek, segmentContents, open, value },
+		states: { months, headingValue, weekdays, segmentContents, open, value },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createDatePicker({
 		forceVisible: true,
@@ -61,7 +61,7 @@
 						<table use:melt={$grid}>
 							<thead aria-hidden="true">
 								<tr>
-									{#each $daysOfWeek as day}
+									{#each $weekdays as day}
 										<th>
 											<div>
 												{day}

--- a/src/docs/previews/date-picker/locale/tailwind/index.svelte
+++ b/src/docs/previews/date-picker/locale/tailwind/index.svelte
@@ -17,7 +17,7 @@
 			segment,
 			trigger,
 		},
-		states: { months, headingValue, daysOfWeek, segmentContents, open, value },
+		states: { months, headingValue, weekdays, segmentContents, open, value },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createDatePicker({
 		forceVisible: true,
@@ -62,7 +62,7 @@
 						<table use:melt={$grid}>
 							<thead aria-hidden="true">
 								<tr>
-									{#each $daysOfWeek as day}
+									{#each $weekdays as day}
 										<th>
 											<div>
 												{day}

--- a/src/docs/previews/date-picker/main/tailwind/index.svelte
+++ b/src/docs/previews/date-picker/main/tailwind/index.svelte
@@ -19,7 +19,7 @@
 			segment,
 			trigger,
 		},
-		states: { months, headingValue, daysOfWeek, segmentContents, open },
+		states: { months, headingValue, weekdays, segmentContents, open },
 		helpers: { isDateDisabled, isDateUnavailable },
 		options: { locale },
 	} = createDatePicker({
@@ -73,7 +73,7 @@
 						<table use:melt={$grid}>
 							<thead aria-hidden="true">
 								<tr>
-									{#each $daysOfWeek as day}
+									{#each $weekdays as day}
 										<th>
 											<div>
 												{day}

--- a/src/docs/previews/date-picker/minMax/tailwind/index.svelte
+++ b/src/docs/previews/date-picker/minMax/tailwind/index.svelte
@@ -18,7 +18,7 @@
 			segment,
 			trigger,
 		},
-		states: { months, headingValue, daysOfWeek, segmentContents, open, value },
+		states: { months, headingValue, weekdays, segmentContents, open, value },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createDatePicker({
 		forceVisible: true,
@@ -65,7 +65,7 @@
 						<table use:melt={$grid}>
 							<thead aria-hidden="true">
 								<tr>
-									{#each $daysOfWeek as day}
+									{#each $weekdays as day}
 										<th>
 											<div>
 												{day}

--- a/src/docs/previews/date-picker/multipleMonths/tailwind/index.svelte
+++ b/src/docs/previews/date-picker/multipleMonths/tailwind/index.svelte
@@ -17,7 +17,7 @@
 			segment,
 			trigger,
 		},
-		states: { months, headingValue, daysOfWeek, segmentContents, open, value },
+		states: { months, headingValue, weekdays, segmentContents, open, value },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createDatePicker({
 		forceVisible: true,
@@ -62,7 +62,7 @@
 						<table use:melt={$grid}>
 							<thead aria-hidden="true">
 								<tr>
-									{#each $daysOfWeek as day}
+									{#each $weekdays as day}
 										<th>
 											<div>
 												{day}

--- a/src/docs/previews/date-picker/pagedNav/tailwind/index.svelte
+++ b/src/docs/previews/date-picker/pagedNav/tailwind/index.svelte
@@ -17,7 +17,7 @@
 			segment,
 			trigger,
 		},
-		states: { months, headingValue, daysOfWeek, segmentContents, open, value },
+		states: { months, headingValue, weekdays, segmentContents, open, value },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createDatePicker({
 		forceVisible: true,
@@ -63,7 +63,7 @@
 						<table use:melt={$grid}>
 							<thead aria-hidden="true">
 								<tr>
-									{#each $daysOfWeek as day}
+									{#each $weekdays as day}
 										<th>
 											<div>
 												{day}

--- a/src/docs/previews/date-picker/preventDeselect/tailwind/index.svelte
+++ b/src/docs/previews/date-picker/preventDeselect/tailwind/index.svelte
@@ -18,7 +18,7 @@
 			segment,
 			trigger,
 		},
-		states: { months, headingValue, daysOfWeek, segmentContents, open, value },
+		states: { months, headingValue, weekdays, segmentContents, open, value },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createDatePicker({
 		forceVisible: true,
@@ -64,7 +64,7 @@
 						<table use:melt={$grid}>
 							<thead aria-hidden="true">
 								<tr>
-									{#each $daysOfWeek as day}
+									{#each $weekdays as day}
 										<th>
 											<div>
 												{day}

--- a/src/docs/previews/date-picker/unavailable/tailwind/index.svelte
+++ b/src/docs/previews/date-picker/unavailable/tailwind/index.svelte
@@ -18,7 +18,7 @@
 			segment,
 			trigger,
 		},
-		states: { months, headingValue, daysOfWeek, segmentContents, open, value },
+		states: { months, headingValue, weekdays, segmentContents, open, value },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createDatePicker({
 		forceVisible: true,
@@ -65,7 +65,7 @@
 						<table use:melt={$grid}>
 							<thead aria-hidden="true">
 								<tr>
-									{#each $daysOfWeek as day}
+									{#each $weekdays as day}
 										<th>
 											<div>
 												{day}

--- a/src/docs/previews/date-picker/usingValue/tailwind/index.svelte
+++ b/src/docs/previews/date-picker/usingValue/tailwind/index.svelte
@@ -18,7 +18,7 @@
 			segment,
 			trigger,
 		},
-		states: { months, headingValue, daysOfWeek, segmentContents, open, value },
+		states: { months, headingValue, weekdays, segmentContents, open, value },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createDatePicker({
 		forceVisible: true,
@@ -62,7 +62,7 @@
 						<table use:melt={$grid}>
 							<thead aria-hidden="true">
 								<tr>
-									{#each $daysOfWeek as day}
+									{#each $weekdays as day}
 										<th>
 											<div>
 												{day}

--- a/src/docs/previews/date-range-picker/defaultPh/tailwind/index.svelte
+++ b/src/docs/previews/date-range-picker/defaultPh/tailwind/index.svelte
@@ -19,7 +19,7 @@
 			endSegment,
 			trigger,
 		},
-		states: { months, headingValue, daysOfWeek, segmentContents, open },
+		states: { months, headingValue, weekdays, segmentContents, open },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createDateRangePicker({
 		forceVisible: true,
@@ -68,7 +68,7 @@
 						<table use:melt={$grid}>
 							<thead aria-hidden="true">
 								<tr>
-									{#each $daysOfWeek as day}
+									{#each $weekdays as day}
 										<th>
 											<div>
 												{day}

--- a/src/docs/previews/date-range-picker/defaultValue/tailwind/index.svelte
+++ b/src/docs/previews/date-range-picker/defaultValue/tailwind/index.svelte
@@ -19,7 +19,7 @@
 			endSegment,
 			trigger,
 		},
-		states: { months, headingValue, daysOfWeek, segmentContents, open },
+		states: { months, headingValue, weekdays, segmentContents, open },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createDateRangePicker({
 		forceVisible: true,
@@ -71,7 +71,7 @@
 						<table use:melt={$grid}>
 							<thead aria-hidden="true">
 								<tr>
-									{#each $daysOfWeek as day}
+									{#each $weekdays as day}
 										<th>
 											<div>
 												{day}

--- a/src/docs/previews/date-range-picker/disabled/tailwind/index.svelte
+++ b/src/docs/previews/date-range-picker/disabled/tailwind/index.svelte
@@ -18,7 +18,7 @@
 			endSegment,
 			trigger,
 		},
-		states: { months, headingValue, daysOfWeek, segmentContents, open },
+		states: { months, headingValue, weekdays, segmentContents, open },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createDateRangePicker({
 		forceVisible: true,
@@ -69,7 +69,7 @@
 						<table use:melt={$grid}>
 							<thead aria-hidden="true">
 								<tr>
-									{#each $daysOfWeek as day}
+									{#each $weekdays as day}
 										<th>
 											<div>
 												{day}

--- a/src/docs/previews/date-range-picker/fixedWeeks/tailwind/index.svelte
+++ b/src/docs/previews/date-range-picker/fixedWeeks/tailwind/index.svelte
@@ -18,7 +18,7 @@
 			endSegment,
 			trigger,
 		},
-		states: { months, headingValue, daysOfWeek, segmentContents, open },
+		states: { months, headingValue, weekdays, segmentContents, open },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createDateRangePicker({
 		forceVisible: true,
@@ -67,7 +67,7 @@
 						<table use:melt={$grid}>
 							<thead aria-hidden="true">
 								<tr>
-									{#each $daysOfWeek as day}
+									{#each $weekdays as day}
 										<th>
 											<div>
 												{day}

--- a/src/docs/previews/date-range-picker/locale/tailwind/index.svelte
+++ b/src/docs/previews/date-range-picker/locale/tailwind/index.svelte
@@ -18,7 +18,7 @@
 			endSegment,
 			trigger,
 		},
-		states: { months, headingValue, daysOfWeek, segmentContents, open },
+		states: { months, headingValue, weekdays, segmentContents, open },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createDateRangePicker({
 		forceVisible: true,
@@ -67,7 +67,7 @@
 						<table use:melt={$grid}>
 							<thead aria-hidden="true">
 								<tr>
-									{#each $daysOfWeek as day}
+									{#each $weekdays as day}
 										<th>
 											<div>
 												{day}

--- a/src/docs/previews/date-range-picker/main/tailwind/index.svelte
+++ b/src/docs/previews/date-range-picker/main/tailwind/index.svelte
@@ -20,7 +20,7 @@
 			content,
 			label,
 		},
-		states: { months, headingValue, daysOfWeek, segmentContents, open },
+		states: { months, headingValue, weekdays, segmentContents, open },
 		options: { locale },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createDateRangePicker({
@@ -81,7 +81,7 @@
 						<table use:melt={$grid}>
 							<thead aria-hidden="true">
 								<tr>
-									{#each $daysOfWeek as day}
+									{#each $weekdays as day}
 										<th>
 											<div>
 												{day}

--- a/src/docs/previews/date-range-picker/minMax/tailwind/index.svelte
+++ b/src/docs/previews/date-range-picker/minMax/tailwind/index.svelte
@@ -19,7 +19,7 @@
 			endSegment,
 			trigger,
 		},
-		states: { months, headingValue, daysOfWeek, segmentContents, open },
+		states: { months, headingValue, weekdays, segmentContents, open },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createDateRangePicker({
 		forceVisible: true,
@@ -70,7 +70,7 @@
 						<table use:melt={$grid}>
 							<thead aria-hidden="true">
 								<tr>
-									{#each $daysOfWeek as day}
+									{#each $weekdays as day}
 										<th>
 											<div>
 												{day}

--- a/src/docs/previews/date-range-picker/multipleMonths/tailwind/index.svelte
+++ b/src/docs/previews/date-range-picker/multipleMonths/tailwind/index.svelte
@@ -18,7 +18,7 @@
 			endSegment,
 			trigger,
 		},
-		states: { months, headingValue, daysOfWeek, segmentContents, open },
+		states: { months, headingValue, weekdays, segmentContents, open },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createDateRangePicker({
 		forceVisible: true,
@@ -68,7 +68,7 @@
 						<table use:melt={$grid}>
 							<thead aria-hidden="true">
 								<tr>
-									{#each $daysOfWeek as day}
+									{#each $weekdays as day}
 										<th>
 											<div>
 												{day}

--- a/src/docs/previews/date-range-picker/pagedNav/tailwind/index.svelte
+++ b/src/docs/previews/date-range-picker/pagedNav/tailwind/index.svelte
@@ -18,7 +18,7 @@
 			endSegment,
 			trigger,
 		},
-		states: { months, headingValue, daysOfWeek, segmentContents, open },
+		states: { months, headingValue, weekdays, segmentContents, open },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createDateRangePicker({
 		forceVisible: true,
@@ -69,7 +69,7 @@
 						<table use:melt={$grid}>
 							<thead aria-hidden="true">
 								<tr>
-									{#each $daysOfWeek as day}
+									{#each $weekdays as day}
 										<th>
 											<div>
 												{day}

--- a/src/docs/previews/date-range-picker/unavailable/tailwind/index.svelte
+++ b/src/docs/previews/date-range-picker/unavailable/tailwind/index.svelte
@@ -19,7 +19,7 @@
 			endSegment,
 			trigger,
 		},
-		states: { months, headingValue, daysOfWeek, segmentContents, open },
+		states: { months, headingValue, weekdays, segmentContents, open },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createDateRangePicker({
 		forceVisible: true,
@@ -70,7 +70,7 @@
 						<table use:melt={$grid}>
 							<thead aria-hidden="true">
 								<tr>
-									{#each $daysOfWeek as day}
+									{#each $weekdays as day}
 										<th>
 											<div>
 												{day}

--- a/src/docs/previews/date-range-picker/usingValue/tailwind/index.svelte
+++ b/src/docs/previews/date-range-picker/usingValue/tailwind/index.svelte
@@ -19,7 +19,7 @@
 			endSegment,
 			trigger,
 		},
-		states: { months, headingValue, daysOfWeek, segmentContents, open, value },
+		states: { months, headingValue, weekdays, segmentContents, open, value },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createDateRangePicker({
 		forceVisible: true,
@@ -72,7 +72,7 @@
 						<table use:melt={$grid}>
 							<thead aria-hidden="true">
 								<tr>
-									{#each $daysOfWeek as day}
+									{#each $weekdays as day}
 										<th>
 											<div>
 												{day}

--- a/src/docs/previews/range-calendar/changePh/tailwind/index.svelte
+++ b/src/docs/previews/range-calendar/changePh/tailwind/index.svelte
@@ -5,7 +5,7 @@
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek },
+		states: { months, headingValue, weekdays },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createRangeCalendar({
 		defaultPlaceholder: new CalendarDate(2021, 2, 1),
@@ -29,7 +29,7 @@
 			<table use:melt={$grid}>
 				<thead aria-hidden="true">
 					<tr>
-						{#each $daysOfWeek as day}
+						{#each $weekdays as day}
 							<th>
 								<div>
 									{day}

--- a/src/docs/previews/range-calendar/changeValue/tailwind/index.svelte
+++ b/src/docs/previews/range-calendar/changeValue/tailwind/index.svelte
@@ -5,7 +5,7 @@
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek },
+		states: { months, headingValue, weekdays },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createRangeCalendar({
 		defaultValue: {
@@ -32,7 +32,7 @@
 			<table use:melt={$grid}>
 				<thead aria-hidden="true">
 					<tr>
-						{#each $daysOfWeek as day}
+						{#each $weekdays as day}
 							<th>
 								<div>
 									{day}

--- a/src/docs/previews/range-calendar/disabled/tailwind/index.svelte
+++ b/src/docs/previews/range-calendar/disabled/tailwind/index.svelte
@@ -4,7 +4,7 @@
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek },
+		states: { months, headingValue, weekdays },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createRangeCalendar({
 		fixedWeeks: true,
@@ -31,7 +31,7 @@
 			<table use:melt={$grid}>
 				<thead aria-hidden="true">
 					<tr>
-						{#each $daysOfWeek as day}
+						{#each $weekdays as day}
 							<th>
 								<div>
 									{day}

--- a/src/docs/previews/range-calendar/fixedWeeks/tailwind/index.svelte
+++ b/src/docs/previews/range-calendar/fixedWeeks/tailwind/index.svelte
@@ -4,7 +4,7 @@
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek },
+		states: { months, headingValue, weekdays },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createRangeCalendar({
 		fixedWeeks: true,
@@ -28,7 +28,7 @@
 			<table use:melt={$grid}>
 				<thead aria-hidden="true">
 					<tr>
-						{#each $daysOfWeek as day}
+						{#each $weekdays as day}
 							<th>
 								<div>
 									{day}

--- a/src/docs/previews/range-calendar/locale/tailwind/index.svelte
+++ b/src/docs/previews/range-calendar/locale/tailwind/index.svelte
@@ -4,7 +4,7 @@
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek },
+		states: { months, headingValue, weekdays },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createRangeCalendar({
 		fixedWeeks: true,
@@ -29,7 +29,7 @@
 			<table use:melt={$grid}>
 				<thead aria-hidden="true">
 					<tr>
-						{#each $daysOfWeek as day}
+						{#each $weekdays as day}
 							<th>
 								<div>
 									{day}

--- a/src/docs/previews/range-calendar/main/tailwind/index.svelte
+++ b/src/docs/previews/range-calendar/main/tailwind/index.svelte
@@ -6,7 +6,7 @@
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek },
+		states: { months, headingValue, weekdays },
 		helpers: { isDateDisabled, isDateUnavailable },
 		options: { locale },
 	} = createRangeCalendar();
@@ -38,7 +38,7 @@
 				<table use:melt={$grid}>
 					<thead aria-hidden="true">
 						<tr>
-							{#each $daysOfWeek as day}
+							{#each $weekdays as day}
 								<th>
 									<div>
 										{day}

--- a/src/docs/previews/range-calendar/minMax/tailwind/index.svelte
+++ b/src/docs/previews/range-calendar/minMax/tailwind/index.svelte
@@ -5,7 +5,7 @@
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek },
+		states: { months, headingValue, weekdays },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createRangeCalendar({
 		fixedWeeks: true,
@@ -32,7 +32,7 @@
 			<table use:melt={$grid}>
 				<thead aria-hidden="true">
 					<tr>
-						{#each $daysOfWeek as day}
+						{#each $weekdays as day}
 							<th>
 								<div>
 									{day}

--- a/src/docs/previews/range-calendar/multipleMonths/tailwind/index.svelte
+++ b/src/docs/previews/range-calendar/multipleMonths/tailwind/index.svelte
@@ -4,7 +4,7 @@
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek },
+		states: { months, headingValue, weekdays },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createRangeCalendar({
 		fixedWeeks: true,
@@ -29,7 +29,7 @@
 			<table use:melt={$grid}>
 				<thead aria-hidden="true">
 					<tr>
-						{#each $daysOfWeek as day}
+						{#each $weekdays as day}
 							<th>
 								<div>
 									{day}

--- a/src/docs/previews/range-calendar/pagedNav/tailwind/index.svelte
+++ b/src/docs/previews/range-calendar/pagedNav/tailwind/index.svelte
@@ -4,7 +4,7 @@
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek },
+		states: { months, headingValue, weekdays },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createRangeCalendar({
 		fixedWeeks: true,
@@ -30,7 +30,7 @@
 			<table use:melt={$grid}>
 				<thead aria-hidden="true">
 					<tr>
-						{#each $daysOfWeek as day}
+						{#each $weekdays as day}
 							<th>
 								<div>
 									{day}

--- a/src/docs/previews/range-calendar/unavailable/tailwind/index.svelte
+++ b/src/docs/previews/range-calendar/unavailable/tailwind/index.svelte
@@ -5,7 +5,7 @@
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { months, headingValue, daysOfWeek },
+		states: { months, headingValue, weekdays },
 		helpers: { isDateDisabled, isDateUnavailable },
 	} = createRangeCalendar({
 		fixedWeeks: true,
@@ -32,7 +32,7 @@
 			<table use:melt={$grid}>
 				<thead aria-hidden="true">
 					<tr>
-						{#each $daysOfWeek as day}
+						{#each $weekdays as day}
 							<th>
 								<div>
 									{day}

--- a/src/lib/builders/calendar/create.ts
+++ b/src/lib/builders/calendar/create.ts
@@ -576,7 +576,7 @@ export function createCalendar<
 	 * <table use:melt={$grid} class="w-full">
 	 * 	<thead aria-hidden="true">
 	 * 		<tr>
-	 * 			{#each $daysOfWeek as day}
+	 * 			{#each $weekdays as day}
 	 * 				<th class="text-sm font-semibold text-magnum-800">
 	 * 					<div class="flex h-6 w-6 items-center justify-center p-4">
 	 * 						{day}

--- a/src/lib/builders/calendar/create.ts
+++ b/src/lib/builders/calendar/create.ts
@@ -56,6 +56,7 @@ const defaults = {
 	maxValue: undefined,
 	disabled: false,
 	readonly: false,
+	weekdayFormat: 'narrow',
 } satisfies CreateCalendarProps;
 
 type CalendarParts = 'content' | 'nextButton' | 'prevButton' | 'grid' | 'cell' | 'heading';
@@ -91,6 +92,7 @@ export function createCalendar<
 		isDateUnavailable,
 		disabled,
 		readonly,
+		weekdayFormat,
 	} = options;
 
 	const ids = toWritableStores({ ...generateIds(calendarIdParts), ...withDefaults.ids });
@@ -613,10 +615,10 @@ export function createCalendar<
 	 * ```
 	 *
 	 */
-	const daysOfWeek = derived([months, locale], ([$months, _]) => {
+	const weekdays = derived([months, weekdayFormat, locale], ([$months, $weekdayFormat, _]) => {
 		if (!$months.length) return [];
 		return $months[0].weeks[0].map((date) => {
-			return formatter.dayOfWeek(toDate(date));
+			return formatter.dayOfWeek(toDate(date), $weekdayFormat);
 		});
 	});
 
@@ -1097,7 +1099,7 @@ import { generateIds } from '../../internal/helpers/id'
 			placeholder: placeholder.toWritable(),
 			months,
 			value,
-			daysOfWeek,
+			weekdays,
 			headingValue,
 		},
 		helpers: {

--- a/src/lib/builders/calendar/types.ts
+++ b/src/lib/builders/calendar/types.ts
@@ -139,16 +139,25 @@ export type CreateCalendarProps<
 	 * be a number between 0 and 6, where 0 is Sunday and 6 is
 	 * Saturday.
 	 *
-	 * @default 0 (Sunday)
+	 * @defaultValue 0 (Sunday)
 	 */
 	weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
 	/**
-	 * How to format the days of the week provided via the `daysOfWeek` state store.
+	 * How the string representation of the weekdays provided via the `weekdays` state store
+	 * should be formatted.
+	 *
+	 * ```md
+	 * - "long": "Sunday", "Monday", "Tuesday", etc.
+	 * - "short": "Sun", "Mon", "Tue", etc.
+	 * - "narrow": "S", "M", "T", etc.
+	 *```
+	 *
+	 * @default "narrow"
 	 *
 	 * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#weekday
 	 */
-	dayOfWeekFormat?: Intl.DateTimeFormatOptions['weekday'];
+	weekdayFormat?: Intl.DateTimeFormatOptions['weekday'];
 
 	/**
 	 * A function that receives a date and returns `true` or `false` to indicate whether

--- a/src/lib/builders/calendar/types.ts
+++ b/src/lib/builders/calendar/types.ts
@@ -144,6 +144,13 @@ export type CreateCalendarProps<
 	weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
 	/**
+	 * How to format the days of the week provided via the `daysOfWeek` state store.
+	 *
+	 * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#weekday
+	 */
+	dayOfWeekFormat?: Intl.DateTimeFormatOptions['weekday'];
+
+	/**
 	 * A function that receives a date and returns `true` or `false` to indicate whether
 	 * the date is disabled.
 	 *

--- a/src/lib/builders/range-calendar/create.ts
+++ b/src/lib/builders/range-calendar/create.ts
@@ -64,6 +64,7 @@ const defaults = {
 	maxValue: undefined,
 	disabled: false,
 	readonly: false,
+	weekdayFormat: 'narrow',
 } satisfies CreateRangeCalendarProps;
 
 /**
@@ -97,6 +98,7 @@ export function createRangeCalendar<T extends DateValue = DateValue>(
 		maxValue,
 		disabled,
 		readonly,
+		weekdayFormat,
 	} = options;
 
 	const ids = toWritableStores({ ...generateIds(rangeCalendarIdParts), ...withDefaults.ids });
@@ -588,10 +590,10 @@ export function createRangeCalendar<T extends DateValue = DateValue>(
 	 * you can do so by accessing the first week of the first month,
 	 * and mapping over the dates to get/format each day of the week.
 	 */
-	const daysOfWeek = derived([months, locale], ([$months, _]) => {
+	const weekdays = derived([months, weekdayFormat, locale], ([$months, $weekdayFormat, _]) => {
 		if (!$months.length) return [];
 		return $months[0].weeks[0].map((date) => {
-			return formatter.dayOfWeek(toDate(date));
+			return formatter.dayOfWeek(toDate(date), $weekdayFormat);
 		});
 	});
 
@@ -1031,7 +1033,7 @@ import { generateIds } from '../../internal/helpers/id'
 		states: {
 			placeholder: placeholder.toWritable(),
 			months,
-			daysOfWeek,
+			weekdays,
 			headingValue,
 			value,
 		},

--- a/src/lib/builders/range-calendar/types.ts
+++ b/src/lib/builders/range-calendar/types.ts
@@ -142,6 +142,21 @@ export type RangeCalendarProps = {
 	weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
 	/**
+	 * How the string representation of the weekdays provided via the `weekdays` state
+	 * store should be formatted.
+	 *
+	 * ```md
+	 * - "long": "Sunday", "Monday", "Tuesday", etc.
+	 * - "short": "Sun", "Mon", "Tue", etc.
+	 * - "narrow": "S", "M", "T", etc.
+	 *```
+	 * @default "narrow"
+	 *
+	 * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#weekday
+	 */
+	weekdayFormat?: Intl.DateTimeFormatOptions['weekday'];
+
+	/**
 	 * Any dates that match the provided matchers will
 	 * be marked as disabled, which means they cannot be
 	 * focused or selected. They will also include a data

--- a/src/tests/calendar/Calendar.spec.ts
+++ b/src/tests/calendar/Calendar.spec.ts
@@ -2,7 +2,7 @@ import { testKbd as kbd } from '../utils.js';
 import { render } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
-import { describe } from 'vitest';
+import { describe, it } from 'vitest';
 import CalendarTest from './CalendarTest.svelte';
 import { CalendarDate, CalendarDateTime, toZoned, type DateValue } from '@internationalized/date';
 import { writable } from 'svelte/store';
@@ -44,13 +44,13 @@ function setupMulti(props: CreateCalendarProps<true> = {}) {
 
 describe('Calendar', () => {
 	describe('Accessibility', () => {
-		test('has no accessibility violations', async () => {
+		it('has no accessibility violations', async () => {
 			const { container } = render(CalendarTest);
 
 			expect(await axe(container)).toHaveNoViolations();
 		});
 	});
-	test('populated with defaultValue - CalendarDate', async () => {
+	it('populated with defaultValue - CalendarDate', async () => {
 		const { getByTestId, calendar } = setup({
 			defaultValue: calendarDate,
 		});
@@ -63,7 +63,7 @@ describe('Calendar', () => {
 		const heading = getByTestId('heading');
 		expect(heading).toHaveTextContent('January 1980');
 	});
-	test('populated with defaultValue - CalendarDateTime', async () => {
+	it('populated with defaultValue - CalendarDateTime', async () => {
 		const { getByTestId, calendar } = setup({
 			defaultValue: calendarDateTime,
 		});
@@ -75,7 +75,7 @@ describe('Calendar', () => {
 		expect(heading).toHaveTextContent('January 1980');
 	});
 
-	test('populated with defaultValue - ZonedDateTime', async () => {
+	it('populated with defaultValue - ZonedDateTime', async () => {
 		const { getByTestId, calendar } = setup({
 			defaultValue: zonedDateTime,
 		});
@@ -87,7 +87,7 @@ describe('Calendar', () => {
 		expect(heading).toHaveTextContent('January 1980');
 	});
 
-	test('populated with controlled value - CalendarDate', async () => {
+	it('populated with controlled value - CalendarDate', async () => {
 		const { getByTestId, calendar } = setup({
 			value: controlledCalendarDate,
 		});
@@ -99,7 +99,7 @@ describe('Calendar', () => {
 		expect(heading).toHaveTextContent('January 1980');
 	});
 
-	test('populated with controlled value - CalendarDateTime', async () => {
+	it('populated with controlled value - CalendarDateTime', async () => {
 		const { getByTestId, calendar } = setup({
 			value: controlledCalendarDateTime,
 		});
@@ -111,7 +111,7 @@ describe('Calendar', () => {
 		expect(heading).toHaveTextContent('January 1980');
 	});
 
-	test('populated with controlled value - ZonedDateTime', async () => {
+	it('populated with controlled value - ZonedDateTime', async () => {
 		const { getByTestId, calendar } = setup({
 			value: controlledZonedDateTime,
 		});
@@ -123,7 +123,7 @@ describe('Calendar', () => {
 		expect(heading).toHaveTextContent('January 1980');
 	});
 
-	test('month navigation', async () => {
+	it('month navigation', async () => {
 		const { getByTestId, user } = setup({
 			defaultValue: zonedDateTime,
 		});
@@ -144,7 +144,7 @@ describe('Calendar', () => {
 		expect(heading).toHaveTextContent('December 1979');
 	});
 
-	test('allow deselection', async () => {
+	it('allow deselection', async () => {
 		const { calendar, queryByTestId, user } = setup({
 			defaultValue: zonedDateTime,
 		});
@@ -159,7 +159,7 @@ describe('Calendar', () => {
 		expect(insideValue).toHaveTextContent('undefined');
 	});
 
-	test('selection with mouse', async () => {
+	it('selection with mouse', async () => {
 		const { getByTestId, user } = setup({
 			defaultPlaceholder: zonedDateTime,
 		});
@@ -173,7 +173,7 @@ describe('Calendar', () => {
 		expect(insideValue).toHaveTextContent(newDate.toString());
 	});
 
-	test('selection with keyboard', async () => {
+	it('selection with keyboard', async () => {
 		const { getByTestId, user } = setup({
 			defaultPlaceholder: zonedDateTime,
 		});
@@ -195,7 +195,7 @@ describe('Calendar', () => {
 		expect(insideValue2).toHaveTextContent(newDate2.toString());
 	});
 
-	test('should display multiple months with numberOfMonths prop', async () => {
+	it('should display multiple months with numberOfMonths prop', async () => {
 		const { getByTestId, calendar, user } = setup({
 			defaultValue: calendarDateTime,
 			numberOfMonths: 2,
@@ -233,7 +233,7 @@ describe('Calendar', () => {
 		expect(heading).toHaveTextContent('December 1979 - January 1980');
 	});
 
-	test('multiple months (paged navigation)', async () => {
+	it('multiple months (paged navigation)', async () => {
 		const { getByTestId, calendar, user } = setup({
 			defaultValue: calendarDateTime,
 			numberOfMonths: 2,
@@ -271,7 +271,7 @@ describe('Calendar', () => {
 		expect(heading).toHaveTextContent('November - December 1979');
 	});
 
-	test('fixedWeeks always renders 6 weeks', async () => {
+	it('fixedWeeks always renders 6 weeks', async () => {
 		const valueStore = writable(calendarDate);
 
 		const { getByTestId, queryByTestId, user } = setup({
@@ -294,7 +294,7 @@ describe('Calendar', () => {
 			expect(queryByTestId('week-6')).not.toBeNull();
 		}
 	});
-	test('controlled value should update selected value', async () => {
+	it('controlled value should update selected value', async () => {
 		const valueStore = writable<DateValue | undefined>(undefined);
 
 		const { getByTestId } = setup({
@@ -313,7 +313,7 @@ describe('Calendar', () => {
 		expect(insideValue).toHaveTextContent('2023-10-11');
 	});
 
-	test('controlled placeholder should change view', async () => {
+	it('controlled placeholder should change view', async () => {
 		const placeholderStore = writable<DateValue>(calendarDate);
 		const { getByTestId } = setup({
 			defaultValue: calendarDate,
@@ -333,7 +333,7 @@ describe('Calendar', () => {
 		expect(insideValue).toHaveTextContent('1980-01-20');
 	});
 
-	test('calendar does not navigate before minValue', async () => {
+	it('calendar does not navigate before minValue', async () => {
 		const { getByTestId, user } = setup({
 			defaultValue: calendarDate,
 			minValue: new CalendarDate(1979, 11, 25),
@@ -355,7 +355,7 @@ describe('Calendar', () => {
 		expect(heading).toHaveTextContent('November 1979');
 	});
 
-	test('calendar does not navigate after maxValue', async () => {
+	it('calendar does not navigate after maxValue', async () => {
 		const { getByTestId, user } = setup({
 			defaultValue: calendarDate,
 			maxValue: new CalendarDate(1980, 4, 1),
@@ -381,7 +381,7 @@ describe('Calendar', () => {
 		expect(heading).toHaveTextContent('April 1980');
 	});
 
-	test('multiple select default Value', async () => {
+	it('multiple select default Value', async () => {
 		const day1 = new CalendarDate(1980, 1, 2);
 		const day2 = new CalendarDate(1980, 1, 5);
 
@@ -399,7 +399,7 @@ describe('Calendar', () => {
 		expect(selectedDays[1]).toHaveTextContent(String(day2.day));
 	});
 
-	test('multiple select controlled value', async () => {
+	it('multiple select controlled value', async () => {
 		const day1 = new CalendarDate(1980, 1, 2);
 		const day2 = new CalendarDate(1980, 1, 5);
 		const value = writable([day1, day2]);
@@ -417,7 +417,7 @@ describe('Calendar', () => {
 		expect(selectedDays[1]).toHaveTextContent(String(day2.day));
 	});
 
-	test('multiple select - prevent deselect false (default)', async () => {
+	it('multiple select - prevent deselect false (default)', async () => {
 		const day1 = new CalendarDate(1980, 1, 2);
 		const day2 = new CalendarDate(1980, 1, 5);
 
@@ -437,7 +437,7 @@ describe('Calendar', () => {
 		expect(selectedDaysAfterClick[0]).toHaveTextContent(String(day2.day));
 	});
 
-	test('multiple select -  prevent deselect true', async () => {
+	it('multiple select -  prevent deselect true', async () => {
 		const day1 = new CalendarDate(1980, 1, 2);
 		const day2 = new CalendarDate(1980, 1, 5);
 
@@ -459,7 +459,7 @@ describe('Calendar', () => {
 		expect(selectedDaysAfterClick[1]).toHaveTextContent(String(day2.day));
 	});
 
-	test('multiple select - allow deselect', async () => {
+	it('multiple select - allow deselect', async () => {
 		const day1 = new CalendarDate(1980, 1, 2);
 		const day2 = new CalendarDate(1980, 1, 5);
 
@@ -474,7 +474,7 @@ describe('Calendar', () => {
 		expect(selectedDays).toHaveLength(2);
 	});
 
-	test('overridable with multiple', async () => {
+	it('overridable with multiple', async () => {
 		const day1 = new CalendarDate(1980, 1, 10);
 		const { getByTestId, calendar, user } = setupMulti({
 			defaultValue: [day1],
@@ -505,7 +505,7 @@ describe('Calendar', () => {
 		expect(selectedDaysAfterClick2).toHaveLength(2);
 	});
 
-	test('overridable with single', async () => {
+	it('overridable with single', async () => {
 		const overrideDay = new CalendarDate(1980, 1, 25);
 
 		const { getByTestId, calendar, user } = setup({
@@ -525,7 +525,7 @@ describe('Calendar', () => {
 		expect(selectedDayAfterClick).toHaveTextContent(String(overrideDay.day));
 	});
 
-	test('unavailable dates behavior', async () => {
+	it('unavailable dates behavior', async () => {
 		const { getByTestId, user } = setup({
 			defaultPlaceholder: calendarDate,
 			isDateUnavailable: (date) => {
@@ -540,7 +540,7 @@ describe('Calendar', () => {
 		expect(thirdDayInMonth).not.toHaveAttribute('data-selected');
 	});
 
-	test('disabled prop prevents calendar focus & interaction', async () => {
+	it('disabled prop prevents calendar focus & interaction', async () => {
 		const { getByTestId, user } = setup({
 			defaultPlaceholder: calendarDate,
 			disabled: true,
@@ -558,7 +558,7 @@ describe('Calendar', () => {
 		expect(firstDayOfMonth).not.toHaveFocus();
 	});
 
-	test('readonly prop prevents selecting dates but allows focus', async () => {
+	it('readonly prop prevents selecting dates but allows focus', async () => {
 		const { getByTestId, user } = setup({
 			defaultPlaceholder: calendarDate,
 			readonly: true,
@@ -576,4 +576,6 @@ describe('Calendar', () => {
 		expect(firstDayOfMonth).toHaveFocus();
 		expect(firstDayOfMonth).not.toHaveAttribute('data-selected');
 	});
+
+	it('');
 });

--- a/src/tests/calendar/Calendar.spec.ts
+++ b/src/tests/calendar/Calendar.spec.ts
@@ -18,6 +18,10 @@ const controlledCalendarDate = writable<DateValue | undefined>(calendarDate);
 const controlledCalendarDateTime = writable<DateValue | undefined>(calendarDateTime);
 const controlledZonedDateTime = writable<DateValue | undefined>(zonedDateTime);
 
+const narrowWeekdays = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
+const shortWeekdays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const longWeekdays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
 function setup(props: CreateCalendarProps = {}) {
 	const user = userEvent.setup();
 	const returned = render(CalendarTest, props);
@@ -618,5 +622,60 @@ describe('Calendar', () => {
 		await user.click(firstDayOfMonth);
 		expect(firstDayOfMonth).toHaveFocus();
 		expect(firstDayOfMonth).not.toHaveAttribute('data-selected');
+	});
+
+	test('weekdayFormat prop - `"narrow"` (default)', async () => {
+		const { getByTestId } = setup();
+
+		for (const [i, weekday] of narrowWeekdays.entries()) {
+			const weekdayElement = getByTestId(`weekday-${i}`);
+			expect(weekdayElement).toHaveTextContent(weekday);
+		}
+	});
+
+	test('weekdayFormat prop - `"short"`', async () => {
+		const { getByTestId } = setup({
+			weekdayFormat: 'short',
+		});
+
+		for (const [i, weekday] of shortWeekdays.entries()) {
+			const weekdayElement = getByTestId(`weekday-${i}`);
+			expect(weekdayElement).toHaveTextContent(weekday);
+		}
+	});
+
+	test('weekdayFormat prop - `"long"`', async () => {
+		const { getByTestId } = setup({
+			weekdayFormat: 'long',
+		});
+
+		for (const [i, weekday] of longWeekdays.entries()) {
+			const weekdayElement = getByTestId(`weekday-${i}`);
+			expect(weekdayElement).toHaveTextContent(weekday);
+		}
+	});
+
+	test('dynamically change weekdayFormat option', async () => {
+		const { getByTestId, user } = setup();
+
+		for (const [i, weekday] of narrowWeekdays.entries()) {
+			const weekdayElement = getByTestId(`weekday-${i}`);
+			expect(weekdayElement).toHaveTextContent(weekday);
+		}
+
+		const cycleButton = getByTestId('cycle-weekday-format');
+		await user.click(cycleButton);
+
+		for (const [i, weekday] of shortWeekdays.entries()) {
+			const weekdayElement = getByTestId(`weekday-${i}`);
+			expect(weekdayElement).toHaveTextContent(weekday);
+		}
+
+		await user.click(cycleButton);
+
+		for (const [i, weekday] of longWeekdays.entries()) {
+			const weekdayElement = getByTestId(`weekday-${i}`);
+			expect(weekdayElement).toHaveTextContent(weekday);
+		}
 	});
 });

--- a/src/tests/calendar/CalendarMultiTest.svelte
+++ b/src/tests/calendar/CalendarMultiTest.svelte
@@ -2,6 +2,7 @@
 	import { createCalendar, type CreateCalendarProps } from '$lib/builders';
 	import { ChevronRight, ChevronLeft } from 'lucide-svelte';
 	import { melt } from '$lib';
+	import { removeUndefined } from '../utils';
 
 	type CalendarProps = CreateCalendarProps<true>;
 
@@ -22,30 +23,34 @@
 	export let fixedWeeks: CalendarProps['fixedWeeks'] = undefined;
 	export let minValue: CalendarProps['minValue'] = undefined;
 	export let maxValue: CalendarProps['maxValue'] = undefined;
+	export let weekdayFormat: CalendarProps['weekdayFormat'] = undefined;
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { value: insideValue, months, headingValue, daysOfWeek },
-	} = createCalendar<true>({
-		value,
-		defaultValue,
-		defaultPlaceholder,
-		onValueChange,
-		onPlaceholderChange,
-		isDateUnavailable,
-		isDateDisabled,
-		locale,
-		calendarLabel,
-		preventDeselect,
-		numberOfMonths,
-		pagedNavigation,
-		placeholder,
-		weekStartsOn,
-		fixedWeeks,
-		minValue,
-		maxValue,
-		multiple: true,
-	});
+		states: { value: insideValue, months, headingValue, weekdays },
+	} = createCalendar(
+		removeUndefined({
+			value,
+			defaultValue,
+			defaultPlaceholder,
+			onValueChange,
+			onPlaceholderChange,
+			isDateUnavailable,
+			isDateDisabled,
+			locale,
+			calendarLabel,
+			preventDeselect,
+			numberOfMonths,
+			pagedNavigation,
+			placeholder,
+			weekStartsOn,
+			fixedWeeks,
+			minValue,
+			maxValue,
+			multiple: true,
+			weekdayFormat,
+		})
+	);
 </script>
 
 <main class="flex h-full">
@@ -72,7 +77,7 @@
 					<table use:melt={$grid} class="w-full" data-testid="grid-{i}">
 						<thead aria-hidden="true">
 							<tr>
-								{#each $daysOfWeek as day, idx}
+								{#each $weekdays as day, idx}
 									<th class="text-sm font-semibold text-magnum-800">
 										<div
 											class="flex h-6 w-6 items-center justify-center p-4"

--- a/src/tests/calendar/CalendarTest.svelte
+++ b/src/tests/calendar/CalendarTest.svelte
@@ -24,10 +24,12 @@
 	export let multiple: boolean | undefined = undefined;
 	export let disabled: CreateCalendarProps['disabled'] = undefined;
 	export let readonly: CreateCalendarProps['readonly'] = undefined;
+	export let weekdayFormat: CreateCalendarProps['weekdayFormat'] = undefined;
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { value: insideValue, months, headingValue, daysOfWeek },
+		states: { value: insideValue, months, headingValue, weekdays },
+		options: { weekdayFormat: weekdayFormatOption },
 	} = createCalendar(
 		removeUndefined({
 			value,
@@ -50,8 +52,22 @@
 			multiple,
 			disabled,
 			readonly,
+			weekdayFormat,
 		})
 	);
+
+	function cycleWeekdayFormat() {
+		weekdayFormatOption.update((prev) => {
+			switch (prev) {
+				case 'narrow':
+					return 'short';
+				case 'short':
+					return 'long';
+				case 'long':
+					return 'short';
+			}
+		});
+	}
 </script>
 
 <main class="flex h-full">
@@ -78,11 +94,11 @@
 						<table use:melt={$grid} class="w-full" data-testid="grid-{i}">
 							<thead aria-hidden="true">
 								<tr>
-									{#each $daysOfWeek as day, idx}
+									{#each $weekdays as day, idx}
 										<th class="text-sm font-semibold text-magnum-800">
 											<div
 												class="flex h-6 w-6 items-center justify-center p-4"
-												data-testid="day-of-week-{idx}"
+												data-testid="weekday-{idx}"
 											>
 												{day}
 											</div>
@@ -113,6 +129,9 @@
 			</div>
 		</div>
 	</div>
+	<button on:click={cycleWeekdayFormat} data-testid="cycle-weekday-format">
+		Cycle weekdayFormat
+	</button>
 </main>
 
 <style lang="postcss">

--- a/src/tests/date-picker/DatePicker.spec.ts
+++ b/src/tests/date-picker/DatePicker.spec.ts
@@ -14,6 +14,10 @@ const calendarDate = new CalendarDate(1980, 1, 20);
 const calendarDateTime = new CalendarDateTime(1980, 1, 20, 12, 30, 0, 0);
 const zonedDateTime = toZoned(calendarDateTime, 'America/New_York');
 
+const narrowWeekdays = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
+const shortWeekdays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const longWeekdays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
 function setup(props: CreateDatePickerProps = {}) {
 	const user = userEvent.setup();
 	const returned = render(DatePickerTest, props);
@@ -179,7 +183,7 @@ describe('DatePicker', () => {
 			await user.click(trigger);
 			const calendar = getByTestId('calendar');
 			expect(calendar).toBeVisible();
-			const secondDayInMonth = getByTestId('month-0-date-2');
+			const secondDayInMonth = getByTestId('month-1-date-2');
 			await user.click(secondDayInMonth);
 			expect(secondDayInMonth).toHaveAttribute('data-selected');
 
@@ -197,7 +201,7 @@ describe('DatePicker', () => {
 			const calendar = getByTestId('calendar');
 			expect(calendar).toBeVisible();
 
-			const secondDayInMonth = getByTestId('month-0-date-2');
+			const secondDayInMonth = getByTestId('month-1-date-2');
 			secondDayInMonth.focus();
 			expect(secondDayInMonth).toHaveFocus();
 			await user.keyboard(kbd.SPACE);
@@ -208,7 +212,7 @@ describe('DatePicker', () => {
 			await user.keyboard(kbd.ARROW_RIGHT);
 			await user.keyboard(kbd.ENTER);
 
-			const thirdDayInMonth = getByTestId('month-0-date-3');
+			const thirdDayInMonth = getByTestId('month-1-date-3');
 			expect(thirdDayInMonth).toHaveAttribute('data-selected');
 			const newDate2 = zonedDateTime.set({ day: 3 });
 			const insideValue2 = getByTestId('inside-value');
@@ -373,7 +377,7 @@ describe('DatePicker', () => {
 			const minuteSegment = getByTestId('minute');
 			expect(minuteSegment).not.toHaveTextContent(String(undefined));
 
-			const firstDayInMonth = getByTestId('month-0-date-1');
+			const firstDayInMonth = getByTestId('month-1-date-1');
 			await user.click(firstDayInMonth);
 
 			await tick();
@@ -391,6 +395,61 @@ describe('DatePicker', () => {
 
 			for (const segment of segments) {
 				expect(getByTestId(segment)).not.toBeNull();
+			}
+		});
+
+		test('weekdayFormat prop - `"narrow"` (default)', async () => {
+			const { getByTestId } = setup();
+
+			for (const [i, weekday] of narrowWeekdays.entries()) {
+				const weekdayElement = getByTestId(`weekday-${i}`);
+				expect(weekdayElement).toHaveTextContent(weekday);
+			}
+		});
+
+		test('weekdayFormat prop - `"short"`', async () => {
+			const { getByTestId } = setup({
+				weekdayFormat: 'short',
+			});
+
+			for (const [i, weekday] of shortWeekdays.entries()) {
+				const weekdayElement = getByTestId(`weekday-${i}`);
+				expect(weekdayElement).toHaveTextContent(weekday);
+			}
+		});
+
+		test('weekdayFormat prop - `"long"`', async () => {
+			const { getByTestId } = setup({
+				weekdayFormat: 'long',
+			});
+
+			for (const [i, weekday] of longWeekdays.entries()) {
+				const weekdayElement = getByTestId(`weekday-${i}`);
+				expect(weekdayElement).toHaveTextContent(weekday);
+			}
+		});
+
+		test('dynamically change weekdayFormat option', async () => {
+			const { getByTestId, user } = setup();
+
+			for (const [i, weekday] of narrowWeekdays.entries()) {
+				const weekdayElement = getByTestId(`weekday-${i}`);
+				expect(weekdayElement).toHaveTextContent(weekday);
+			}
+
+			const cycleButton = getByTestId('cycle-weekday-format');
+			await user.click(cycleButton);
+
+			for (const [i, weekday] of shortWeekdays.entries()) {
+				const weekdayElement = getByTestId(`weekday-${i}`);
+				expect(weekdayElement).toHaveTextContent(weekday);
+			}
+
+			await user.click(cycleButton);
+
+			for (const [i, weekday] of longWeekdays.entries()) {
+				const weekdayElement = getByTestId(`weekday-${i}`);
+				expect(weekdayElement).toHaveTextContent(weekday);
 			}
 		});
 	});

--- a/src/tests/date-picker/DatePickerTest.svelte
+++ b/src/tests/date-picker/DatePickerTest.svelte
@@ -3,6 +3,7 @@
 	import { ChevronRight, ChevronLeft, Calendar } from 'lucide-svelte';
 	import { melt } from '$lib';
 	import { fade } from 'svelte/transition';
+	import { removeUndefined } from '../utils';
 
 	export let value: CreateDatePickerProps['value'] = undefined;
 	export let defaultValue: CreateDatePickerProps['defaultValue'] = undefined;
@@ -25,6 +26,7 @@
 	export let pagedNavigation: CreateDatePickerProps['pagedNavigation'] = undefined;
 	export let placeholder: CreateDatePickerProps['placeholder'] = undefined;
 	export let weekStartsOn: CreateDatePickerProps['weekStartsOn'] = undefined;
+	export let weekdayFormat: CreateDatePickerProps['weekdayFormat'] = undefined;
 
 	const {
 		elements: {
@@ -40,31 +42,47 @@
 			content,
 			label,
 		},
-		states: { value: insideValue, months, headingValue, daysOfWeek, segmentContents },
-		options: { locale: insideLocale },
-	} = createDatePicker({
-		value,
-		defaultValue,
-		defaultPlaceholder,
-		onValueChange,
-		onPlaceholderChange,
-		isDateUnavailable,
-		disabled,
-		readonly,
-		hourCycle,
-		locale,
-		hideTimeZone,
-		granularity,
-		dateFieldIds,
-		calendarIds,
-		preventDeselect,
-		calendarLabel,
-		numberOfMonths,
-		pagedNavigation,
-		placeholder,
-		weekStartsOn,
-		isDateDisabled,
-	});
+		states: { value: insideValue, months, headingValue, weekdays, segmentContents },
+		options: { locale: insideLocale, weekdayFormat: weekdayFormatOption },
+	} = createDatePicker(
+		removeUndefined({
+			value,
+			defaultValue,
+			defaultPlaceholder,
+			onValueChange,
+			onPlaceholderChange,
+			isDateUnavailable,
+			disabled,
+			readonly,
+			hourCycle,
+			locale,
+			hideTimeZone,
+			granularity,
+			dateFieldIds,
+			calendarIds,
+			preventDeselect,
+			calendarLabel,
+			numberOfMonths,
+			pagedNavigation,
+			placeholder,
+			weekStartsOn,
+			isDateDisabled,
+			weekdayFormat,
+		})
+	);
+
+	function cycleWeekdayFormat() {
+		weekdayFormatOption.update((prev) => {
+			switch (prev) {
+				case 'narrow':
+					return 'short';
+				case 'short':
+					return 'long';
+				case 'long':
+					return 'short';
+			}
+		});
+	}
 </script>
 
 <main class="flex w-full flex-col items-center gap-3">
@@ -116,11 +134,11 @@
 				<table use:melt={$grid} class="w-full" data-testid="grid-{i}">
 					<thead aria-hidden="true">
 						<tr>
-							{#each $daysOfWeek as day, idx}
+							{#each $weekdays as day, idx}
 								<th class="text-sm font-semibold text-magnum-800">
 									<div
 										class="flex h-6 w-6 items-center justify-center p-4"
-										data-testid="day-of-week-{idx}"
+										data-testid="weekday-{idx}"
 									>
 										{day}
 									</div>
@@ -136,7 +154,7 @@
 										<div
 											use:melt={$cell(date, month.value)}
 											class="cell"
-											data-testid="month-{i}-date-{date.day}"
+											data-testid="month-{date.month}-date-{date.day}"
 										>
 											{date.day}
 										</div>
@@ -148,6 +166,9 @@
 				</table>
 			{/each}
 		</div>
+		<button on:click={cycleWeekdayFormat} data-testid="cycle-weekday-format">
+			Cycle weekdayFormat
+		</button>
 	</div>
 </main>
 

--- a/src/tests/range-calendar/RangeCalendar.spec.ts
+++ b/src/tests/range-calendar/RangeCalendar.spec.ts
@@ -28,6 +28,10 @@ const controlledCalendarDateRange = writable<DateRange>(calendarDateRange);
 const controlledCalendarDateTimeRange = writable<DateRange>(calendarDateTimeRange);
 const controlledZonedDateTimeRange = writable<DateRange>(zonedDateTimeRange);
 
+const narrowWeekdays = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
+const shortWeekdays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const longWeekdays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
 function setup(props: CreateRangeCalendarProps = {}) {
 	const user = userEvent.setup();
 	const returned = render(RangeCalendarTest, props);
@@ -369,7 +373,7 @@ describe('Range Calendar', () => {
 		expect(heading).toHaveTextContent('April 1980');
 	});
 
-	test.todo('overridable store functions as expected', async () => {
+	test('overridable store functions as expected', async () => {
 		const overrideDay = {
 			start: new CalendarDate(1980, 2, 25),
 			end: new CalendarDate(1980, 2, 27),
@@ -392,8 +396,8 @@ describe('Range Calendar', () => {
 		await user.click(fourthDayInMonth);
 		await tick();
 
-		const selectedDaysAfterClick = calendar.querySelectorAll('[data-selected]');
-		expect(selectedDaysAfterClick).toHaveLength(3);
+		const selectedDaysAfterClick = getByTestId('calendar').querySelectorAll('[data-selected]');
+		expect(selectedDaysAfterClick).toHaveLength(2);
 	});
 
 	test('unavailable dates behavior', async () => {
@@ -442,5 +446,60 @@ describe('Range Calendar', () => {
 		await user.dblClick(fifthDayInMonth);
 
 		expect(calendar.querySelectorAll('[data-selected]')).toHaveLength(1);
+	});
+
+	test('weekdayFormat prop - `"narrow"` (default)', async () => {
+		const { getByTestId } = setup();
+
+		for (const [i, weekday] of narrowWeekdays.entries()) {
+			const weekdayElement = getByTestId(`weekday-${i}`);
+			expect(weekdayElement).toHaveTextContent(weekday);
+		}
+	});
+
+	test('weekdayFormat prop - `"short"`', async () => {
+		const { getByTestId } = setup({
+			weekdayFormat: 'short',
+		});
+
+		for (const [i, weekday] of shortWeekdays.entries()) {
+			const weekdayElement = getByTestId(`weekday-${i}`);
+			expect(weekdayElement).toHaveTextContent(weekday);
+		}
+	});
+
+	test('weekdayFormat prop - `"long"`', async () => {
+		const { getByTestId } = setup({
+			weekdayFormat: 'long',
+		});
+
+		for (const [i, weekday] of longWeekdays.entries()) {
+			const weekdayElement = getByTestId(`weekday-${i}`);
+			expect(weekdayElement).toHaveTextContent(weekday);
+		}
+	});
+
+	test('dynamically change weekdayFormat option', async () => {
+		const { getByTestId, user } = setup();
+
+		for (const [i, weekday] of narrowWeekdays.entries()) {
+			const weekdayElement = getByTestId(`weekday-${i}`);
+			expect(weekdayElement).toHaveTextContent(weekday);
+		}
+
+		const cycleButton = getByTestId('cycle-weekday-format');
+		await user.click(cycleButton);
+
+		for (const [i, weekday] of shortWeekdays.entries()) {
+			const weekdayElement = getByTestId(`weekday-${i}`);
+			expect(weekdayElement).toHaveTextContent(weekday);
+		}
+
+		await user.click(cycleButton);
+
+		for (const [i, weekday] of longWeekdays.entries()) {
+			const weekdayElement = getByTestId(`weekday-${i}`);
+			expect(weekdayElement).toHaveTextContent(weekday);
+		}
 	});
 });

--- a/src/tests/range-calendar/RangeCalendarTest.svelte
+++ b/src/tests/range-calendar/RangeCalendarTest.svelte
@@ -2,6 +2,7 @@
 	import { createRangeCalendar, type CreateRangeCalendarProps } from '$lib/builders';
 	import { ChevronRight, ChevronLeft } from 'lucide-svelte';
 	import { melt } from '$lib';
+	import { removeUndefined } from '../utils';
 
 	export let value: CreateRangeCalendarProps['value'] = undefined;
 	export let defaultValue: CreateRangeCalendarProps['defaultValue'] = undefined;
@@ -20,29 +21,47 @@
 	export let fixedWeeks: CreateRangeCalendarProps['fixedWeeks'] = undefined;
 	export let minValue: CreateRangeCalendarProps['minValue'] = undefined;
 	export let maxValue: CreateRangeCalendarProps['maxValue'] = undefined;
+	export let weekdayFormat: CreateRangeCalendarProps['weekdayFormat'] = undefined;
 
 	const {
 		elements: { calendar, heading, grid, cell, prevButton, nextButton },
-		states: { value: insideValue, months, headingValue, daysOfWeek },
-	} = createRangeCalendar({
-		value,
-		defaultValue,
-		defaultPlaceholder,
-		onValueChange,
-		onPlaceholderChange,
-		isDateUnavailable,
-		isDateDisabled,
-		locale,
-		calendarLabel,
-		preventDeselect,
-		numberOfMonths,
-		pagedNavigation,
-		placeholder,
-		weekStartsOn,
-		fixedWeeks,
-		minValue,
-		maxValue,
-	});
+		states: { value: insideValue, months, headingValue, weekdays },
+		options: { weekdayFormat: weekdayFormatOption },
+	} = createRangeCalendar(
+		removeUndefined({
+			value,
+			defaultValue,
+			defaultPlaceholder,
+			onValueChange,
+			onPlaceholderChange,
+			isDateUnavailable,
+			isDateDisabled,
+			locale,
+			calendarLabel,
+			preventDeselect,
+			numberOfMonths,
+			pagedNavigation,
+			placeholder,
+			weekStartsOn,
+			fixedWeeks,
+			minValue,
+			maxValue,
+			weekdayFormat,
+		})
+	);
+
+	function cycleWeekdayFormat() {
+		weekdayFormatOption.update((prev) => {
+			switch (prev) {
+				case 'narrow':
+					return 'short';
+				case 'short':
+					return 'long';
+				case 'long':
+					return 'short';
+			}
+		});
+	}
 </script>
 
 <main class="flex h-full">
@@ -71,11 +90,11 @@
 					<table use:melt={$grid} class="w-full" data-testid="grid-{i}">
 						<thead aria-hidden="true">
 							<tr>
-								{#each $daysOfWeek as day, idx}
+								{#each $weekdays as day, idx}
 									<th class="text-sm font-semibold text-magnum-800">
 										<div
 											class="flex h-6 w-6 items-center justify-center p-4"
-											data-testid="day-of-week-{idx}"
+											data-testid="weekday-{idx}"
 										>
 											{day}
 										</div>
@@ -105,6 +124,9 @@
 			</div>
 		</div>
 	</div>
+	<button on:click={cycleWeekdayFormat} data-testid="cycle-weekday-format">
+		Cycle weekdayFormat
+	</button>
 </main>
 
 <style lang="postcss">


### PR DESCRIPTION
### Breaking Change
**Calendar**, **Range Calendar**, **Date Picker**, and **Date Range Picker**:
- Rename the `daysOfWeek` state store returned from the builders to `weekdays`

### Improvements
**Calendar**, **Range Calendar**, **Date Picker**, and **Date Range Picker**:
- Add a `weekdayFormat` prop to the calendar builders which allows users to specify how the weekdays should be formatted based on the `Int.DateTimeFormat` [options](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#weekday)

Closes: #782