### PR TITLE
docs: Tags Input mentions that addOnPaste is true by default but it doesn't work

### DIFF
--- a/src/docs/data/builders/tags-input.ts
+++ b/src/docs/data/builders/tags-input.ts
@@ -54,7 +54,7 @@ const OPTION_PROPS = [
 		name: 'addOnPaste',
 		type: 'boolean',
 		description: 'Whether or not the input should add tags on paste.',
-		default: 'true',
+		default: 'false',
 	},
 	{
 		name: 'maxTags',


### PR DESCRIPTION
## Changes
- change wrong default of `true` to `false` for `addOnPaste` in `tags-input.ts`

## Motivation

The default value of `addOnPaste` is defined as `false` here: https://github.com/melt-ui/melt-ui/blob/26e41134169528e22451782259be0b2506bdaec0/src/lib/builders/tags-input/create.ts#L34

BUT it was showing as `true` in the documentation on the website.

Closes https://github.com/melt-ui/melt-ui/issues/828