### PR TITLE
fix: docs slider types

### DIFF
--- a/src/docs/data/builders/slider.ts
+++ b/src/docs/data/builders/slider.ts
@@ -56,13 +56,13 @@ const builder = builderSchema(BUILDER_NAME, {
 		},
 		{
 			name: 'value',
-			type: 'Writable<number>',
+			type: 'Writable<number[]>',
 			description: 'A writable store that can be used to update the slider value.',
 			see: SEE.BRING_YOUR_OWN_STORE,
 		},
 		{
 			name: 'onValueChange',
-			type: 'ChangeFn<number>',
+			type: 'ChangeFn<number[]>',
 			description: 'A callback that is called when the value of the slider changes.',
 			see: SEE.CHANGE_FUNCTIONS,
 		},


### PR DESCRIPTION
fixed docs slider types to match the actual typescript types

<img width="545" alt="image" src="https://github.com/melt-ui/melt-ui/assets/53095479/eae42197-3e34-4d1d-ac73-d9509d3ab67d">

### Docs Before

![image](https://github.com/melt-ui/melt-ui/assets/53095479/ae86ac82-9433-4f05-844e-715fe247b9da)

### Docs After
![image](https://github.com/melt-ui/melt-ui/assets/53095479/312b1c3f-0690-40b8-8c56-1715391a1335)
