### PR TITLE
[table of contents] fix page scroll jump on item click

### DIFF
--- a/src/lib/builders/table-of-contents/create.ts
+++ b/src/lib/builders/table-of-contents/create.ts
@@ -372,7 +372,7 @@ export function createTableOfContents(args: CreateTableOfContentsArgs) {
 
 					// Add items hash to URL
 					if (id) {
-						window.location.hash = id;
+						history.pushState(null, '', `#${id}`);
 					}
 				})
 			);


### PR DESCRIPTION
closes https://github.com/melt-ui/melt-ui/issues/920

When clicking on an item in the table of contents, the page immediately scrolls to the html element with the corresponding ID. This behavior is actually wrong, because according to the code, if no custom `scrollFn` is passed to the table of contents builder, then `window.scrollTo({ top: offsetPosition, behavior: scrollBehaviour })` is called and the default behavior is smooth as per the docs, which should result in a smooth scroll. 

However, the reason the scroll is not smooth even though we are calling `window.scrollTo()` as said above is because after that we set `window.location.hash = id` which immediately changes the page scroll position to the item with the ID. 

In order to prevent the browser from scrolling to the element so that we can manually do so, we need to call `event.preventDefault()` when the anchor element is clicked, which is already done. In addition, we also need to ```history.pushState(null, '', `#${id}`);``` which doesn't change the page's scroll position, contrary to setting `window.location.hash` which does cause a page scroll jump.

So in order to fix this issue, we need to replace `window.location.hash = id` with ```history.pushState(null, '', `#${id}`);```

This issue also becomes obvious when in the docs example of table of contents, we pass a `scrollFn` to the builder which according to the code comments should:
```typescript
/**
 * Here we're overwriting the default scroll function
 * so that we only scroll within the ToC preview
 * container, instead of the entire page.
 */
```
but the page scroll jumps instead of performing the desired behavior of scrolling the preview container instead of the page.

### Docs Table of Contents After
https://b005dbbf-685b-42e9-9961-5b74e58b0921.s3.us-east-1.amazonaws.com/example-after.mp4

### Docs Table of Contents Before
https://b005dbbf-685b-42e9-9961-5b74e58b0921.s3.us-east-1.amazonaws.com/exaple-before.mp4

### Table of contents used in docs After
https://b005dbbf-685b-42e9-9961-5b74e58b0921.s3.us-east-1.amazonaws.com/docs-after.mp4

### Table of contents used in docs Before
https://b005dbbf-685b-42e9-9961-5b74e58b0921.s3.us-east-1.amazonaws.com/docs-before.mp4