### PR TITLE
[ToggleGroup] Fix onValueChanged when adding items

### DIFF
--- a/.changeset/spotty-ants-kiss.md
+++ b/.changeset/spotty-ants-kiss.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+ToggleGroup: Fixes curr & next always bbeing the same value

--- a/src/lib/builders/toggle-group/create.ts
+++ b/src/lib/builders/toggle-group/create.ts
@@ -112,8 +112,7 @@ export const createToggleGroup = <T extends ToggleGroupType = 'single'>(
 						if ($value.includes(itemValue)) {
 							return $value.filter((i) => i !== itemValue);
 						}
-						$value.push(itemValue);
-						return $value;
+						return [...$value, itemValue];
 					}
 					return $value === itemValue ? undefined : itemValue;
 				});


### PR DESCRIPTION
The ToggleGroup onValueChanged was not working properly when items were being added. I noticed both the v.curr and v.next values were always the same.

Upon further examination, I noticed that when removing items the v.curr and v.next were correct.

Digging into the code, we can see that when items are removed, a copy of the array is returned, but when an item is added, the same instance of the array is returned.

This fix simply returns a copy of the array when an item is added.

I can confirm my use case of "Set a max to the toggled items" now works perfectly.