### PR TITLE
Auto gen CSS demos from Tailwind demos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ src/pagefind/**/*
 !src/pagefind/pagefind.js
 
 static/pagefind/**/*
+
+deno.lock
+*.temp.css
+src/docs/previews/**/css-gen

--- a/.prettierignore
+++ b/.prettierignore
@@ -33,3 +33,7 @@ playwright-report
 .vercel
 
 src/pagefind/**/*
+
+deno.lock
+*.temp.css
+src/docs/previews/**/css-gen

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,5 @@
+{
+	"tasks": {
+		"dev": "deno run --allow-read --allow-write --allow-run ./scripts/generate-previews/index.ts"
+	}
+}

--- a/scripts/generate-previews/constants.ts
+++ b/scripts/generate-previews/constants.ts
@@ -1,0 +1,2 @@
+export const PREVIEWS_DIR_PATH = './src/docs/previews';
+export const CSS_STACK_DIR_NAME = 'css-gen';

--- a/scripts/generate-previews/convertClassMappingToStyle.ts
+++ b/scripts/generate-previews/convertClassMappingToStyle.ts
@@ -1,0 +1,13 @@
+import type { ClassMapping } from './types.ts';
+
+export const convertClassMappingToStyle = (mapping: ClassMapping) => {
+	let style = '';
+	for (const [key, value] of Object.entries(mapping)) {
+		style += `
+.${key} {
+    @apply ${value};
+}
+`;
+	}
+	return style;
+};

--- a/scripts/generate-previews/convertTwStyles.ts
+++ b/scripts/generate-previews/convertTwStyles.ts
@@ -1,0 +1,37 @@
+export const convertTwStyles = async (inputFilePath: string, outputFilePath: string) => {
+	const command = [
+		'C:\\Program Files\\nodejs\\npx.cmd',
+		// 'npx',
+		'tailwindcss',
+		'-i',
+		inputFilePath,
+		'-o',
+		outputFilePath,
+	];
+
+	// new Deno.Command('C:\\Program Files\\nodejs\\npx.cmd', {
+	// 	args: command,
+	// 	stdin: 'piped',
+	// 	stdout: 'piped',
+	// });
+
+	const process = Deno.run({
+		cmd: command,
+		stdout: 'piped',
+		stderr: 'piped',
+	});
+
+	const { code } = await process.status();
+
+	if (code === 0) {
+		const rawOutput = await process.output();
+		const output = new TextDecoder().decode(rawOutput);
+		console.log(output);
+	} else {
+		const rawError = await process.stderrOutput();
+		const errorString = new TextDecoder().decode(rawError);
+		console.error(errorString);
+	}
+
+	process.close();
+};

--- a/scripts/generate-previews/index.ts
+++ b/scripts/generate-previews/index.ts
@@ -1,0 +1,69 @@
+import { ensureDir } from 'https://deno.land/std@0.208.0/fs/ensure_dir.ts';
+import { copy } from 'https://deno.land/std@0.208.0/fs/copy.ts';
+import { emptyDir } from 'https://deno.land/std@0.109.0/fs/empty_dir.ts';
+import { PREVIEWS_DIR_PATH, CSS_STACK_DIR_NAME } from './constants.ts';
+import { processHtml } from './processHtml.ts';
+import { convertClassMappingToStyle } from './convertClassMappingToStyle.ts';
+import { convertTwStyles } from './convertTwStyles.ts';
+
+for await (const previewEntry of Deno.readDir(PREVIEWS_DIR_PATH)) {
+	if (!previewEntry.isDirectory) continue;
+
+	if (previewEntry.name !== 'avatar') continue;
+
+	const DEMOS_DIR_PATH = `${PREVIEWS_DIR_PATH}/${previewEntry.name}`;
+
+	for await (const demoDirEntry of Deno.readDir(DEMOS_DIR_PATH)) {
+		if (!previewEntry.isDirectory) continue;
+
+		const DEMO_STACK_DIR_PATH = `${DEMOS_DIR_PATH}/${demoDirEntry.name}`;
+		const TW_STACK_DIR_PATH = `${DEMO_STACK_DIR_PATH}/tailwind`;
+		const CSS_STACK_DIR_PATH = `${DEMO_STACK_DIR_PATH}/${CSS_STACK_DIR_NAME}/`;
+
+		await emptyDir(CSS_STACK_DIR_PATH);
+
+		// tailwind/*.svelte, ...
+		for await (const twDirEntry of Deno.readDir(TW_STACK_DIR_PATH)) {
+			ensureDir(CSS_STACK_DIR_PATH);
+
+			if (twDirEntry.isDirectory) {
+				await copy(`${TW_STACK_DIR_PATH}/${twDirEntry.name}`, `${CSS_STACK_DIR_PATH}`);
+			} else if (twDirEntry.isFile) {
+				if (twDirEntry.name.endsWith('.svelte')) {
+					// ./src/docs/previews/avatar/main/tailwind/index.svelte
+					const componentTextContent = await Deno.readTextFile(
+						`${TW_STACK_DIR_PATH}/${twDirEntry.name}`
+					);
+
+					const { mapping, modifiedHtml } = processHtml(componentTextContent);
+					const cssStyle = convertClassMappingToStyle(mapping);
+
+					const TW_INPUT_CSSTEMP_FILE_PATH = `${CSS_STACK_DIR_PATH}/${twDirEntry.name}.input.temp.css`;
+					const TW_OUTPUT_CSSTEMP_FILE_PATH = `${CSS_STACK_DIR_PATH}/${twDirEntry.name}.output.temp.css`;
+
+					// TODO what if style tag already exists
+					await Deno.writeTextFile(TW_INPUT_CSSTEMP_FILE_PATH, cssStyle);
+
+					await convertTwStyles(TW_INPUT_CSSTEMP_FILE_PATH, TW_OUTPUT_CSSTEMP_FILE_PATH);
+
+					const twOutputCSSTempFileContent = await Deno.readTextFile(TW_OUTPUT_CSSTEMP_FILE_PATH);
+					const componentStyles = `
+<style>
+    ${twOutputCSSTempFileContent}
+</style>
+`;
+
+					await Deno.writeTextFile(
+						`${CSS_STACK_DIR_PATH}/${twDirEntry.name}`,
+						modifiedHtml + componentStyles
+					);
+
+					await Deno.remove(TW_INPUT_CSSTEMP_FILE_PATH);
+					await Deno.remove(TW_OUTPUT_CSSTEMP_FILE_PATH);
+				} else {
+					await Deno.copyFile(`${TW_STACK_DIR_PATH}/${twDirEntry.name}`, `${CSS_STACK_DIR_PATH}`);
+				}
+			}
+		}
+	}
+}

