### PR TITLE
Checkbox: add `disabled` prop to button that wraps input

### DIFF
--- a/.changeset/tasty-seahorses-listen.md
+++ b/.changeset/tasty-seahorses-listen.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+Checkbox: add `disabled` prop to button that wraps input

--- a/src/lib/builders/checkbox/create.ts
+++ b/src/lib/builders/checkbox/create.ts
@@ -37,6 +37,7 @@ export function createCheckbox(props?: CreateCheckboxProps) {
 		returned: ([$checked, $disabled, $required]) => {
 			return {
 				'data-disabled': disabledAttr($disabled),
+				disabled: disabledAttr($disabled),
 				'data-state':
 					$checked === 'indeterminate' ? 'indeterminate' : $checked ? 'checked' : 'unchecked',
 				type: 'button',


### PR DESCRIPTION
When using [the example code from the melt-ui docs](https://www.melt-ui.com/docs/builders/checkbox), with a disabled checkbox:

```js
const {...} = createCheckbox({ disabled: true });
```

The resulting output is a disabled `<input />` inside of a non-disabled `<button />` (though it's pretty clear that the intent was to disable the button, because it does get `data-disabled="true"`:

```html
<button data-disabled="true" data-state="unchecked" type="button" role="checkbox" aria-checked="false" aria-required="false" data-melt-checkbox="">
    <input type="checkbox" aria-hidden="true" hidden="true" tabindex="-1" name="" value="disabled" disabled="" data-melt-checkbox-input="" style="position: absolute; opacity: 0; pointer-events: none; margin: 0px; transform: translateX(-100%);">
</button>
```

As a result, when using keyboard navigation, the button does receive focus as if the checkbox were enabled, which deviates from expected behavior.

This change adds the `disabled` attribute to the button, returning to expected behavior.