### PR TITLE
fix(Toast): use as const` for close element `type` attribute

### DIFF
--- a/.changeset/great-toys-look.md
+++ b/.changeset/great-toys-look.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+Toast: return close element `type` attribute type as `"button"` instead of `string`

--- a/src/lib/builders/toast/create.ts
+++ b/src/lib/builders/toast/create.ts
@@ -192,7 +192,7 @@ export function createToaster<T = object>(props?: CreateToasterProps) {
 	const close = makeElement(name('close'), {
 		returned: () => {
 			return (id: string) => ({
-				type: 'button',
+				type: 'button' as const,
 				'data-id': id,
 			});
 		},


### PR DESCRIPTION
type property on toast close element was returning as string where ts expects `'button' | 'reset' | 'submit' | null | undefined`. Similar to https://github.com/melt-ui/melt-ui/pull/859.

fixes ex:
![image](https://github.com/melt-ui/melt-ui/assets/33409847/4be6bf9c-9258-4bb3-912a-09f76f0d0f89)
