### PR TITLE
fix(escape-keydown): remove `capture` listener

### DIFF
--- a/.changeset/slow-apples-fry.md
+++ b/.changeset/slow-apples-fry.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+escape-keydown: remove `capture` listener (fixes #842)

--- a/src/lib/internal/actions/escape-keydown/action.ts
+++ b/src/lib/internal/actions/escape-keydown/action.ts
@@ -28,7 +28,6 @@ const documentEscapeKeyStore = readable<KeyboardEvent | undefined>(
 		// Adds a keydown event listener to the document, calling the keydown function when triggered.
 		const unsubscribe = addEventListener(document, 'keydown', keydown, {
 			passive: false,
-			capture: true,
 		});
 
 		// Returns a function to unsubscribe from the event listener and stop tracking keydown events.


### PR DESCRIPTION
> A boolean value indicating that events of this type will be dispatched to the registered listener before being dispatched to any EventTarget beneath it in the DOM tree. If not specified, defaults to false.

This means that the top-level listener was running before any listener(s) that actually should be run. Because of this, it was impossible for a "child" listener to intercept an `ESC` keydown event & have it not affect the rest of the page.

Closes #842