### PR TITLE
allow 00 as values in minute and second segment for date field

### DIFF
--- a/.changeset/warm-donkeys-eat.md
+++ b/.changeset/warm-donkeys-eat.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+Date/Range Field: fix: bug preventing `00` as value for minute and second segments (closes: #854)

--- a/src/lib/builders/date-field/create.ts
+++ b/src/lib/builders/date-field/create.ts
@@ -1428,7 +1428,7 @@ export function createDateField(props?: CreateDateFieldProps) {
 					if (num === 0) {
 						states.minute.lastKeyZero = true;
 						announcer.announce(null);
-						return null;
+						return 0;
 					}
 
 					/**
@@ -1613,7 +1613,7 @@ export function createDateField(props?: CreateDateFieldProps) {
 					if (num === 0) {
 						states.second.lastKeyZero = true;
 						announcer.announce(null);
-						return null;
+						return 0;
 					}
 
 					/**

--- a/src/tests/date-field/DateField.spec.ts
+++ b/src/tests/date-field/DateField.spec.ts
@@ -14,7 +14,7 @@ import {
 import type { CreateDateFieldProps } from '$lib';
 
 const calendarDateOther = new CalendarDate(1980, 1, 20);
-const calendarDateTimeOther = new CalendarDateTime(1980, 1, 20, 12, 30, 0, 0);
+const calendarDateTimeOther = new CalendarDateTime(1980, 1, 20, 12, 30, 30, 0);
 const zonedDateTimeOther = toZoned(calendarDateTimeOther, 'America/New_York');
 
 function setup(props: CreateDateFieldProps = {}) {
@@ -489,6 +489,101 @@ describe('DateField', () => {
 		expect(minuteSegment).toHaveTextContent('30');
 		await user.keyboard(`{1}`);
 		expect(minuteSegment).toHaveTextContent('1');
+	});
+
+	test('fully overwrite on first click and type - second', async () => {
+		const user = userEvent.setup();
+		const { getByTestId } = setup({
+			defaultValue: calendarDateTimeOther,
+			granularity: 'second',
+		});
+
+		const secondSegment = getByTestId('second');
+		await user.click(secondSegment);
+		expect(secondSegment).toHaveFocus();
+		expect(secondSegment).toHaveTextContent('30');
+		await user.keyboard(`{1}`);
+		expect(secondSegment).toHaveTextContent('1');
+	});
+
+	test('disallows 00 as value - month', async () => {
+		const user = userEvent.setup();
+		const { getByTestId } = setup({
+			defaultValue: calendarDateTimeOther,
+			granularity: 'second',
+		});
+
+		const monthSegment = getByTestId('month');
+		await user.click(monthSegment);
+		expect(monthSegment).toHaveFocus();
+		expect(monthSegment).toHaveTextContent('1');
+		await user.keyboard(`{0}`);
+		await user.keyboard(`{0}`);
+		expect(monthSegment).toHaveTextContent('mm');
+	});
+
+	test('disallows 00 as value - day', async () => {
+		const user = userEvent.setup();
+		const { getByTestId } = setup({
+			defaultValue: calendarDateTimeOther,
+			granularity: 'second',
+		});
+
+		const daySegment = getByTestId('day');
+		await user.click(daySegment);
+		expect(daySegment).toHaveFocus();
+		expect(daySegment).toHaveTextContent('20');
+		await user.keyboard(`{0}`);
+		await user.keyboard(`{0}`);
+		expect(daySegment).toHaveTextContent('dd');
+	});
+
+	test('disallows 00 as value - hour', async () => {
+		const user = userEvent.setup();
+		const { getByTestId } = setup({
+			defaultValue: calendarDateTimeOther,
+			granularity: 'second',
+		});
+
+		const hourSegment = getByTestId('hour');
+		await user.click(hourSegment);
+		expect(hourSegment).toHaveFocus();
+		expect(hourSegment).toHaveTextContent('12');
+		await user.keyboard(`{0}`);
+		await user.keyboard(`{0}`);
+		expect(hourSegment).toHaveTextContent('––');
+	});
+
+	test('allows 00 as value - minute', async () => {
+		const user = userEvent.setup();
+		const { getByTestId } = setup({
+			defaultValue: calendarDateTimeOther,
+			granularity: 'second',
+		});
+
+		const minuteSegment = getByTestId('minute');
+		await user.click(minuteSegment);
+		expect(minuteSegment).toHaveFocus();
+		expect(minuteSegment).toHaveTextContent('30');
+		await user.keyboard(`{0}`);
+		await user.keyboard(`{0}`);
+		expect(minuteSegment).toHaveTextContent('00');
+	});
+
+	test('allows 00 as value - second', async () => {
+		const user = userEvent.setup();
+		const { getByTestId } = setup({
+			defaultValue: calendarDateTimeOther,
+			granularity: 'second',
+		});
+
+		const secondSegment = getByTestId('second');
+		await user.click(secondSegment);
+		expect(secondSegment).toHaveFocus();
+		expect(secondSegment).toHaveTextContent('30');
+		await user.keyboard(`{0}`);
+		await user.keyboard(`{0}`);
+		expect(secondSegment).toHaveTextContent('00');
 	});
 
 	test('displays correct timezone with ZonedDateTime value - now', async () => {


### PR DESCRIPTION
Previously when User typed in `00` as the value for minute and second segment it would not get registered. This fixes the issue and allows `00` as a valid input for minute and second segment but disallowing for the other fields.