### PR TITLE
fix(progress): allow null value for indeterminate state

### DIFF
--- a/.changeset/tricky-cougars-burn.md
+++ b/.changeset/tricky-cougars-burn.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+Progress: allow `null` value for indeterminate state

--- a/src/lib/builders/progress/types.ts
+++ b/src/lib/builders/progress/types.ts
@@ -9,7 +9,7 @@ export type CreateProgressProps = {
 	 *
 	 * @default 0
 	 */
-	defaultValue?: number;
+	defaultValue?: number | null;
 
 	/**
 	 * The controlled value store for the radio group.
@@ -17,14 +17,14 @@ export type CreateProgressProps = {
 	 *
 	 * @see https://melt-ui.com/docs/controlled#bring-your-own-store
 	 */
-	value?: Writable<number>;
+	value?: Writable<number | null>;
 
 	/**
 	 * The callback invoked when the value store of the progress changes.
 	 *
 	 * @see https://melt-ui.com/docs/controlled#change-functions
 	 */
-	onValueChange?: ChangeFn<number>;
+	onValueChange?: ChangeFn<number | null>;
 
 	/**
 	 * The maximum value of the progress.


### PR DESCRIPTION
The purpose of this PR is to update the types of the `value` prop used by the `Progress` builder to allow for passing a `null` value to effectively be able to set the progress in the `indeterminate` state, as the implementation suggests:

https://github.com/melt-ui/melt-ui/blob/74e868522ec869ed8a1cdb2192f41a9bd881bd8e/src/lib/builders/progress/create.ts#L38