### PR TITLE
fix(slider): remove `aria-disabled` from root

### DIFF
--- a/.changeset/strong-flowers-hunt.md
+++ b/.changeset/strong-flowers-hunt.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+Slider: remove `aria-disabled` from root

--- a/src/lib/builders/slider/create.ts
+++ b/src/lib/builders/slider/create.ts
@@ -137,10 +137,6 @@ export const createSlider = (props?: CreateSliderProps) => {
 			return {
 				dir: $dir,
 				disabled: disabledAttr($disabled),
-				// TODO: Consider removing `aria-disabled` from here.
-				// `aria-disabled` doesn't make sense on the root
-				// because the slider `role` is on the thumb.
-				'aria-disabled': disabledAttr($disabled),
 				'data-disabled': disabledAttr($disabled),
 				'data-orientation': $orientation,
 				style: $disabled


### PR DESCRIPTION
The `aria-disabled` prop should be only be present on the thumb, where the "slider" role exist.