### PR TITLE
feat: expose `onOutsideClick` handler

### DIFF
--- a/.changeset/shy-walls-buy.md
+++ b/.changeset/shy-walls-buy.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": minor
+---
+
+feat: expose `onOutsideClick` handler

--- a/src/lib/builders/context-menu/create.ts
+++ b/src/lib/builders/context-menu/create.ts
@@ -55,6 +55,7 @@ const defaults = {
 	disableFocusFirstItem: true,
 	closeFocus: undefined,
 	closeOnItemClick: true,
+	onOutsideClick: undefined,
 } satisfies CreateContextMenuProps;
 
 const { name, selector } = createElHelpers<_MenuParts>('context-menu');
@@ -110,6 +111,7 @@ export function createContextMenu(props?: CreateContextMenuProps) {
 	const longPressTimer = writable(0);
 
 	function handleClickOutside(e: PointerEvent) {
+		get(rootOptions.onOutsideClick)?.(e);
 		if (e.defaultPrevented) return;
 
 		const target = e.target;

--- a/src/lib/builders/date-picker/create.ts
+++ b/src/lib/builders/date-picker/create.ts
@@ -27,6 +27,7 @@ const defaults = {
 	},
 	closeOnEscape: true,
 	closeOnOutsideClick: true,
+	onOutsideClick: undefined,
 	preventScroll: false,
 	forceVisible: false,
 	locale: 'en',
@@ -72,6 +73,7 @@ export function createDatePicker(props?: CreateDatePickerProps) {
 		forceVisible: withDefaults.forceVisible,
 		openFocus: pickerOpenFocus,
 		ids: withDefaults.popoverIds,
+		onOutsideClick: withDefaults.onOutsideClick,
 	});
 
 	const trigger = builder('popover-trigger', {

--- a/src/lib/builders/date-range-picker/create.ts
+++ b/src/lib/builders/date-range-picker/create.ts
@@ -37,6 +37,7 @@ const defaults = {
 	minValue: undefined,
 	maxValue: undefined,
 	weekdayFormat: 'narrow',
+	onOutsideClick: undefined,
 } satisfies CreateDateRangePickerProps;
 
 export function createDateRangePicker(props?: CreateDateRangePickerProps) {
@@ -68,6 +69,7 @@ export function createDateRangePicker(props?: CreateDateRangePickerProps) {
 		portal: withDefaults.portal,
 		forceVisible: withDefaults.forceVisible,
 		openFocus: pickerOpenFocus,
+		onOutsideClick: withDefaults.onOutsideClick,
 	});
 
 	const options = toWritableStores({
@@ -149,6 +151,10 @@ export function createDateRangePicker(props?: CreateDateRangePickerProps) {
 				placeholder.reset();
 			}
 		}
+	});
+
+	effect([options.onOutsideClick], ([$onOutsideClick]) => {
+		popover.options.onOutsideClick.set($onOutsideClick);
 	});
 
 	const rangeFieldOptions = omit(

--- a/src/lib/builders/dialog/create.ts
+++ b/src/lib/builders/dialog/create.ts
@@ -23,11 +23,11 @@ import {
 	sleep,
 	styleToString,
 	toWritableStores,
+	omit,
 } from '$lib/internal/helpers/index.js';
 import type { Defaults, MeltActionReturn } from '$lib/internal/types.js';
 import { tick } from 'svelte';
 import { derived, get, writable } from 'svelte/store';
-import { omit } from '../../internal/helpers/object';
 import type { DialogEvents } from './events.js';
 import type { CreateDialogProps } from './types.js';
 
@@ -51,6 +51,8 @@ const defaults = {
 	forceVisible: false,
 	openFocus: undefined,
 	closeFocus: undefined,
+	onOutsideClick: undefined,
+	onEscapeKeydown: undefined,
 } satisfies Defaults<CreateDialogProps>;
 
 const openDialogIds = writable<string[]>([]);
@@ -72,6 +74,8 @@ export function createDialog(props?: CreateDialogProps) {
 		forceVisible,
 		openFocus,
 		closeFocus,
+		onOutsideClick,
+		onEscapeKeydown,
 	} = options;
 
 	const activeTrigger = writable<HTMLElement | null>(null);
@@ -164,7 +168,9 @@ export function createDialog(props?: CreateDialogProps) {
 
 			if (get(closeOnEscape)) {
 				const escapeKeydown = useEscapeKeydown(node, {
-					handler: () => {
+					handler: (e) => {
+						get(onEscapeKeydown)?.(e);
+						if (e.defaultPrevented) return;
 						handleClose();
 					},
 				});
@@ -229,6 +235,7 @@ export function createDialog(props?: CreateDialogProps) {
 					return useClickOutside(node, {
 						enabled: $open,
 						handler: (e: PointerEvent) => {
+							get(onOutsideClick)?.(e);
 							if (e.defaultPrevented) return;
 
 							const $openDialogIds = get(openDialogIds);

--- a/src/lib/builders/dialog/create.ts
+++ b/src/lib/builders/dialog/create.ts
@@ -52,7 +52,6 @@ const defaults = {
 	openFocus: undefined,
 	closeFocus: undefined,
 	onOutsideClick: undefined,
-	onEscapeKeydown: undefined,
 } satisfies Defaults<CreateDialogProps>;
 
 const openDialogIds = writable<string[]>([]);
@@ -75,7 +74,6 @@ export function createDialog(props?: CreateDialogProps) {
 		openFocus,
 		closeFocus,
 		onOutsideClick,
-		onEscapeKeydown,
 	} = options;
 
 	const activeTrigger = writable<HTMLElement | null>(null);
@@ -168,9 +166,7 @@ export function createDialog(props?: CreateDialogProps) {
 
 			if (get(closeOnEscape)) {
 				const escapeKeydown = useEscapeKeydown(node, {
-					handler: (e) => {
-						get(onEscapeKeydown)?.(e);
-						if (e.defaultPrevented) return;
+					handler: () => {
 						handleClose();
 					},
 				});

--- a/src/lib/builders/dialog/types.ts
+++ b/src/lib/builders/dialog/types.ts
@@ -4,13 +4,69 @@ import type { Writable } from 'svelte/store';
 import type { DialogIdParts, createDialog } from './create.js';
 export type { DialogComponentEvents } from './events.js';
 export type CreateDialogProps = {
+	/**
+	 * If true, the dialog will prevent scrolling on the body
+	 * when it is open.
+	 *
+	 * @default true
+	 */
 	preventScroll?: boolean;
+
+	/**
+	 * If true, the dialog will close when the user presses the escape key.
+	 *
+	 * @default true
+	 */
 	closeOnEscape?: boolean;
+
+	/**
+	 * If true, the dialog will close when the user clicks outside of it.
+	 *
+	 * @default true
+	 */
 	closeOnOutsideClick?: boolean;
+
+	/**
+	 * A custom event handler for the "outside click" event.
+	 * If `event.preventDefault()` is called within the function,
+	 * the dialog will not close when the user clicks outside of it.
+	 */
+	onOutsideClick?: (event: PointerEvent) => void;
+
+	/**
+	 * A custom event handler for the "escape keydown" event, which
+	 * by default closes the dialog. If `event.preventDefault()` is called
+	 * within the function, the dialog will not close when the user presses
+	 * the escape key.
+	 */
+	onEscapeKeydown?: (event: KeyboardEvent) => void;
+
+	/**
+	 * The `role` attribute to apply to the dialog.
+	 *
+	 * @default 'dialog'
+	 */
 	role?: 'dialog' | 'alertdialog';
+
+	/**
+	 * If true, the dialog will be open by default.
+	 *
+	 * @default false
+	 */
 	defaultOpen?: boolean;
+
+	/**
+	 * A writable store that controls the open state of the dialog.
+	 * @see [Controlled Usage](https://melt-ui.com/docs/controlled#bring-your-own-store)
+	 */
 	open?: Writable<boolean>;
+
+	/**
+	 * A function that will be called when the open state of the dialog changes.
+	 * @see [Controlled Usage](https://melt-ui.com/docs/controlled#change-functions)
+	 */
 	onOpenChange?: ChangeFn<boolean>;
+
 	/**
 	 * If not undefined, the dialog content will be rendered within the provided element or selector.
 	 *
@@ -18,6 +74,13 @@ export type CreateDialogProps = {
 	 */
 	portal?: HTMLElement | string | null;
 
+	/**
+	 * If true, the dialog will be visible regardless of the open state.
+	 * Use this when you want to conditionally render the content of the dialog
+	 * using an `{#if ...}` block.
+	 *
+	 * @default false
+	 */
 	forceVisible?: boolean;
 
 	/**

--- a/src/lib/builders/dialog/types.ts
+++ b/src/lib/builders/dialog/types.ts
@@ -27,19 +27,12 @@ export type CreateDialogProps = {
 	closeOnOutsideClick?: boolean;
 
 	/**
-	 * A custom event handler for the "outside click" event.
+	 * A custom event handler for the "outside click" event, which
+	 * is handled by the `document`.
 	 * If `event.preventDefault()` is called within the function,
 	 * the dialog will not close when the user clicks outside of it.
 	 */
 	onOutsideClick?: (event: PointerEvent) => void;
-
-	/**
-	 * A custom event handler for the "escape keydown" event, which
-	 * by default closes the dialog. If `event.preventDefault()` is called
-	 * within the function, the dialog will not close when the user presses
-	 * the escape key.
-	 */
-	onEscapeKeydown?: (event: KeyboardEvent) => void;
 
 	/**
 	 * The `role` attribute to apply to the dialog.

--- a/src/lib/builders/dropdown-menu/create.ts
+++ b/src/lib/builders/dropdown-menu/create.ts
@@ -21,6 +21,7 @@ const defaults = {
 	closeFocus: undefined,
 	disableFocusFirstItem: false,
 	closeOnItemClick: true,
+	onOutsideClick: undefined,
 } satisfies CreateDropdownMenuProps;
 
 export function createDropdownMenu(props?: CreateDropdownMenuProps) {

--- a/src/lib/builders/link-preview/create.ts
+++ b/src/lib/builders/link-preview/create.ts
@@ -42,6 +42,7 @@ const defaults = {
 	forceVisible: false,
 	portal: 'body',
 	closeOnEscape: true,
+	onOutsideClick: undefined,
 } satisfies CreateLinkPreviewProps;
 
 export const linkPreviewIdParts = ['trigger', 'content'] as const;
@@ -71,6 +72,7 @@ export function createLinkPreview(props: CreateLinkPreviewProps = {}) {
 		forceVisible,
 		portal,
 		closeOnEscape,
+		onOutsideClick,
 	} = options;
 
 	const ids = toWritableStores({ ...generateIds(linkPreviewIdParts), ...withDefaults.ids });
@@ -190,7 +192,22 @@ export function createLinkPreview(props: CreateLinkPreviewProps = {}) {
 						open: open,
 						options: {
 							floating: $positioning,
-							clickOutside: $closeOnOutsideClick ? undefined : null,
+							clickOutside: $closeOnOutsideClick
+								? {
+										handler: (e) => {
+											get(onOutsideClick)?.(e);
+											if (e.defaultPrevented) return;
+
+											if (
+												isHTMLElement($activeTrigger) &&
+												!$activeTrigger.contains(e.target as Element)
+											) {
+												open.set(false);
+												$activeTrigger.focus();
+											}
+										},
+								  }
+								: null,
 							portal: getPortalDestination(node, $portal),
 							focusTrap: null,
 							escapeKeydown: $closeOnEscape ? undefined : null,

--- a/src/lib/builders/link-preview/types.ts
+++ b/src/lib/builders/link-preview/types.ts
@@ -58,6 +58,14 @@ export type CreateLinkPreviewProps = {
 	closeOnOutsideClick?: boolean;
 
 	/**
+	 * A custom event handler for the "outside click" event, which
+	 * is handled by the `document`.
+	 * If `event.preventDefault()` is called within the function,
+	 * the dialog will not close when the user clicks outside of it.
+	 */
+	onOutsideClick?: (event: PointerEvent) => void;
+
+	/**
 	 * Whether or not to close the linkpreview when the escape key is pressed
 	 * while it is open.
 	 *

--- a/src/lib/builders/listbox/create.ts
+++ b/src/lib/builders/listbox/create.ts
@@ -75,6 +75,7 @@ const defaults = {
 	name: undefined,
 	typeahead: true,
 	highlightOnHover: true,
+	onOutsideClick: undefined,
 } satisfies Defaults<CreateListboxProps<unknown>>;
 
 export const listboxIdParts = ['trigger', 'menu', 'label'] as const;
@@ -133,6 +134,7 @@ export function createListbox<
 		typeahead,
 		name: nameProp,
 		highlightOnHover,
+		onOutsideClick,
 	} = options;
 	const { name, selector } = createElHelpers(withDefaults.builder);
 
@@ -475,6 +477,9 @@ export function createListbox<
 								clickOutside: $closeOnOutsideClick
 									? {
 											handler: (e) => {
+												get(onOutsideClick)?.(e);
+												if (e.defaultPrevented) return;
+
 												const target = e.target;
 												if (!isElement(target)) return;
 												if (target === $activeTrigger || $activeTrigger.contains(target)) {

--- a/src/lib/builders/listbox/create.ts
+++ b/src/lib/builders/listbox/create.ts
@@ -458,15 +458,8 @@ export function createListbox<
 			const unsubscribe = executeCallbacks(
 				// Bind the popper portal to the input element.
 				effect(
-					[isVisible, closeOnEscape, portal, closeOnOutsideClick, positioning, activeTrigger],
-					([
-						$isVisible,
-						$closeOnEscape,
-						$portal,
-						$closeOnOutsideClick,
-						$positioning,
-						$activeTrigger,
-					]) => {
+					[isVisible, portal, closeOnOutsideClick, positioning, activeTrigger],
+					([$isVisible, $portal, $closeOnOutsideClick, $positioning, $activeTrigger]) => {
 						unsubPopper();
 
 						if (!$isVisible || !$activeTrigger) return;
@@ -492,13 +485,7 @@ export function createListbox<
 											ignore: ignoreHandler,
 									  }
 									: null,
-								escapeKeydown: $closeOnEscape
-									? {
-											handler: () => {
-												closeMenu();
-											},
-									  }
-									: null,
+								escapeKeydown: null,
 								portal: getPortalDestination(node, $portal),
 							},
 						});

--- a/src/lib/builders/listbox/types.ts
+++ b/src/lib/builders/listbox/types.ts
@@ -112,6 +112,14 @@ export type CreateListboxProps<
 	closeOnEscape?: boolean;
 
 	/**
+	 * A custom event handler for the "outside click" event, which
+	 * is handled by the `document`.
+	 * If `event.preventDefault()` is called within the function,
+	 * the dialog will not close when the user clicks outside of it.
+	 */
+	onOutsideClick?: (event: PointerEvent) => void;
+
+	/**
 	 * Whether or not to prevent scrolling the page when the
 	 * listbox menu is open.
 	 *

--- a/src/lib/builders/menu/create.ts
+++ b/src/lib/builders/menu/create.ts
@@ -76,6 +76,7 @@ const defaults = {
 	defaultOpen: false,
 	typeahead: true,
 	closeOnItemClick: true,
+	onOutsideClick: undefined,
 } satisfies Defaults<_CreateMenuProps>;
 
 export function createMenuBuilder(opts: _MenuBuilderOptions) {
@@ -94,6 +95,7 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 		closeFocus,
 		disableFocusFirstItem,
 		closeOnItemClick,
+		onOutsideClick,
 	} = opts.rootOptions;
 
 	const rootOpen = opts.rootOpen;
@@ -189,7 +191,22 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 							open: rootOpen,
 							options: {
 								floating: $positioning,
-								clickOutside: $closeOnOutsideClick ? undefined : null,
+								clickOutside: $closeOnOutsideClick
+									? {
+											handler: (e) => {
+												get(onOutsideClick)?.(e);
+												if (e.defaultPrevented) return;
+
+												if (
+													isHTMLElement($rootActiveTrigger) &&
+													!$rootActiveTrigger.contains(e.target as Element)
+												) {
+													rootOpen.set(false);
+													$rootActiveTrigger.focus();
+												}
+											},
+									  }
+									: null,
 								portal: getPortalDestination(node, $portal),
 								escapeKeydown: $closeOnEscape ? undefined : null,
 							},

--- a/src/lib/builders/menu/types.ts
+++ b/src/lib/builders/menu/types.ts
@@ -61,6 +61,14 @@ export type _CreateMenuProps = {
 	closeOnOutsideClick?: boolean;
 
 	/**
+	 * A custom event handler for the "outside click" event, which
+	 * is handled by the `document`.
+	 * If `event.preventDefault()` is called within the function,
+	 * the dialog will not close when the user clicks outside of it.
+	 */
+	onOutsideClick?: (event: PointerEvent) => void;
+
+	/**
 	 * Whether or not to loop the menu navigation.
 	 *
 	 * @default false
@@ -181,6 +189,7 @@ export type _MenuBuilderOptions = {
 		closeFocus: Writable<FocusProp | undefined>;
 		disableFocusFirstItem: Writable<boolean>;
 		closeOnItemClick: Writable<boolean>;
+		onOutsideClick: Writable<((event: PointerEvent) => void) | undefined>;
 	};
 
 	nextFocusable: Writable<HTMLElement | null>;

--- a/src/lib/builders/popover/create.ts
+++ b/src/lib/builders/popover/create.ts
@@ -43,6 +43,7 @@ const defaults = {
 	forceVisible: false,
 	openFocus: undefined,
 	closeFocus: undefined,
+	onOutsideClick: undefined,
 } satisfies Defaults<CreatePopoverProps>;
 
 type PopoverParts = 'trigger' | 'content' | 'arrow' | 'close';
@@ -66,6 +67,7 @@ export function createPopover(args?: CreatePopoverProps) {
 		forceVisible,
 		openFocus,
 		closeFocus,
+		onOutsideClick,
 	} = options;
 
 	const openWritable = withDefaults.open ?? writable(withDefaults.defaultOpen);
@@ -179,6 +181,8 @@ export function createPopover(args?: CreatePopoverProps) {
 	}
 
 	function handleClickOutside(e: PointerEvent) {
+		get(onOutsideClick)?.(e);
+		if (e.defaultPrevented) return;
 		const target = e.target;
 		const triggerEl = document.getElementById(get(ids.trigger));
 

--- a/src/lib/builders/popover/types.ts
+++ b/src/lib/builders/popover/types.ts
@@ -61,6 +61,14 @@ export type CreatePopoverProps = {
 	closeOnOutsideClick?: boolean;
 
 	/**
+	 * A custom event handler for the "outside click" event, which
+	 * is handled by the `document`.
+	 * If `event.preventDefault()` is called within the function,
+	 * the dialog will not close when the user clicks outside of it.
+	 */
+	onOutsideClick?: (event: PointerEvent) => void;
+
+	/**
 	 * Whether or not to prevent scrolling when the popover is open.
 	 *
 	 * @default false

--- a/src/tests/combobox/Combobox.spec.ts
+++ b/src/tests/combobox/Combobox.spec.ts
@@ -140,6 +140,47 @@ describe('Combobox', () => {
 		expect(label.id).toBe(ids.label);
 	});
 
+	test("Doesn't close on outside click if defaultPrevented on `onOutsideClick` handler", async () => {
+		const user = userEvent.setup();
+		const { getByTestId } = render(ComboboxTest, { onOutsideClick: (e) => e.preventDefault() });
+		const input = getByTestId('input');
+
+		await user.click(input);
+		expect(getByTestId('menu')).toBeVisible();
+
+		const outsideClick = getByTestId('outside-click');
+		await user.click(outsideClick);
+		expect(getByTestId('menu')).toBeVisible();
+	});
+
+	test('Closes on escape by default', async () => {
+		const user = userEvent.setup();
+		const { getByTestId } = render(ComboboxTest);
+
+		const input = getByTestId('input');
+		const menu = getByTestId('menu');
+
+		await user.click(input);
+		expect(menu).toBeVisible();
+
+		await user.keyboard(kbd.ESCAPE);
+		expect(menu).not.toBeVisible();
+	});
+
+	test('Respects the `closeOnEscape` prop', async () => {
+		const user = userEvent.setup();
+		const { getByTestId } = render(ComboboxTest, { closeOnEscape: false });
+
+		const input = getByTestId('input');
+		const menu = getByTestId('menu');
+
+		await user.click(input);
+		expect(menu).toBeVisible();
+
+		await user.keyboard(kbd.ESCAPE);
+		expect(menu).toBeVisible();
+	});
+
 	test.todo('Selects multiple items when `multiple` is true');
 	test.todo('Manually setting the value updates the label');
 	test.todo('Updating options and setting the value updates the label');

--- a/src/tests/combobox/ComboboxTest.svelte
+++ b/src/tests/combobox/ComboboxTest.svelte
@@ -17,6 +17,8 @@
 	export let multiple = false;
 	export let defaultValue: string | undefined = undefined;
 	export let ids: CreateComboboxProps<unknown>['ids'] = undefined;
+	export let onOutsideClick: CreateComboboxProps<unknown>['onOutsideClick'] = undefined;
+	export let closeOnEscape: CreateComboboxProps<unknown>['closeOnEscape'] = undefined;
 
 	const {
 		elements: { menu, input, option, label },
@@ -31,6 +33,8 @@
 				  }
 				: undefined,
 			ids,
+			onOutsideClick,
+			closeOnEscape,
 		})
 	);
 
@@ -60,4 +64,5 @@
 			{/each}
 		</div>
 	</ul>
+	<div data-testid="outside-click" />
 </main>

--- a/src/tests/context-menu/ContextMenu.spec.ts
+++ b/src/tests/context-menu/ContextMenu.spec.ts
@@ -205,4 +205,16 @@ describe('Context Menu', () => {
 		const submenu = getByTestId('submenu');
 		expect(submenu.id).toBe(subIds.menu);
 	});
+
+	test("Doesn't close on outsideClick if defaultPrevented in onOutsideClick", async () => {
+		const { user, menu, getByTestId } = await open({
+			onOutsideClick: (e) => {
+				e.preventDefault();
+			},
+		});
+		expect(menu).toBeVisible();
+		const outsideClick = getByTestId('outside-click');
+		await user.click(outsideClick);
+		expect(menu).toBeVisible();
+	});
 });

--- a/src/tests/date-picker/DatePicker.spec.ts
+++ b/src/tests/date-picker/DatePicker.spec.ts
@@ -545,4 +545,22 @@ describe('DatePicker', () => {
 		await user.click(label);
 		expect(monthSegment).toHaveFocus();
 	});
+
+	test("doesn't close on outside click if preventDefault called in `onOutsideClick`", async () => {
+		const { getByTestId, trigger, user } = setup({
+			onOutsideClick: (e) => {
+				e.preventDefault();
+			},
+		});
+		const content = getByTestId('content');
+
+		expect(content).not.toBeVisible();
+		await user.click(trigger);
+		await waitFor(() => expect(content).toBeVisible());
+		await user.click(content);
+		await waitFor(() => expect(content).toBeVisible());
+		const outside = getByTestId('inside-value');
+		await user.click(outside);
+		await waitFor(() => expect(content).toBeVisible());
+	});
 });

--- a/src/tests/date-picker/DatePickerTest.svelte
+++ b/src/tests/date-picker/DatePickerTest.svelte
@@ -2,7 +2,6 @@
 	import { createDatePicker, type CreateDatePickerProps } from '$lib/builders';
 	import { ChevronRight, ChevronLeft, Calendar } from 'lucide-svelte';
 	import { melt } from '$lib';
-	import { fade } from 'svelte/transition';
 	import { removeUndefined } from '../utils';
 
 	export let value: CreateDatePickerProps['value'] = undefined;
@@ -28,6 +27,7 @@
 	export let placeholder: CreateDatePickerProps['placeholder'] = undefined;
 	export let weekStartsOn: CreateDatePickerProps['weekStartsOn'] = undefined;
 	export let weekdayFormat: CreateDatePickerProps['weekdayFormat'] = undefined;
+	export let onOutsideClick: CreateDatePickerProps['onOutsideClick'] = undefined;
 
 	const {
 		elements: {
@@ -71,6 +71,7 @@
 			isDateDisabled,
 			weekdayFormat,
 			popoverIds,
+			onOutsideClick,
 		})
 	);
 
@@ -118,7 +119,6 @@
 	</div>
 	<div
 		class="z-10 w-80 rounded-[4px] bg-white p-3 shadow-sm"
-		transition:fade={{ duration: 100 }}
 		use:melt={$content}
 		data-testid="content"
 	>

--- a/src/tests/dialog/Dialog.spec.ts
+++ b/src/tests/dialog/Dialog.spec.ts
@@ -77,6 +77,25 @@ describe('Dialog', () => {
 		expect(content).not.toBeVisible();
 	});
 
+	it('Prevents closing on outside click if `defaultPrevented` in `onOutsideClick` callback', async () => {
+		const { getByTestId, user, trigger } = setup({
+			onOutsideClick: (e) => {
+				e.preventDefault();
+			},
+		});
+		const overlay = getByTestId('overlay');
+		const content = getByTestId('content');
+
+		expect(trigger).toBeVisible();
+		expect(content).not.toBeVisible();
+		await user.click(trigger);
+		expect(content).toBeVisible();
+		await sleep(100);
+		expect(overlay).toBeVisible();
+		await user.click(overlay);
+		expect(content).toBeVisible();
+	});
+
 	it('Portalled el attaches dialog to body', async () => {
 		const { getByTestId, user, trigger } = setup();
 		await user.click(trigger);

--- a/src/tests/dropdown-menu/DropdownMenu.spec.ts
+++ b/src/tests/dropdown-menu/DropdownMenu.spec.ts
@@ -244,6 +244,20 @@ describe('Dropdown Menu (Default)', () => {
 		expect(submenu.id).toBe(subIds.menu);
 	});
 
+	test("Doesn't close on outsideClick if defaultPrevented in onOutsideClick", async () => {
+		const { user, trigger, getByTestId } = setup({
+			onOutsideClick: (e) => {
+				e.preventDefault();
+			},
+		});
+		const menu = getByTestId('menu');
+		await user.click(trigger);
+		expect(menu).toBeVisible();
+		const outsideClick = getByTestId('outside-click');
+		await user.click(outsideClick);
+		expect(menu).toBeVisible();
+	});
+
 	test.todo('Radio items');
 });
 

--- a/src/tests/dropdown-menu/DropdownMenuTest.svelte
+++ b/src/tests/dropdown-menu/DropdownMenuTest.svelte
@@ -18,13 +18,15 @@
 	const {
 		elements: { trigger, menu, item, separator, arrow },
 		builders: { createSubmenu, createMenuRadioGroup, createCheckboxItem },
-	} = createDropdownMenu({
-		loop,
-		closeFocus,
-		closeOnEscape,
-		closeOnOutsideClick,
-		...$$restProps,
-	});
+	} = createDropdownMenu(
+		removeUndefined({
+			loop,
+			closeFocus,
+			closeOnEscape,
+			closeOnOutsideClick,
+			...$$restProps,
+		})
+	);
 
 	const {
 		elements: { checkboxItem: settingsSyncCheckbox },

--- a/src/tests/link-preview/LinkPreview.spec.ts
+++ b/src/tests/link-preview/LinkPreview.spec.ts
@@ -74,6 +74,20 @@ describe('LinkPreview (Default)', () => {
 		await waitFor(() => expect(content).not.toBeVisible());
 	});
 
+	test.skip('Closes on outside click by default', async () => {
+		const { getByTestId, trigger, user } = setup();
+		const content = getByTestId('content');
+
+		expect(content).not.toBeVisible();
+		await user.hover(trigger);
+		await waitFor(() => expect(content).toBeVisible());
+		await user.click(content);
+		await waitFor(() => expect(content).toBeVisible());
+		const start = getByTestId('start');
+		await user.click(start);
+		await waitFor(() => expect(content).not.toBeVisible());
+	});
+
 	test('Custom ids are applied when provided', async () => {
 		const ids = {
 			content: 'id-content',

--- a/src/tests/popover/Popover.spec.ts
+++ b/src/tests/popover/Popover.spec.ts
@@ -57,6 +57,23 @@ describe('Popover (Default)', () => {
 		await waitFor(() => expect(content).not.toBeVisible());
 	});
 
+	test('doesnt close when preventDefault called in `onOutsideClick`', async () => {
+		const { content, trigger, user, getByTestId } = setup({
+			onOutsideClick: (e) => {
+				e.preventDefault();
+			},
+		});
+
+		expect(content).not.toBeVisible();
+		await user.click(trigger);
+		await waitFor(() => expect(content).toBeVisible());
+		await user.click(content);
+		await waitFor(() => expect(content).toBeVisible());
+		const outside = getByTestId('outside');
+		await user.click(outside);
+		await waitFor(() => expect(content).toBeVisible());
+	});
+
 	test('Toggles open state on trigger click', async () => {
 		const { content, trigger, user } = setup();
 

--- a/src/tests/select/Select.spec.ts
+++ b/src/tests/select/Select.spec.ts
@@ -199,6 +199,25 @@ describe('Select', () => {
 		expect(menu).toBeVisible();
 	});
 
+	test("doesn't close when preventDefault called in `onOutsideClick`", async () => {
+		const user = userEvent.setup();
+		const { getByTestId } = render(SelectTest, {
+			onOutsideClick: (e) => {
+				e.preventDefault();
+			},
+		});
+		const trigger = getByTestId('trigger');
+		const menu = getByTestId('menu');
+
+		expect(menu).not.toBeVisible();
+		await user.click(trigger);
+		expect(menu).toBeVisible();
+
+		const outside = getByTestId('outside');
+		await user.click(outside);
+		expect(menu).toBeVisible();
+	});
+
 	test('Applies custom ids when provided', async () => {
 		const ids = {
 			label: 'id-label',

--- a/src/tests/select/Select.spec.ts
+++ b/src/tests/select/Select.spec.ts
@@ -14,10 +14,10 @@ describe('Select', () => {
 	});
 
 	test('Opens/Closes when trigger is clicked', async () => {
+		const user = userEvent.setup();
 		const { getByTestId } = render(SelectTest);
 		const trigger = getByTestId('trigger');
 		const menu = getByTestId('menu');
-		const user = userEvent.setup();
 
 		expect(menu).not.toBeVisible();
 		await user.click(trigger);
@@ -27,11 +27,26 @@ describe('Select', () => {
 		expect(menu).not.toBeVisible();
 	});
 
-	test.each(OPEN_KEYS)('Opens when %s is pressed', async (key) => {
+	test('Closes on escape keydown', async () => {
+		const user = userEvent.setup();
 		const { getByTestId } = render(SelectTest);
 		const trigger = getByTestId('trigger');
 		const menu = getByTestId('menu');
+
+		expect(menu).not.toBeVisible();
+		await user.click(trigger);
+		expect(menu).toBeVisible();
+		expect(trigger).toHaveFocus();
+
+		await user.keyboard(kbd.ESCAPE);
+		expect(menu).not.toBeVisible();
+	});
+
+	test.each(OPEN_KEYS)('Opens when %s is pressed', async (key) => {
 		const user = userEvent.setup();
+		const { getByTestId } = render(SelectTest);
+		const trigger = getByTestId('trigger');
+		const menu = getByTestId('menu');
 
 		expect(menu).not.toBeVisible();
 		await act(() => trigger.focus());
@@ -40,10 +55,10 @@ describe('Select', () => {
 	});
 
 	test('Toggles when trigger is clicked', async () => {
+		const user = userEvent.setup();
 		const { getByTestId } = render(SelectTest);
 		const trigger = getByTestId('trigger');
 		const menu = getByTestId('menu');
-		const user = userEvent.setup();
 
 		expect(menu).not.toBeVisible();
 		await user.click(trigger);
@@ -54,10 +69,10 @@ describe('Select', () => {
 	});
 
 	test('Toggles when icon within trigger is clicked', async () => {
+		const user = userEvent.setup();
 		const { getByTestId } = render(SelectTest);
 		const icon = getByTestId('icon');
 		const menu = getByTestId('menu');
-		const user = userEvent.setup();
 
 		expect(menu).not.toBeVisible();
 		await user.click(icon);
@@ -68,10 +83,10 @@ describe('Select', () => {
 	});
 
 	test('Selects item when clicked', async () => {
+		const user = userEvent.setup();
 		const { getByTestId } = render(SelectTest);
 		const trigger = getByTestId('trigger');
 		const menu = getByTestId('menu');
-		const user = userEvent.setup();
 
 		expect(trigger).not.toHaveTextContent('Caramel');
 
@@ -98,10 +113,10 @@ describe('Select', () => {
 	});
 
 	test('Selects multiple items when `multiple` is true', async () => {
+		const user = userEvent.setup();
 		const { getByTestId } = render(SelectTest, { multiple: true });
 		const trigger = getByTestId('trigger');
 		const menu = getByTestId('menu');
-		const user = userEvent.setup();
 
 		expect(trigger).not.toHaveTextContent('Caramel');
 
@@ -156,10 +171,10 @@ describe('Select', () => {
 	});
 
 	test('Respects the `closeOnEscape` prop', async () => {
+		const user = userEvent.setup();
 		const { getByTestId } = render(SelectTest, { closeOnEscape: false });
 		const trigger = getByTestId('trigger');
 		const menu = getByTestId('menu');
-		const user = userEvent.setup();
 
 		expect(menu).not.toBeVisible();
 		await user.click(trigger);
@@ -170,10 +185,10 @@ describe('Select', () => {
 	});
 
 	test('Respects the `closeOnOutsideClick` prop', async () => {
+		const user = userEvent.setup();
 		const { getByTestId } = render(SelectTest, { closeOnOutsideClick: false });
 		const trigger = getByTestId('trigger');
 		const menu = getByTestId('menu');
-		const user = userEvent.setup();
 
 		expect(menu).not.toBeVisible();
 		await user.click(trigger);

--- a/src/tests/select/SelectTest.svelte
+++ b/src/tests/select/SelectTest.svelte
@@ -9,6 +9,7 @@
 	export let closeOnEscape = true;
 	export let closeOnOutsideClick = true;
 	export let ids: CreateSelectProps['ids'] = undefined;
+	export let onOutsideClick: CreateSelectProps['onOutsideClick'] = undefined;
 	const {
 		elements: { trigger, menu, option, group, groupLabel, label },
 		states: { selected, selectedLabel },
@@ -26,6 +27,7 @@
 			closeOnEscape,
 			closeOnOutsideClick,
 			ids,
+			onOutsideClick,
 		})
 	);
 


### PR DESCRIPTION
This PR exposes an `onOutsideClick` prop for all components where we handle "outside click" events. This is a prop rather than an event dispatch as these events are handled at the `document`, so dispatching them from a random element would be weird.

If you call `event.preventDefault()` inside this handler, it will cancel all default behavior applied by Melt.

I also added some tests for this functionality.