### PR TITLE
fix(menu): focus on the trigger when rootActiveTrigger is defined

### DIFF
--- a/.changeset/seven-pillows-turn.md
+++ b/.changeset/seven-pillows-turn.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+fix(menu): focus on the trigger when rootActiveTrigger is defined

--- a/src/lib/builders/menu/create.ts
+++ b/src/lib/builders/menu/create.ts
@@ -1138,55 +1138,50 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 		}
 	});
 
-	effect(
-		[rootOpen, rootActiveTrigger, preventScroll],
-		([$rootOpen, $rootActiveTrigger, $preventScroll]) => {
-			if (!isBrowser) return;
-
-			const unsubs: Array<() => void> = [];
-
-			if (opts.removeScroll && $rootOpen && $preventScroll) {
-				unsubs.push(removeScroll());
-			}
-
+	effect([rootOpen], ([$rootOpen]) => {
+		if (!isBrowser) return;
+		if (!$rootOpen) {
+			const $rootActiveTrigger = get(rootActiveTrigger);
+			if (!$rootActiveTrigger) return;
 			const $closeFocus = get(closeFocus);
 
-			if (!$rootOpen) {
-				if ($rootActiveTrigger) {
-					// If we already have a reference to the trigger, focus it
-					handleFocus({ prop: $closeFocus, defaultEl: $rootActiveTrigger });
-				} else {
-					// otherwise we'll get the trigger el and focus it
-					handleFocus({
-						prop: $closeFocus,
-						defaultEl: document.getElementById(get(rootIds.trigger)),
-					});
-				}
+			if (!$rootOpen && $rootActiveTrigger) {
+				handleFocus({ prop: $closeFocus, defaultEl: $rootActiveTrigger });
 			}
-
-			// if the menu is open, we'll sleep for a sec so the menu can render
-			// before we focus on either the first item or the menu itself.
-			sleep(1).then(() => {
-				const menuEl = document.getElementById(get(rootIds.menu));
-				if (menuEl && $rootOpen && get(isUsingKeyboard)) {
-					if (get(disableFocusFirstItem)) {
-						handleRovingFocus(menuEl);
-						return;
-					}
-					// Get menu items belonging to the root menu
-					const menuItems = getMenuItems(menuEl);
-					if (!menuItems.length) return;
-
-					// Focus on first menu item
-					handleRovingFocus(menuItems[0]);
-				}
-			});
-
-			return () => {
-				unsubs.forEach((unsub) => unsub());
-			};
 		}
-	);
+	});
+
+	effect([rootOpen, preventScroll], ([$rootOpen, $preventScroll]) => {
+		if (!isBrowser) return;
+
+		const unsubs: Array<() => void> = [];
+
+		if (opts.removeScroll && $rootOpen && $preventScroll) {
+			unsubs.push(removeScroll());
+		}
+
+		// if the menu is open, we'll sleep for a sec so the menu can render
+		// before we focus on either the first item or the menu itself.
+		sleep(1).then(() => {
+			const menuEl = document.getElementById(get(rootIds.menu));
+			if (menuEl && $rootOpen && get(isUsingKeyboard)) {
+				if (get(disableFocusFirstItem)) {
+					handleRovingFocus(menuEl);
+					return;
+				}
+				// Get menu items belonging to the root menu
+				const menuItems = getMenuItems(menuEl);
+				if (!menuItems.length) return;
+
+				// Focus on first menu item
+				handleRovingFocus(menuItems[0]);
+			}
+		});
+
+		return () => {
+			unsubs.forEach((unsub) => unsub());
+		};
+	});
 
 	effect(rootOpen, ($rootOpen) => {
 		if (!isBrowser) return;

--- a/src/tests/dropdown-menu/DropdownMenu.spec.ts
+++ b/src/tests/dropdown-menu/DropdownMenu.spec.ts
@@ -7,6 +7,7 @@ import DropdownMenuTest from './DropdownMenuTest.svelte';
 import DropdownMenuForceVisible from './DropdownMenuForceVisibleTest.svelte';
 import type { CreateDropdownMenuProps } from '$lib';
 import { sleep } from '$lib/internal/helpers/sleep.js';
+import { tick } from 'svelte';
 
 const OPEN_KEYS = [kbd.ENTER, kbd.ARROW_DOWN, kbd.SPACE];
 
@@ -322,10 +323,13 @@ describe('Dropdown Menu (forceVisible)', () => {
 		expect(queryByTestId('menu')).toBeNull();
 		await user.click(trigger);
 		await waitFor(() => expect(queryByTestId('menu')).not.toBeNull());
+		await user.keyboard(kbd.ARROW_DOWN);
 
+		expect(trigger).not.toHaveFocus();
+		const spy = vi.spyOn(trigger, 'focus');
 		await user.keyboard(kbd.ESCAPE);
 		await waitFor(() => expect(queryByTestId('menu')).toBeNull());
-		await waitFor(() => expect(trigger).toHaveFocus());
+		expect(spy).toHaveBeenCalled();
 	});
 
 	test.each(OPEN_KEYS)('Opens when %s is pressed', async (key) => {

--- a/src/tests/dropdown-menu/DropdownMenu.spec.ts
+++ b/src/tests/dropdown-menu/DropdownMenu.spec.ts
@@ -1,6 +1,6 @@
 import { render, act, waitFor } from '@testing-library/svelte';
 import { axe } from 'jest-axe';
-import { describe, vi, it } from 'vitest';
+import { describe, vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import { testKbd as kbd } from '../utils.js';
 import DropdownMenuTest from './DropdownMenuTest.svelte';

--- a/src/tests/dropdown-menu/DropdownMenu.spec.ts
+++ b/src/tests/dropdown-menu/DropdownMenu.spec.ts
@@ -1,6 +1,6 @@
 import { render, act, waitFor } from '@testing-library/svelte';
 import { axe } from 'jest-axe';
-import { describe, vi } from 'vitest';
+import { describe, vi, it } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import { testKbd as kbd } from '../utils.js';
 import DropdownMenuTest from './DropdownMenuTest.svelte';
@@ -43,6 +43,19 @@ describe('Dropdown Menu (Default)', () => {
 
 		await user.click(trigger);
 		expect(menu).not.toBeVisible();
+	});
+
+	test('Refocuses the trigger when menu closed with keyboard', async () => {
+		const { user, trigger, getByTestId } = setup();
+		const menu = getByTestId('menu');
+
+		expect(menu).not.toBeVisible();
+		await user.click(trigger);
+		expect(menu).toBeVisible();
+
+		await user.keyboard(kbd.ESCAPE);
+		expect(menu).not.toBeVisible();
+		expect(trigger).toHaveFocus();
 	});
 
 	test.each(OPEN_KEYS)('Opens when %s is pressed', async (key) => {
@@ -301,6 +314,18 @@ describe('Dropdown Menu (forceVisible)', () => {
 
 		await user.click(trigger);
 		await waitFor(() => expect(queryByTestId('menu')).toBeNull());
+	});
+
+	test('Refocuses the trigger when menu closed with keyboard', async () => {
+		const { queryByTestId, user, trigger } = setupForceVis();
+
+		expect(queryByTestId('menu')).toBeNull();
+		await user.click(trigger);
+		await waitFor(() => expect(queryByTestId('menu')).not.toBeNull());
+
+		await user.keyboard(kbd.ESCAPE);
+		await waitFor(() => expect(queryByTestId('menu')).toBeNull());
+		await waitFor(() => expect(trigger).toHaveFocus());
 	});
 
 	test.each(OPEN_KEYS)('Opens when %s is pressed', async (key) => {


### PR DESCRIPTION
fix #867.

When the page is first loaded, there is no need to focus on the trigger even if $rootOpen is false.

However, when rootActiveTrigger is set at the time it is mounted, the effect will be executed and the trigger will be focused.

Since we only need to pay attention to whether the menu is closed or not, we did not need to monitor the rootActiveTrigger.