--- a/scripts/generate-previews/processHtml.ts
+++ b/scripts/generate-previews/processHtml.ts
@@ -1,0 +1,36 @@
+import type { ClassMapping } from './types.ts';
+
+export const processHtml = (html: string) => {
+	const mapping: ClassMapping = {};
+	const regex =
+		/<(\w+)([^>]*)\bclass\s*=\s*(['"])(.*?)\3([^>]*)\bdata-class\s*=\s*(['"])(.*?)\6([^>]*)>/g;
+
+	const modifiedHtml = html.replace(
+		regex,
+		(
+			_match,
+			tagName,
+			beforeClass,
+			_classQuote,
+			classValue,
+			betweenAttrs,
+			_dataClassQuote,
+			dataClassValue,
+			afterDataClass
+		) => {
+			if ((classValue && !dataClassValue) || (!classValue && dataClassValue)) {
+				throw new Error(
+					`Class and data-class attributes must be provided together for ${tagName} element.`
+				);
+			}
+
+			// Mapping data-class attributes to class attributes
+			mapping[dataClassValue] = classValue;
+
+			// Replace class attribute with data-class value and remove data-class attribute
+			return `<${tagName}${beforeClass} class="${dataClassValue}"${betweenAttrs}${afterDataClass}>`;
+		}
+	);
+
+	return { mapping, modifiedHtml };
+};

--- a/scripts/generate-previews/types.ts
+++ b/scripts/generate-previews/types.ts
@@ -1,0 +1,1 @@
+export type ClassMapping = { [key: string]: string };

--- a/src/docs/previews/avatar/main/tailwind/index.svelte
+++ b/src/docs/previews/avatar/main/tailwind/index.svelte
@@ -23,43 +23,55 @@
 	});
 </script>
 
-<div class="flex w-full items-center justify-center gap-6">
+<div class="flex w-full items-center justify-center gap-6" data-class="root">
 	<div
 		class="flex h-16 w-16 items-center justify-center rounded-full bg-neutral-100"
+		data-class="item"
 	>
 		<img
 			use:melt={$image}
 			alt="Avatar"
 			class="h-full w-full rounded-[inherit]"
+			data-class="avatar"
 		/>
-		<span use:melt={$fallback} class="text-3xl font-medium text-magnum-700"
-			>RH</span
+		<span
+			use:melt={$fallback}
+			class="text-3xl font-medium text-magnum-700"
+			data-class="fallback">RH</span
 		>
 	</div>
 
 	<div
 		class="flex h-16 w-16 items-center justify-center rounded-full bg-neutral-100"
+		data-class="item"
 	>
 		<img
 			use:melt={$imageA}
 			alt="Avatar"
 			class="h-full w-full rounded-[inherit]"
+			data-class="avatar"
 		/>
-		<span use:melt={$fallbackA} class="text-3xl font-medium text-magnum-700"
-			>SH</span
+		<span
+			use:melt={$fallbackA}
+			class="text-3xl font-medium text-magnum-700"
+			data-class="fallback">SH</span
 		>
 	</div>
 
 	<div
 		class="flex h-16 w-16 items-center justify-center rounded-full bg-neutral-100"
+		data-class="item"
 	>
 		<img
 			use:melt={$imageB}
 			alt="Avatar"
 			class="h-full w-full rounded-[inherit]"
+			data-class="avatar"
 		/>
-		<span use:melt={$fallbackB} class="text-3xl font-medium text-magnum-700"
-			>UI</span
+		<span
+			use:melt={$fallbackB}
+			class="text-3xl font-medium text-magnum-700"
+			data-class="fallback">UI</span
 		>
 	</div>
 </div>


### PR DESCRIPTION
Hey

What I've done looks awful.

It only works for the `avatar` preview.

The `css-gen` folder is auto-generated (from the tailwind demo).

You need to install Deno to get this working :|
https://docs.deno.com/runtime/manual/getting_started/installation

After installing Deno, run this command `deno task dev`.

---

https://github.com/melt-ui/melt-ui/issues/574#issuecomment-1814406887