### PR TITLE
docs: decrease sidebar font size

### DIFF
--- a/src/docs/components/nav/sidebar-nav.svelte
+++ b/src/docs/components/nav/sidebar-nav.svelte
@@ -8,7 +8,7 @@
 	{#each navConfig.sidebarNav as navItem, index (index)}
 		<div>
 			<span
-				class="text-md block whitespace-nowrap rounded-lg border border-transparent px-3 pb-2 text-sm font-semibold uppercase tracking-wider text-zinc-400"
+				class="block whitespace-nowrap rounded-lg border border-transparent px-3 pb-2 text-sm font-semibold uppercase tracking-wider text-zinc-400"
 			>
 				{navItem.title}
 			</span>
@@ -20,8 +20,8 @@
 								<a
 									href={item.href}
 									class={cn(
-										'block whitespace-nowrap rounded-lg border-2 border-transparent px-3 py-2 font-medium capitalize',
-										'hover:bg-magnum-900/25',
+										'block whitespace-nowrap rounded-lg border-2 border-transparent px-2.5 py-1.5 font-medium capitalize',
+										'text-sm hover:bg-magnum-900/25',
 										'data-[active=true]:border-magnum-400 data-[active=true]:bg-magnum-900/50'
 									)}
 									data-active={$page.url.pathname === item.href}


### PR DESCRIPTION
On vertically smaller screen sizes, only a small portion of the sidebar is visible due to the size of the height each nav item takes up.

This PR decreases that size slightly, allowing more items to be visible at a time. 