### PR TITLE
chore: make `GITHUB_TOKEN` dynamic for docsite builds

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -65,6 +65,8 @@ jobs:
 
       - name: Build site
         run: pnpm build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy to Cloudflare Pages
         id: cloudflare-pages-deploy

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -74,7 +74,7 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           projectName: melt-ui
-          directory: ./.svelte-kit/cloudflare
+          directory: ./build
           deploymentName: Preview
 
   untrusted-preview:
@@ -121,6 +121,6 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           projectName: melt-ui
-          directory: ./.svelte-kit/cloudflare
+          directory: ./build
           deploymentName: Preview
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -65,8 +65,6 @@ jobs:
 
       - name: Build site
         run: pnpm build
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy to Cloudflare Pages
         id: cloudflare-pages-deploy

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -16,6 +16,7 @@
 name: Preview Deployment
 on:
   pull_request_target:
+    types: [opened, synchronize]
 
 # cancel in-progress runs on new commits to same PR (github.event.number)
 concurrency:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Build site
         run: pnpm build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy to Cloudflare Pages
         uses: AdrianGonz97/refined-cf-pages-action@v1

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -50,5 +50,5 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           projectName: melt-ui
-          directory: ./.svelte-kit/cloudflare
+          directory: ./build
           deploymentName: Production

--- a/src/routes/docs/[...slug]/+page.server.ts
+++ b/src/routes/docs/[...slug]/+page.server.ts
@@ -1,10 +1,6 @@
 import { navConfig } from '$docs/config.js';
 import type { EntryGenerator, PageLoad } from './$types.js';
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import { GITHUB_TOKEN } from '$env/static/private';
-
 export const entries = (() => {
 	return navConfig.sidebarNav[0].items.map((item) => {
 		return { slug: item.title.toLowerCase().replaceAll(' ', '-') };
@@ -42,21 +38,13 @@ const getContributors = async () => {
 		try {
 			// eslint-disable-next-line no-console
 			console.log('Fetching contributors...');
-			const res = await fetch(`https://api.github.com/repos/melt-ui/melt-ui/contributors`, {
-				headers: {
-					Authorization: `Bearer ${GITHUB_TOKEN}`,
-				},
-			});
+			const res = await fetch(`https://api.github.com/repos/melt-ui/melt-ui/contributors`);
 
 			const contributors = (await res.json()) as Contributor[];
 
 			const contributorsWithName = (await Promise.all(
 				contributors.map(async (contributor) => {
-					const res = await fetch(`https://api.github.com/users/${contributor.login}`, {
-						headers: {
-							Authorization: `Bearer ${GITHUB_TOKEN}`,
-						},
-					});
+					const res = await fetch(`https://api.github.com/users/${contributor.login}`);
 					const { name, bio } = await res.json();
 					return {
 						...contributor,

--- a/src/routes/docs/[...slug]/+page.server.ts
+++ b/src/routes/docs/[...slug]/+page.server.ts
@@ -1,6 +1,8 @@
 import { navConfig } from '$docs/config.js';
 import type { EntryGenerator, PageLoad } from './$types.js';
 
+import { env } from '$env/dynamic/private';
+
 export const entries = (() => {
 	return navConfig.sidebarNav[0].items.map((item) => {
 		return { slug: item.title.toLowerCase().replaceAll(' ', '-') };
@@ -36,15 +38,25 @@ let storedContributors: FullContributor[] | undefined;
 const getContributors = async () => {
 	if (!storedContributors) {
 		try {
+			if (env.GITHUB_TOKEN === undefined) return [];
+
 			// eslint-disable-next-line no-console
 			console.log('Fetching contributors...');
-			const res = await fetch(`https://api.github.com/repos/melt-ui/melt-ui/contributors`);
+			const res = await fetch(`https://api.github.com/repos/melt-ui/melt-ui/contributors`, {
+				headers: {
+					Authorization: `Bearer ${env.GITHUB_TOKEN}`,
+				},
+			});
 
 			const contributors = (await res.json()) as Contributor[];
 
 			const contributorsWithName = (await Promise.all(
 				contributors.map(async (contributor) => {
-					const res = await fetch(`https://api.github.com/users/${contributor.login}`);
+					const res = await fetch(`https://api.github.com/users/${contributor.login}`, {
+						headers: {
+							Authorization: `Bearer ${env.GITHUB_TOKEN}`,
+						},
+					});
 					const { name, bio } = await res.json();
 					return {
 						...contributor,


### PR DESCRIPTION
The idea here is to only expose the `GITHUB_TOKEN` during production builds. `GITHUB_TOKEN` was changed to a dynamic env var so that preview builds don't fail when it's missing.