### PR TITLE
fix: Close tooltip on scroll

### DIFF
--- a/.changeset/silly-bananas-train.md
+++ b/.changeset/silly-bananas-train.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+Tooltip: fixed a bug where the content would remain open when scrolling outside (Closed: #945)

--- a/src/lib/builders/tooltip/create.ts
+++ b/src/lib/builders/tooltip/create.ts
@@ -7,6 +7,8 @@ import {
 	executeCallbacks,
 	getPortalDestination,
 	isBrowser,
+	isDocument,
+	isElement,
 	isTouch,
 	kbd,
 	makeHullFromElements,
@@ -233,9 +235,24 @@ export function createTooltip(props?: CreateTooltipProps) {
 				}
 			);
 
+			/**
+			 * We don't want the tooltip to remain open if the user starts scrolling
+			 * while their pointer is over the tooltip, so we close it.
+			 */
+			function handleScroll(e: Event) {
+				if (!open.get()) return;
+				const target = e.target;
+				if (!isElement(target) && !isDocument(target)) return;
+				const triggerEl = getEl('trigger');
+				if (triggerEl && target.contains(triggerEl)) {
+					closeTooltip();
+				}
+			}
+
 			const unsubEvents = executeCallbacks(
 				addMeltEventListener(node, 'pointerenter', () => openTooltip('pointer')),
-				addMeltEventListener(node, 'pointerdown', () => openTooltip('pointer'))
+				addMeltEventListener(node, 'pointerdown', () => openTooltip('pointer')),
+				addEventListener(window, 'scroll', handleScroll, { capture: true })
 			);
 
 			return {

--- a/src/lib/internal/helpers/is.ts
+++ b/src/lib/internal/helpers/is.ts
@@ -6,6 +6,10 @@ export const isFunction = (v: unknown): v is Function => typeof v === 'function'
 
 export const isLetter = (key: string) => /^[a-z]$/i.test(key);
 
+export function isDocument(element: unknown): element is Document {
+	return element instanceof Document;
+}
+
 export function isElement(element: unknown): element is Element {
 	return element instanceof Element;
 }

--- a/src/tests/tooltip/Tooltip.spec.ts
+++ b/src/tests/tooltip/Tooltip.spec.ts
@@ -1,31 +1,43 @@
-import { render, waitFor } from '@testing-library/svelte';
+import { fireEvent, render, waitFor } from '@testing-library/svelte';
 import { get, writable } from 'svelte/store';
 import { describe, expect, test } from 'vitest';
 import Tooltip from './Tooltip.svelte';
 import { userEvent } from '@testing-library/user-event';
 import { sleep } from '$lib/internal/helpers/index.js';
+import type { CreateTooltipProps } from '$lib/index.js';
+
+/**
+ * Simple setup function to render the tooltip component and
+ * return the user event object, trigger, content, and other
+ * methods returned from the render function.
+ */
+function setup(props: CreateTooltipProps = {}) {
+	const user = userEvent.setup();
+	const returned = render(Tooltip, { props });
+	const trigger = returned.getByTestId('trigger');
+	const content = returned.getByTestId('content');
+	return {
+		...returned,
+		user,
+		trigger,
+		content,
+	};
+}
 
 describe('Tooltip', () => {
 	test('It opens when hovered, and closes when left', async () => {
-		const { getByTestId } = render(Tooltip);
-		const user = userEvent.setup();
-
-		const trigger = getByTestId('trigger');
-		const content = getByTestId('content');
+		const { user, trigger, content } = setup();
 		expect(content).not.toBeVisible();
 
-		user.hover(trigger);
-		await waitFor(() => expect(content).toBeVisible());
+		await user.hover(trigger);
+		expect(content).toBeVisible();
 
-		user.unhover(trigger);
-		await waitFor(() => expect(content).not.toBeVisible());
+		await user.unhover(trigger);
+		expect(content).not.toBeVisible();
 	});
 
 	test('It opens when focused, and closes when blurred', async () => {
-		const { getByTestId } = render(Tooltip);
-
-		const trigger = getByTestId('trigger');
-		const content = getByTestId('content');
+		const { trigger, content } = setup();
 		expect(content).not.toBeVisible();
 
 		trigger.focus();
@@ -40,72 +52,80 @@ describe('Tooltip', () => {
 			trigger: 'id-trigger',
 			content: 'id-content',
 		};
-		const { getByTestId } = render(Tooltip, {
-			ids,
-		});
+		const { trigger, content } = setup({ ids });
 
-		const trigger = getByTestId('trigger');
-		const content = getByTestId('content');
 		expect(trigger.id).toBe(ids.trigger);
 		expect(content.id).toBe(ids.content);
 	});
 
-	test.skip('When the tooltip was opened by focusing, leaving the trigger does not close it', async () => {
-		const { getByTestId } = render(Tooltip);
-		const user = userEvent.setup();
-
-		const trigger = getByTestId('trigger');
-		const content = getByTestId('content');
+	test('When the tooltip was opened by focusing, leaving the trigger does not close it', async () => {
+		const { user, trigger, content } = setup();
 		expect(content).not.toBeVisible();
 
 		trigger.focus();
 		await waitFor(() => expect(content).toBeVisible());
 
-		user.hover(trigger);
-		await waitFor(() => expect(content).toBeVisible());
+		await user.hover(trigger);
+		expect(content).toBeVisible();
 
-		user.unhover(trigger);
-		await waitFor(() => expect(content).toBeVisible());
+		await user.unhover(trigger);
+		expect(content).toBeVisible();
 
 		trigger.blur();
 		await waitFor(() => expect(content).not.toBeVisible());
 	});
 
-	test.skip('When the tooltip was opened by pointer, blurring the trigger does not close it', async () => {
-		const { getByTestId } = render(Tooltip);
-		const user = userEvent.setup();
-
-		const trigger = getByTestId('trigger');
-		const content = getByTestId('content');
+	test('When the tooltip was opened by pointer, blurring the trigger does not close it', async () => {
+		const { user, trigger, content } = setup();
 		expect(content).not.toBeVisible();
 
-		user.hover(trigger);
-		await waitFor(() => expect(content).toBeVisible());
+		await user.hover(trigger);
+		expect(content).toBeVisible();
 
 		trigger.focus();
 		await waitFor(() => expect(content).toBeVisible());
 
 		trigger.blur();
-		await sleep(100);
 		await waitFor(() => expect(content).toBeVisible());
 
-		user.unhover(trigger);
+		await user.unhover(trigger);
+		expect(content).not.toBeVisible();
+	});
+
+	test('When focusing the trigger, you should be able to click the content', async () => {
+		const { user, trigger, content } = setup();
+		expect(content).not.toBeVisible();
+
+		await fireEvent(trigger, new FocusEvent('focus'));
+		await waitFor(() => expect(content).toBeVisible());
+
+		await user.click(content);
+		await sleep(100);
+		expect(content).toBeVisible();
+	});
+
+	test('When tooltip is open and the user scrolls outside the content, it closes', async () => {
+		const { user, trigger, content } = setup();
+
+		await user.hover(trigger);
+		expect(content).toBeVisible();
+
+		await fireEvent.scroll(document);
 		await waitFor(() => expect(content).not.toBeVisible());
 	});
 
-	test.skip('When focusing the trigger, you should be able to click the content', async () => {
-		const { getByTestId } = render(Tooltip);
+	test('When the tooltip is open and the user scrolls inside the content, it stays open', async () => {
+		const { user, trigger, content } = setup();
 
-		const trigger = getByTestId('trigger');
-		const content = getByTestId('content');
-		expect(content).not.toBeVisible();
+		await user.hover(trigger);
+		expect(content).toBeVisible();
 
-		trigger.focus();
-		await waitFor(() => expect(content).toBeVisible());
-
-		userEvent.click(content);
-		await sleep(100);
-		await waitFor(() => expect(content).toBeVisible());
+		await user.click(content);
+		expect(content).toBeVisible();
+		await fireEvent.scroll(content);
+		// sleep to account for any delays in the scroll event and close
+		await sleep(50);
+		expect(content).toBeVisible();
 	});
 });
 

--- a/src/tests/tooltip/Tooltip.svelte
+++ b/src/tests/tooltip/Tooltip.svelte
@@ -3,6 +3,8 @@
 	import type { Writable } from 'svelte/store';
 	import { removeUndefined } from '../utils.js';
 
+	type $$Props = CreateTooltipProps;
+
 	export let open: Writable<boolean> | undefined = undefined;
 	export let group: CreateTooltipProps['group'] = undefined;
 	export let closeOnPointerDown: CreateTooltipProps['closeOnPointerDown'] = false;
@@ -19,6 +21,7 @@
 			openDelay: 0,
 			closeDelay: 0,
 			ids,
+			...$$restProps,
 		})
 	);
 
@@ -26,4 +29,13 @@
 </script>
 
 <button use:melt={$trigger} data-testid="trigger">Trigger</button>
-<div use:melt={$content} data-testid="content">Content</div>
+<div use:melt={$content} data-testid="content" class="h-4 overflow-y-auto">
+	Lorem ipsum dolor sit amet consectetur adipisicing elit. Repudiandae provident non quam,
+	distinctio dolorum sunt sed minus adipisci. Commodi, alias minima! Nisi architecto corrupti quam
+	quisquam totam laborum voluptatem accusantium. Lorem ipsum, dolor sit amet consectetur adipisicing
+	elit. Consectetur excepturi dolore quaerat atque laudantium sapiente reiciendis ipsum quisquam eum
+	officiis corporis iure nam dicta maiores quam, ipsa accusamus obcaecati. Quidem? Lorem ipsum dolor
+	sit amet, consectetur adipisicing elit. Laudantium perspiciatis excepturi eius deleniti laborum
+	vero iure, corporis nihil animi consectetur debitis optio blanditiis quia sed velit, accusamus et,
+	tempora vel.
+</div>


### PR DESCRIPTION
Closes #945 

This PR addresses a bug where the tooltip content would remain open if a user scrolls outside of it, which is unexpected behavior. I've added a listener to the `window` when the content is mounted to handle scroll events that occur outside the content. If the tooltip content is scrollable, we don't close when scrolling that content, only other scroll targets.

I've added tests for this functionality & patched some of the tooltip tests that are currently being skipped to now work. A `setup` test helper for the tooltip tests.  