### PR TITLE
fix(Toast): use as const for `'assertive' | 'polite'` aria-live type

### DIFF
--- a/.changeset/gorgeous-paws-do.md
+++ b/.changeset/gorgeous-paws-do.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+Toast: return `aria-live` type as `'assertive' | 'polite'`

--- a/src/lib/builders/toast/create.ts
+++ b/src/lib/builders/toast/create.ts
@@ -111,7 +111,7 @@ export function createToaster<T = object>(props?: CreateToasterProps) {
 					role: 'alert',
 					'aria-describedby': toast.ids.description,
 					'aria-labelledby': toast.ids.title,
-					'aria-live': toast.type === 'foreground' ? 'assertive' : 'polite',
+					'aria-live': toast.type === 'foreground' ? ('assertive' as const) : ('polite' as const),
 					tabindex: -1,
 				};
 			};

--- a/src/lib/builders/toast/create.ts
+++ b/src/lib/builders/toast/create.ts
@@ -111,7 +111,7 @@ export function createToaster<T = object>(props?: CreateToasterProps) {
 					role: 'alert',
 					'aria-describedby': toast.ids.description,
 					'aria-labelledby': toast.ids.title,
-					'aria-live': toast.type === 'foreground' ? ('assertive' as const) : ('polite' as const),
+					'aria-live': (toast.type === 'foreground' ? 'assertive' : 'polite') as const,
 					tabindex: -1,
 				};
 			};


### PR DESCRIPTION
aria-live property on toast `content` store was returning as `string` where ts expects `"off" | "assertive" | "polite"`. Similar to #839.

fixes ex:
<img width="775" alt="image" src="https://github.com/melt-ui/melt-ui/assets/33409847/65d8722b-254f-4d57-ad47-31e2e01533b1">
