### PR TITLE
Fix(calendar): extraDays array should add days starting from 1

### DIFF
--- a/.changeset/quiet-ads-allow.md
+++ b/.changeset/quiet-ads-allow.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+Fix(calendar): extraDays array should add days starting from 1

--- a/src/lib/internal/helpers/date/calendar.ts
+++ b/src/lib/internal/helpers/date/calendar.ts
@@ -98,7 +98,7 @@ function createMonth(props: CreateMonthProps): Month<DateValue> {
 		}
 
 		const extraDaysArray = Array.from({ length: extraDays }, (_, i) => {
-			const incr = i;
+			const incr = i + 1;
 			return startFrom.add({ days: incr });
 		});
 		nextMonthDays.push(...extraDaysArray);

--- a/src/lib/internal/helpers/date/tests/calendar.spec.ts
+++ b/src/lib/internal/helpers/date/tests/calendar.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { createMonths } from '../calendar.js';
+import { CalendarDate } from '@internationalized/date';
+
+const calendarDate = new CalendarDate(2024, 1, 1);
+
+describe('Calendar', () => {
+	it('should create a month with the given locale, no fixed weeks and week starting on 0', () => {
+		const month = createMonths({
+			dateObj: calendarDate,
+			weekStartsOn: 0,
+			fixedWeeks: false,
+			locale: 'en-US',
+			numberOfMonths: 1,
+		});
+		expect(month[0].value.toString()).toBe(calendarDate.toString());
+	});
+
+	it('should create a month not containing duplicate dates when fixed weeks is true', () => {
+		const month = createMonths({
+			dateObj: calendarDate,
+			weekStartsOn: 0,
+			fixedWeeks: true,
+			locale: 'en-US',
+			numberOfMonths: 1,
+		});
+		const dateStringArray = month[0].dates.map((date) => date.toString());
+		const dateStringSet = new Set(dateStringArray);
+		expect(dateStringArray.length).toBe(dateStringSet.size);
+	});
+});

--- a/src/lib/internal/helpers/date/tests/calendar.spec.ts
+++ b/src/lib/internal/helpers/date/tests/calendar.spec.ts
@@ -16,16 +16,19 @@ describe('Calendar', () => {
 		expect(month[0].value.toString()).toBe(calendarDate.toString());
 	});
 
-	it('should create a month not containing duplicate dates when fixed weeks is true', () => {
-		const month = createMonths({
-			dateObj: calendarDate,
-			weekStartsOn: 0,
-			fixedWeeks: true,
-			locale: 'en-US',
-			numberOfMonths: 1,
-		});
-		const dateStringArray = month[0].dates.map((date) => date.toString());
-		const dateStringSet = new Set(dateStringArray);
-		expect(dateStringArray.length).toBe(dateStringSet.size);
-	});
+	it.each([0, 1, 2, 3, 4, 5, 6])(
+		'should create a month not containing duplicate dates when fixed weeks is true',
+		(i) => {
+			const month = createMonths({
+				dateObj: calendarDate,
+				weekStartsOn: i,
+				fixedWeeks: true,
+				locale: 'en-US',
+				numberOfMonths: 1,
+			});
+			const dateStringArray = month[0].dates.map((date) => date.toString());
+			const dateStringSet = new Set(dateStringArray);
+			expect(dateStringArray.length).toBe(dateStringSet.size);
+		}
+	);
 });

--- a/src/tests/date-picker/DatePicker.spec.ts
+++ b/src/tests/date-picker/DatePicker.spec.ts
@@ -293,7 +293,7 @@ describe('DatePicker', () => {
 			}
 		});
 
-		test('increments segment on arrow down', async () => {
+		test('decrements segment on arrow down', async () => {
 			const user = userEvent.setup();
 			const { getByTestId } = setup({
 				defaultPlaceholder: calendarDateToday,
@@ -309,24 +309,11 @@ describe('DatePicker', () => {
 
 			await user.keyboard(kbd.ARROW_DOWN);
 
-			expect(firstSegment).toHaveTextContent(String(calendarDateToday.month));
-		});
-
-		test('increments segment on arrow down', async () => {
-			const { getByTestId, user } = setup({
-				defaultPlaceholder: calendarDateToday,
-			});
-
-			const firstSegment = getByTestId('month');
-			await user.click(firstSegment);
-
-			await user.keyboard(kbd.ARROW_DOWN);
-
-			const currentMonth = calendarDateToday.month;
-			expect(firstSegment).toHaveTextContent(String(currentMonth));
-
-			await user.keyboard(kbd.ARROW_DOWN);
-			expect(firstSegment).toHaveTextContent(String(calendarDateToday.month));
+			if (calendarDateToday.month === 1) {
+				expect(firstSegment).toHaveTextContent(String(12));
+			} else {
+				expect(firstSegment).toHaveTextContent(String(calendarDateToday.month - 1));
+			}
 		});
 
 		test('navigates segments using arrow keys', async () => {

--- a/src/tests/date-picker/DatePicker.spec.ts
+++ b/src/tests/date-picker/DatePicker.spec.ts
@@ -308,7 +308,8 @@ describe('DatePicker', () => {
 			expect(firstSegment).toHaveTextContent(String(currentMonth));
 
 			await user.keyboard(kbd.ARROW_DOWN);
-			expect(firstSegment).toHaveTextContent(String(calendarDateToday.month - 1));
+
+			expect(firstSegment).toHaveTextContent(String(calendarDateToday.month));
 		});
 
 		test('increments segment on arrow down', async () => {
@@ -325,7 +326,7 @@ describe('DatePicker', () => {
 			expect(firstSegment).toHaveTextContent(String(currentMonth));
 
 			await user.keyboard(kbd.ARROW_DOWN);
-			expect(firstSegment).toHaveTextContent(String(calendarDateToday.month - 1));
+			expect(firstSegment).toHaveTextContent(String(calendarDateToday.month));
 		});
 
 		test('navigates segments using arrow keys', async () => {
@@ -377,6 +378,7 @@ describe('DatePicker', () => {
 		test('when no time selected, selecting', async () => {
 			const { getByTestId, queryByTestId, user, trigger } = setup({
 				granularity: 'minute',
+				defaultValue: new CalendarDateTime(2021, 1, 1),
 			});
 
 			await user.click(trigger);
@@ -393,7 +395,7 @@ describe('DatePicker', () => {
 			const minuteSegment = getByTestId('minute');
 			expect(minuteSegment).not.toHaveTextContent(String(undefined));
 
-			const firstDayInMonth = getByTestId('month-1-date-1');
+			const firstDayInMonth = getByTestId('month-2-date-1');
 			await user.click(firstDayInMonth);
 
 			await tick();


### PR DESCRIPTION
Fixes #868.

I've updated the extraDaysArray variable to add days starting from 1, not 0 which was causing the duplication outlined in the issue and I've added some tests for this particular edge case.

I've also added some defaults for some DatePicker tests which were breaking when I first forked the repository without making any modifications in the code.

Let me know if I need to make any other changes. Thanks!