### PR TITLE
fix: export menu checkbox return type

### DIFF
--- a/src/lib/builders/context-menu/types.ts
+++ b/src/lib/builders/context-menu/types.ts
@@ -28,3 +28,8 @@ export type ContextMenuRadioGroup = BuilderReturn<ContextMenuBuilders['createMen
 export type ContextMenuRadioGroupElements = ContextMenuRadioGroup['elements'];
 export type ContextMenuRadioGroupStates = ContextMenuRadioGroup['states'];
 export type ContextMenuRadioGroupHelpers = ContextMenuRadioGroup['helpers'];
+
+export type ContextMenuCheckboxItem = BuilderReturn<ContextMenuBuilders['createCheckboxItem']>;
+export type ContextMenuCheckboxItemElements = ContextMenuCheckboxItem['elements'];
+export type ContextMenuCheckboxItemStates = ContextMenuCheckboxItem['states'];
+export type ContextMenuCheckboxItemHelpers = ContextMenuCheckboxItem['helpers'];

--- a/src/lib/builders/dropdown-menu/types.ts
+++ b/src/lib/builders/dropdown-menu/types.ts
@@ -2,6 +2,7 @@ import type { BuilderReturn } from '$lib/internal/types.js';
 import type { _Menu } from '../menu/index.js';
 import type { createDropdownMenu } from './create.js';
 export type { DropdownMenuComponentEvents } from './events.js';
+
 // Props
 export type CreateDropdownMenuProps = _Menu['builder'];
 export type CreateDropdownSubmenuProps = _Menu['submenu'];
@@ -27,3 +28,8 @@ export type DropdownMenuRadioGroup = BuilderReturn<DropdownMenuBuilders['createM
 export type DropdownMenuRadioGroupElements = DropdownMenuRadioGroup['elements'];
 export type DropdownMenuRadioGroupStates = DropdownMenuRadioGroup['states'];
 export type DropdownMenuRadioGroupHelpers = DropdownMenuRadioGroup['helpers'];
+
+export type DropdownMenuCheckboxItem = BuilderReturn<DropdownMenuBuilders['createCheckboxItem']>;
+export type DropdownMenuCheckboxItemElements = DropdownMenuCheckboxItem['elements'];
+export type DropdownMenuCheckboxItemStates = DropdownMenuCheckboxItem['states'];
+export type DropdownMenuCheckboxItemHelpers = DropdownMenuCheckboxItem['helpers'];

--- a/src/lib/builders/menu/create.ts
+++ b/src/lib/builders/menu/create.ts
@@ -478,12 +478,19 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 			},
 		});
 
+		const isChecked = derived(checked, ($checked) => $checked === true);
+		const _isIndeterminate = derived(checked, ($checked) => $checked === 'indeterminate');
+
 		return {
 			elements: {
 				checkboxItem,
 			},
 			states: {
 				checked,
+			},
+			helpers: {
+				isChecked,
+				isIndeterminate: _isIndeterminate,
 			},
 			options: {
 				disabled,

--- a/src/lib/builders/menubar/types.ts
+++ b/src/lib/builders/menubar/types.ts
@@ -3,6 +3,7 @@ import type { BuilderReturn } from '$lib/internal/types.js';
 import type { _Menu } from '../menu/index.js';
 import type { MenubarIdParts, createMenubar } from './create.js';
 export type { MenubarComponentEvents } from './events.js';
+
 // Props
 export type CreateMenubarProps = {
 	/**
@@ -23,6 +24,7 @@ export type CreateMenubarProps = {
 	 */
 	ids?: Partial<IdObj<MenubarIdParts>>;
 };
+
 export type CreateMenubarMenuProps = _Menu['builder'];
 export type CreateMenubarSubmenuProps = _Menu['submenu'];
 export type MenubarMenuItemProps = _Menu['item'];
@@ -52,3 +54,8 @@ export type MenubarMenuRadioGroup = BuilderReturn<MenubarMenuBuilders['createMen
 export type MenubarMenuRadioGroupElements = MenubarMenuRadioGroup['elements'];
 export type MenubarMenuRadioGroupStates = MenubarMenuRadioGroup['states'];
 export type MenubarMenuRadioGroupHelpers = MenubarMenuRadioGroup['helpers'];
+
+export type MenubarMenuCheckboxItem = BuilderReturn<MenubarMenuBuilders['createCheckboxItem']>;
+export type MenubarMenuCheckboxItemElements = MenubarMenuCheckboxItem['elements'];
+export type MenubarMenuCheckboxItemStates = MenubarMenuCheckboxItem['states'];
+export type MenubarMenuCheckboxItemHelpers = MenubarMenuCheckboxItem['helpers'];


### PR DESCRIPTION
Exports the type for the `createMenuCheckboxItem` builder which we had previously forgot to export.