### PR TITLE
fix: aria-modal attr type

### DIFF
--- a/.changeset/silent-doors-impress.md
+++ b/.changeset/silent-doors-impress.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+- Dialog: fix `aria-modal` attribute type

--- a/src/lib/builders/dialog/create.ts
+++ b/src/lib/builders/dialog/create.ts
@@ -189,7 +189,7 @@ export function createDialog(props?: CreateDialogProps) {
 				role: get(role),
 				'aria-describedby': $descriptionId,
 				'aria-labelledby': $titleId,
-				'aria-modal': $isVisible ? 'true' : undefined,
+				'aria-modal': $isVisible ? ('true' as const) : undefined,
 				'data-state': $isVisible ? 'open' : 'closed',
 				tabindex: -1,
 				hidden: $isVisible ? undefined : true,


### PR DESCRIPTION
# Description
fix: `aria-modal` attr TS type matches the type of a Svelte Element

# Context
Fixes #787 
