### PR TITLE
Slider: Refactor Thumb and Tick

### DIFF
--- a/.changeset/lazy-zoos-itch.md
+++ b/.changeset/lazy-zoos-itch.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": minor
+---
+
+Slider: Refactor thumb and tick

--- a/src/docs/pp.js
+++ b/src/docs/pp.js
@@ -71,7 +71,7 @@ export function processMeltAttributes(input) {
 	while (meltAttribute !== null && tries < 100000) {
 		tries++;
 		const { builder } = meltAttribute;
-		const store = builder.startsWith("$") ? builder.slice(1) : builder;
+		const store = builder.startsWith('$') ? builder.slice(1) : builder;
 
 		let /** @type {string} */ oldMelt, /** @type {string} */ newMelt;
 		if ('args' in meltAttribute) {
@@ -82,7 +82,7 @@ export function processMeltAttributes(input) {
 			const { index } = meltAttribute;
 			oldMelt = `use:melt={${builder}[${index}]}`;
 			newMelt = `{...${builder}[${index}]} use:${store}`;
-		} else if (builder.startsWith("$")) {
+		} else if (builder.startsWith('$')) {
 			oldMelt = `use:melt={${builder}}`;
 			newMelt = `{...${builder}} use:${store}`;
 		} else {

--- a/src/docs/pp.js
+++ b/src/docs/pp.js
@@ -3,7 +3,7 @@
  * @property {string} builder - The builder of the melt attribute.
  *
  * @typedef {Object} Args
- * @property {string|null} args - The arguments of the melt attribute.
+ * @property {string} args - The arguments of the melt attribute.
  *
  * @typedef {Object} Index
  * @property {string} index - The index of the melt attribute in the string.

--- a/src/docs/pp.js
+++ b/src/docs/pp.js
@@ -1,14 +1,21 @@
 /**
- * @typedef {Object} MeltAttribute
+ * @typedef {Object} Builder
  * @property {string} builder - The builder of the melt attribute.
+ *
+ * @typedef {Object} Args
  * @property {string|null} args - The arguments of the melt attribute.
+ *
+ * @typedef {Object} Index
+ * @property {string} index - The index of the melt attribute in the string.
+ *
+ * @typedef {Builder | Builder & Args | Builder & Index} MeltAttribute
  */
 
 /**
  * Extracts the builder and arguments from a melt attribute in a string.
  *
  * @param {string} input - The string containing the melt attribute.
- * @returns {MeltAttribute|null} - The builder and arguments of the melt attribute, or null if no melt attribute is found.
+ * @returns {MeltAttribute | null} - The builder and arguments of the melt attribute, or null if no melt attribute is found.
  */
 export function extractMeltAttribute(input) {
 	const meltStart = input.indexOf('use:melt={');
@@ -26,20 +33,28 @@ export function extractMeltAttribute(input) {
 
 	if (balance !== 0) return null;
 
-	const meltContent = substring.slice(1, index - 1);
+	const meltContent = substring.slice(0, index - 1);
 	const argStart = meltContent.indexOf('(');
 	const argEnd = meltContent.lastIndexOf(')');
 
-	// If there are no arguments
-	if (argStart === -1 || argEnd === -1) {
-		return { builder: meltContent, args: null };
+	// If there are arguments
+	if (argStart !== -1 && argEnd !== -1) {
+		const builder = meltContent.slice(0, argStart);
+		const args = meltContent.slice(argStart + 1, argEnd);
+		return { builder, args };
 	}
 
-	// If there are arguments
-	const builder = meltContent.slice(0, argStart);
-	const args = meltContent.slice(argStart + 1, argEnd);
+	const indexStart = meltContent.indexOf('[');
+	const indexEnd = meltContent.lastIndexOf(']');
 
-	return { builder, args };
+	// If there is an index
+	if (indexStart !== -1 && indexEnd !== -1) {
+		const builder = meltContent.slice(0, indexStart);
+		const index = meltContent.slice(indexStart + 1, indexEnd);
+		return { builder, index };
+	}
+
+	return { builder: meltContent };
 }
 
 /**
@@ -55,16 +70,25 @@ export function processMeltAttributes(input) {
 	let tries = 0;
 	while (meltAttribute !== null && tries < 100000) {
 		tries++;
-		const oldMelt = `use:melt={$${
-			meltAttribute.args !== null
-				? `${meltAttribute.builder}(${meltAttribute.args})`
-				: meltAttribute.builder
-		}}`;
-		const newMelt = `{...$${
-			meltAttribute.args !== null
-				? `${meltAttribute.builder}(${meltAttribute.args})`
-				: meltAttribute.builder
-		}} use:${meltAttribute.builder}`;
+		const { builder } = meltAttribute;
+		const store = builder.startsWith("$") ? builder.slice(1) : builder;
+
+		let /** @type {string} */ oldMelt, /** @type {string} */ newMelt;
+		if ('args' in meltAttribute) {
+			const { args } = meltAttribute;
+			oldMelt = `use:melt={${builder}(${args})}`;
+			newMelt = `{...${builder}(${args})} use:${store}`;
+		} else if ('index' in meltAttribute) {
+			const { index } = meltAttribute;
+			oldMelt = `use:melt={${builder}[${index}]}`;
+			newMelt = `{...${builder}[${index}]} use:${store}`;
+		} else if (builder.startsWith("$")) {
+			oldMelt = `use:melt={${builder}}`;
+			newMelt = `{...${builder}} use:${store}`;
+		} else {
+			oldMelt = `use:melt={${builder}}`;
+			newMelt = `{...${builder}} use:${builder}.action`;
+		}
 
 		output = output.replace(oldMelt, newMelt);
 		meltAttribute = extractMeltAttribute(output);

--- a/src/docs/pp.spec.ts
+++ b/src/docs/pp.spec.ts
@@ -2,15 +2,29 @@ import { test, expect } from 'vitest';
 import { extractMeltAttribute, processMeltAttributes } from './pp.js';
 
 const extractMeltAttributeCases = [
-	{ input: 'use:melt={$trigger(id)}', expected: { builder: 'trigger', args: 'id' } },
-	{ input: 'use:melt={$trigger}', expected: { builder: 'trigger', args: null } },
+	{
+		input: 'use:melt={$trigger(id)}',
+		expected: { builder: '$trigger', args: 'id' },
+	},
+	{
+		input: 'use:melt={$trigger}',
+		expected: { builder: '$trigger' },
+	},
 	{
 		input: "use:melt={$trigger({helpme: 'god'} )}",
-		expected: { builder: 'trigger', args: "{helpme: 'god'} " },
+		expected: { builder: '$trigger', args: "{helpme: 'god'} " },
 	},
 	{
 		input: "use:melt={$trigger({helpme: 'god'} )} awesome={coolio}",
-		expected: { builder: 'trigger', args: "{helpme: 'god'} " },
+		expected: { builder: '$trigger', args: "{helpme: 'god'} " },
+	},
+	{
+		input: 'use:melt={$thumbs[0]}',
+		expected: { builder: '$thumbs', index: '0' },
+	},
+	{
+		input: 'use:melt={thumb}',
+		expected: { builder: 'thumb' },
 	},
 ];
 
@@ -33,6 +47,14 @@ const processMeltAttributesCases = [
 	{
 		input: "use:melt={$trigger({helpme: 'god'} )} awesome={coolio}",
 		expected: "{...$trigger({helpme: 'god'} )} use:trigger awesome={coolio}",
+	},
+	{
+		input: 'use:melt={$thumbs[0]}',
+		expected: '{...$thumbs[0]} use:thumbs',
+	},
+	{
+		input: 'use:melt={thumb}',
+		expected: '{...thumb} use:thumb.action',
 	},
 ];
 

--- a/src/docs/previews/slider/main/tailwind/index.svelte
+++ b/src/docs/previews/slider/main/tailwind/index.svelte
@@ -2,7 +2,7 @@
 	import { createSlider, melt } from '$lib/index.js';
 
 	const {
-		elements: { root, range, thumb },
+		elements: { root, range, thumbs },
 	} = createSlider({
 		defaultValue: [30],
 		min: 0,
@@ -15,8 +15,9 @@
 	<span class="h-[3px] w-full bg-black/40">
 		<span use:melt={$range} class="h-[3px] bg-white" />
 	</span>
+
 	<span
-		use:melt={$thumb()}
+		use:melt={$thumbs[0]}
 		class="h-5 w-5 rounded-full bg-white focus:ring-4 focus:!ring-black/40"
 	/>
 </span>

--- a/src/docs/previews/slider/range/tailwind/index.svelte
+++ b/src/docs/previews/slider/range/tailwind/index.svelte
@@ -2,8 +2,7 @@
 	import { createSlider, melt } from '$lib/index.js';
 
 	const {
-		elements: { root, range, thumb },
-		states: { value },
+		elements: { root, range, thumbs },
 	} = createSlider({
 		defaultValue: [20, 80],
 		max: 100,
@@ -15,9 +14,11 @@
 		<span use:melt={$range} class="h-[3px] bg-white" />
 	</span>
 
-	{#each $value as _}
+	{#each $thumbs as thumb}
+		<!-- TODO: use pp when it supports builder arrays -->
 		<span
-			use:melt={$thumb()}
+			{...thumb}
+			use:thumb.action
 			class="h-5 w-5 rounded-full bg-white focus:ring-4 focus:!ring-black/40"
 		/>
 	{/each}

--- a/src/docs/previews/slider/range/tailwind/index.svelte
+++ b/src/docs/previews/slider/range/tailwind/index.svelte
@@ -15,10 +15,8 @@
 	</span>
 
 	{#each $thumbs as thumb}
-		<!-- TODO: use pp when it supports builder arrays -->
 		<span
-			{...thumb}
-			use:thumb.action
+			use:melt={thumb}
 			class="h-5 w-5 rounded-full bg-white focus:ring-4 focus:!ring-black/40"
 		/>
 	{/each}

--- a/src/docs/previews/slider/rtl_horizontal/tailwind/index.svelte
+++ b/src/docs/previews/slider/rtl_horizontal/tailwind/index.svelte
@@ -2,8 +2,7 @@
 	import { createSlider, melt } from '$lib/index.js';
 
 	const {
-		elements: { root, range, thumb },
-		states: { value },
+		elements: { root, range, thumbs },
 	} = createSlider({
 		dir: 'rtl',
 		defaultValue: [30],
@@ -16,10 +15,8 @@
 		<span use:melt={$range} class="h-[3px] bg-white" />
 	</span>
 
-	{#each $value as _}
-		<span
-			use:melt={$thumb()}
-			class="h-5 w-5 rounded-full bg-white focus:ring-4 focus:!ring-black/40"
-		/>
-	{/each}
+	<span
+		use:melt={$thumbs[0]}
+		class="h-5 w-5 rounded-full bg-white focus:ring-4 focus:!ring-black/40"
+	/>
 </span>

--- a/src/docs/previews/slider/rtl_vertical/tailwind/index.svelte
+++ b/src/docs/previews/slider/rtl_vertical/tailwind/index.svelte
@@ -2,8 +2,7 @@
 	import { createSlider, melt } from '$lib/index.js';
 
 	const {
-		elements: { root, range, thumb },
-		states: { value },
+		elements: { root, range, thumbs },
 	} = createSlider({
 		dir: 'rtl',
 		orientation: 'vertical',
@@ -20,10 +19,8 @@
 		<span use:melt={$range} class="w-[3px] bg-white" />
 	</span>
 
-	{#each $value as _}
-		<span
-			use:melt={$thumb()}
-			class="h-5 w-5 rounded-full bg-white focus:ring-4 focus:!ring-black/40"
-		/>
-	{/each}
+	<span
+		use:melt={$thumbs[0]}
+		class="h-5 w-5 rounded-full bg-white focus:ring-4 focus:!ring-black/40"
+	/>
 </span>

--- a/src/docs/previews/slider/ticks/tailwind/index.svelte
+++ b/src/docs/previews/slider/ticks/tailwind/index.svelte
@@ -17,10 +17,8 @@
 	</span>
 
 	{#each $ticks as tick}
-		<!-- TODO: use pp when it supports builder arrays -->
 		<span
-			{...tick}
-			use:tick.action
+			use:melt={tick}
 			class="h-[3px] w-[3px] rounded-full bg-white/50 data-[bounded]:bg-magnum-800/75"
 		/>
 	{/each}

--- a/src/docs/previews/slider/ticks/tailwind/index.svelte
+++ b/src/docs/previews/slider/ticks/tailwind/index.svelte
@@ -2,8 +2,7 @@
 	import { createSlider, melt } from '$lib/index.js';
 
 	const {
-		elements: { root, range, thumb, tick },
-		states: { ticks },
+		elements: { root, range, thumbs, ticks },
 	} = createSlider({
 		defaultValue: [5],
 		min: 0,
@@ -17,15 +16,17 @@
 		<span use:melt={$range} class="h-[3px] bg-white" />
 	</span>
 
-	{#each { length: $ticks } as _}
+	{#each $ticks as tick}
+		<!-- TODO: use pp when it supports builder arrays -->
 		<span
-			use:melt={$tick()}
+			{...tick}
+			use:tick.action
 			class="h-[3px] w-[3px] rounded-full bg-white/50 data-[bounded]:bg-magnum-800/75"
 		/>
 	{/each}
 
 	<span
-		use:melt={$thumb()}
+		use:melt={$thumbs[0]}
 		class="h-5 w-5 rounded-full bg-white focus:ring-4 focus:!ring-black/40"
 	/>
 </span>

--- a/src/docs/previews/slider/vertical/tailwind/index.svelte
+++ b/src/docs/previews/slider/vertical/tailwind/index.svelte
@@ -2,7 +2,7 @@
 	import { createSlider, melt } from '$lib/index.js';
 
 	const {
-		elements: { root, range, thumb },
+		elements: { root, range, thumbs },
 	} = createSlider({
 		defaultValue: [30],
 		max: 100,
@@ -17,8 +17,9 @@
 	<span class="h-[200px] w-full bg-black/40">
 		<span use:melt={$range} class="w-full bg-white" />
 	</span>
+
 	<span
-		use:melt={$thumb()}
+		use:melt={$thumbs[0]}
 		class="h-5 w-5 rounded-full bg-white focus:ring-4 focus:!ring-black/40"
 	/>
 </span>

--- a/src/routes/(landing-ui)/slider.svelte
+++ b/src/routes/(landing-ui)/slider.svelte
@@ -3,21 +3,22 @@
 	import { createSlider, melt } from '$lib/index.js';
 
 	const {
-		elements: { root, range, thumb },
+		elements: { root, range, thumbs },
 	} = createSlider({
 		defaultValue: [60],
 		max: 100,
 	});
+
 	let className = '';
 	export { className as class };
 </script>
 
-<span use:melt={$root} class={cn('relative flex  w-[15rem] items-center', className)}>
+<span use:melt={$root} class={cn('relative flex w-[15rem] items-center', className)}>
 	<span class="block h-1.5 w-full rounded-full bg-neutral-400 dark:bg-neutral-700">
 		<span use:melt={$range} class="h-1.5 rounded-full bg-magnum-400" />
 	</span>
 	<span
-		use:melt={$thumb()}
+		use:melt={$thumbs[0]}
 		class="block rounded-full bg-white shadow square-6 focus:ring-4 focus:ring-magnum-600 dark:bg-white dark:shadow-none"
 	/>
 </span>

--- a/src/tests/slider/RangeSlider.svelte
+++ b/src/tests/slider/RangeSlider.svelte
@@ -18,17 +18,14 @@
 		</span>
 
 		{#each $ticks as tick}
-			<!-- TODO: use pp when it supports builder arrays -->
-			<span {...tick} use:tick.action data-testid="tick" />
+			<span use:melt={tick} data-testid="tick" />
 		{/each}
 
 		{#each $thumbs as thumb, i}
-			<!-- TODO: use pp when it supports builder arrays -->
 			<span
 				aria-label="Volume"
 				data-testid="thumb-{i}"
-				{...thumb}
-				use:thumb.action
+				use:melt={thumb}
 				class="block h-5 w-5 rounded-full bg-white focus:ring-4 focus:ring-black/40"
 			/>
 		{/each}

--- a/src/tests/slider/RangeSlider.svelte
+++ b/src/tests/slider/RangeSlider.svelte
@@ -4,8 +4,7 @@
 	export let values = [20, 80];
 
 	const {
-		elements: { root, range, thumb, tick },
-		states: { value, ticks },
+		elements: { root, range, thumbs, ticks },
 	} = createSlider({
 		defaultValue: values,
 		max: 100,
@@ -18,17 +17,20 @@
 			<span data-testid="range" use:melt={$range} class="h-[3px] bg-white" />
 		</span>
 
-		{#each $value as _, i}
+		{#each $ticks as tick}
+			<!-- TODO: use pp when it supports builder arrays -->
+			<span {...tick} use:tick.action data-testid="tick" />
+		{/each}
+
+		{#each $thumbs as thumb, i}
+			<!-- TODO: use pp when it supports builder arrays -->
 			<span
 				aria-label="Volume"
 				data-testid="thumb-{i}"
-				use:melt={$thumb()}
+				{...thumb}
+				use:thumb.action
 				class="block h-5 w-5 rounded-full bg-white focus:ring-4 focus:ring-black/40"
 			/>
-		{/each}
-
-		{#each { length: $ticks } as _}
-			<span use:melt={$tick()} data-testid="tick" />
 		{/each}
 	</span>
 </main>

--- a/src/tests/slider/Slider.svelte
+++ b/src/tests/slider/Slider.svelte
@@ -39,8 +39,7 @@
 		</span>
 
 		{#each $ticks as tick}
-			<!-- TODO: use pp when it supports builder arrays -->
-			<span {...tick} use:tick.action data-testid="tick" />
+			<span use:melt={tick} data-testid="tick" />
 		{/each}
 
 		<span

--- a/src/tests/slider/Slider.svelte
+++ b/src/tests/slider/Slider.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { createSlider, melt, type CreateSliderProps } from '$lib/index.js';
+
 	export let value = [30];
 	export let max = 100;
 	export let min = 0;
@@ -10,8 +11,7 @@
 	export let resetStep: number | undefined = undefined;
 
 	const {
-		elements: { root, range, thumb, tick },
-		states: { ticks },
+		elements: { root, range, thumbs, ticks },
 		options: { min: optionsMin, max: optionsMax, step: optionsStep },
 	} = createSlider({
 		defaultValue: value,
@@ -37,14 +37,17 @@
 		<span class="block h-[3px] w-full bg-black/40">
 			<span data-testid="range" use:melt={$range} class="h-[3px] bg-white" />
 		</span>
+
+		{#each $ticks as tick}
+			<!-- TODO: use pp when it supports builder arrays -->
+			<span {...tick} use:tick.action data-testid="tick" />
+		{/each}
+
 		<span
 			aria-label="Volume"
 			data-testid="thumb"
-			use:melt={$thumb()}
+			use:melt={$thumbs[0]}
 			class="block h-5 w-5 rounded-full bg-white focus:ring-4 focus:ring-black/40"
 		/>
 	</span>
-	{#each { length: $ticks } as _}
-		<span use:melt={$tick()} data-testid="tick" />
-	{/each}
 </main>


### PR DESCRIPTION
This pr changes and `thumb` and `tick` elements from being functions to just arrays of builders.

```html
<!-- the old API -->
{#each { length: $ticks } as _}
  <span use:melt={$tick()} />
{/each}

{#each $value as _}
  <span use:melt={$thumb()} />
{/each}

<!-- the new API -->
{#each $thumbs as thumb}
  <span use:melt={thumb} />
{/each}

{#each $ticks as tick}
  <span use:melt={tick} />
{/each}
```

Limitations:
The melt pp does not seem to work with the new loop syntax. I added TODOs to replace the loops later on when this issue is fixed.

Update:
The pp works fine. The problem is in the docs itself.
