### PR TITLE
Right arrow in tree view focuses next element if not expanding

### DIFF
--- a/.changeset/loud-radios-hug.md
+++ b/.changeset/loud-radios-hug.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+Tree: Right arrow focuses next element if not expanding

--- a/src/lib/builders/tree/create.ts
+++ b/src/lib/builders/tree/create.ts
@@ -171,12 +171,12 @@ export function createTreeView(args?: CreateTreeViewProps) {
 							setFocusedItem(item as HTMLElement);
 						}
 					} else if (key === kbd.ARROW_RIGHT) {
-						if (elementIsExpanded(node)) {
-							// Focus first child
+						if (elementIsExpanded(node) || !elementHasChildren(node)) {
+							// Focus first child or next el
 							const nextItem = items[nodeIdx + 1];
 							if (!nextItem) return;
 							setFocusedItem(nextItem);
-						} else if (elementHasChildren(node)) {
+						} else {
 							// Expand group
 							toggleChildrenElements(node);
 						}


### PR DESCRIPTION
If you have an element without children, pressing right arrow focuses the next item.

This behavior is consistent with IDEs and allows expanding an entire directory tree simply by holding right-arrow.