### PR TITLE
docs: Fix 'denied' prop name on Tags Input builder docs

### DIFF
--- a/src/docs/data/builders/tags-input.ts
+++ b/src/docs/data/builders/tags-input.ts
@@ -69,7 +69,7 @@ const OPTION_PROPS = [
 		default: '[]',
 	},
 	{
-		name: 'disallowed',
+		name: 'denied',
 		type: 'string[]',
 		description: 'The disallowed tags.',
 		default: '[]',


### PR DESCRIPTION
In the Tags Input builder docs `denied` prop was still referenced as `disallowed` even though it was changed on: https://github.com/melt-ui/melt-ui/commit/072e30053a4b35a39cce5e5a7f8234fe2e7da14a