### PR TITLE
Slider: Fix return type of `thumb` builder

### DIFF
--- a/.changeset/swift-dragons-drop.md
+++ b/.changeset/swift-dragons-drop.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+Types: fix wrong builder return type for functions

--- a/src/lib/internal/helpers/builder.ts
+++ b/src/lib/internal/helpers/builder.ts
@@ -51,12 +51,10 @@ type BuilderStore<
 	Name extends string
 > = Readable<
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	ReturnType<R> extends (...args: any) => any
+	ReturnType<R> extends infer F extends (...args: any) => any
 		? ((
-				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-				// @ts-ignore - This is a valid type, but TS doesn't like it for some reason. TODO: Figure out why
-				...args: Parameters<ReturnType<R>>
-		  ) => ReturnType<R> & { [K in `data-melt-${Name}`]: '' } & { action: A }) & { action: A }
+				...args: Parameters<F>
+		  ) => ReturnType<F> & { [K in `data-melt-${Name}`]: '' } & { action: A }) & { action: A }
 		: ReturnType<R> & { [K in `data-melt-${Name}`]: '' } & { action: A }
 >;
 


### PR DESCRIPTION
The return type of `$thumb()` is incorrectly typed as a function, even though it is not.