### PR TITLE
fix: type of `type` in tabs builder

### DIFF
--- a/.changeset/giant-spoons-sleep.md
+++ b/.changeset/giant-spoons-sleep.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+fix: type of type in tabs builder

--- a/src/lib/builders/tabs/create.ts
+++ b/src/lib/builders/tabs/create.ts
@@ -90,7 +90,7 @@ export function createTabs(props?: CreateTabsProps) {
 				const isActive = sourceOfTruth === tabValue;
 
 				return {
-					type: 'button',
+					type: 'button' as const,
 					role: 'tab',
 					'data-state': isActive ? 'active' : 'inactive',
 					tabindex: isActive ? 0 : -1,


### PR DESCRIPTION
Fixes the type of `type` in the tabs builder which was conflicting with svelte button types