### PR TITLE
fix: failed opening dev container on macos

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -9,6 +9,7 @@ if [ -n "${REMOTE_CONTAINERS}" ] || [ -n "${CODESPACES}" ]; then
 
 	# perform additional one-time setup just after
 	# the devcontainer is created
+	pnpm config set store-dir /home/node/.local/share/pnpm/store
 	pnpm install --dir "${workspace_root}" # install workspace node dependencies
 	npx --yes playwright install           # install playwright browsers
 


### PR DESCRIPTION
## Description
While attempting to open a dev container in VS Code on macOS, I encountered a build failure due to an `ERR_PNPM_LINKING_FAILED` error. This issue was caused by the pnpm store path being set to `/workspaces/melt-ui/.pnpm-store/v3`. To resolve this, I have explicitly set the pnpm store directory in the `post-create.sh` script.

## Purpose
This pull request is a bug fix aimed at preventing the `ERR_PNPM_LINKING_FAILED` error when building the container, ensuring a smoother development setup for macOS users.

## Changes Made
- Modified the `post-create.sh` script to set the pnpm store directory explicitly.

## Additional Notes
Please note that this change has not been tested on Linux or Windows systems. If you are using these operating systems, please test the changes and provide feedback.
