### PR TITLE
fix: menubar `preventScroll`

### DIFF
--- a/.changeset/lemon-shrimps-tan.md
+++ b/.changeset/lemon-shrimps-tan.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": minor
+---
+
+Add `preventScroll` prop to `createMenubar` and remove it from `createMenu` builders returned from the menubar builder

--- a/.changeset/lemon-shrimps-tan.md
+++ b/.changeset/lemon-shrimps-tan.md
@@ -2,4 +2,4 @@
 "@melt-ui/svelte": minor
 ---
 
-Add `preventScroll` prop to `createMenubar` and remove it from `createMenu` builders returned from the menubar builder
+Menubar: Add `preventScroll` prop. Removes it from the returned `createMenu` builders (closes #821)

--- a/src/docs/data/builders/menubar.ts
+++ b/src/docs/data/builders/menubar.ts
@@ -7,7 +7,7 @@ import { getMenuSchemas, getMenuTriggerDataAttrs } from './menu.js';
 import { menubarEvents } from '$lib/builders/menubar/events.js';
 import { menubarIdParts } from '$lib';
 
-const OPTION_PROPS = [PROPS.CLOSE_ON_ESCAPE, PROPS.LOOP];
+const OPTION_PROPS = [PROPS.CLOSE_ON_ESCAPE, PROPS.LOOP, PROPS.PREVENT_SCROLL];
 const BUILDER_NAME = 'menubar';
 
 const builder = builderSchema(BUILDER_NAME, {
@@ -23,9 +23,16 @@ const builder = builderSchema(BUILDER_NAME, {
 	options: OPTION_PROPS,
 });
 
+const menubarMenuBuilderProps = dropdownBuilder.props?.filter((p) => p.name !== 'preventScroll');
+const menubarMenuBuilderOptions = dropdownBuilder.options?.filter(
+	(opt) => opt.name !== 'preventScroll'
+);
+
 const menuBuilder = {
 	...dropdownBuilder,
 	title: 'createMenu',
+	props: menubarMenuBuilderProps,
+	options: menubarMenuBuilderOptions,
 };
 const {
 	menu,

--- a/src/lib/builders/menubar/types.ts
+++ b/src/lib/builders/menubar/types.ts
@@ -16,8 +16,18 @@ export type CreateMenubarProps = {
 
 	/**
 	 * Whether to close the active menu when the escape key is pressed.
+	 *
+	 * @default true
 	 */
 	closeOnEscape?: boolean;
+
+	/**
+	 * Whether to prevent scrolling the body when any menu within
+	 * the menubar is open.
+	 *
+	 * @default true
+	 */
+	preventScroll?: boolean;
 
 	/**
 	 * Optionally override the default ids we assign to the elements
@@ -25,7 +35,7 @@ export type CreateMenubarProps = {
 	ids?: Partial<IdObj<MenubarIdParts>>;
 };
 
-export type CreateMenubarMenuProps = _Menu['builder'];
+export type CreateMenubarMenuProps = Omit<_Menu['builder'], 'preventScroll'>;
 export type CreateMenubarSubmenuProps = _Menu['submenu'];
 export type MenubarMenuItemProps = _Menu['item'];
 export type CreateMenuRadioGroupProps = _Menu['radioGroup'];


### PR DESCRIPTION
Related: #821

When using the menubar, you need to decide on a per-menubar basis whether to prevent scroll, rather than on a per-menu basis. Doing so on a per-menu basis causes significant lag and performance hits if one menu in the menubar does preventScroll and another doesn't.

A `preventScroll` prop & option has been added to the `createMenubar` builder, while we have removed the prop from the `createMenu` builder that the menubar builder returns, as it will inherit this prop from the menubar. 
