### PR TITLE
fix(Toolbar): set correct tabindex for buttons and links

### DIFF
--- a/.changeset/proud-pigs-pump.md
+++ b/.changeset/proud-pigs-pump.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+Toolbar: set correct tabindex for buttons and links

--- a/src/lib/builders/toolbar/create.ts
+++ b/src/lib/builders/toolbar/create.ts
@@ -48,9 +48,19 @@ export const createToolbar = (props?: CreateToolbarProps) => {
 			({
 				role: 'button',
 				type: 'button',
-				tabIndex: -1,
 			} as const),
 		action: (node: HTMLElement): MeltActionReturn<ToolbarEvents['button']> => {
+			const parentToolbar = node.closest('[data-melt-toolbar]');
+			if (!isHTMLElement(parentToolbar)) return {};
+
+			const items = getToolbarItems(parentToolbar);
+
+			if (items[0] === node) {
+				node.tabIndex = 0;
+			} else {
+				node.tabIndex = -1;
+			}
+
 			const unsub = addMeltEventListener(node, 'keydown', handleKeyDown);
 
 			return {
@@ -63,10 +73,19 @@ export const createToolbar = (props?: CreateToolbarProps) => {
 		returned: () =>
 			({
 				role: 'link',
-				'data-melt-toolbar-item': '',
-				tabIndex: -1,
 			} as const),
 		action: (node: HTMLElement): MeltActionReturn<ToolbarEvents['link']> => {
+			const parentToolbar = node.closest('[data-melt-toolbar]');
+			if (!isHTMLElement(parentToolbar)) return {};
+
+			const items = getToolbarItems(parentToolbar);
+
+			if (items[0] === node) {
+				node.tabIndex = 0;
+			} else {
+				node.tabIndex = -1;
+			}
+
 			const unsub = addMeltEventListener(node, 'keydown', handleKeyDown);
 
 			return {
@@ -226,7 +245,7 @@ export const createToolbar = (props?: CreateToolbarProps) => {
 
 	function getToolbarItems(element: HTMLElement) {
 		return Array.from(
-			element.querySelectorAll(`${selector('item')}, ${selector('button')}`)
+			element.querySelectorAll(`${selector('item')}, ${selector('button')}, ${selector('link')}`)
 		).filter((el): el is HTMLElement => isHTMLElement(el));
 	}
 
@@ -250,9 +269,7 @@ export const createToolbar = (props?: CreateToolbarProps) => {
 		const root = el.closest('[data-melt-toolbar]');
 		if (!isHTMLElement(root)) return;
 
-		const items = Array.from(
-			root.querySelectorAll(`${selector('item')}, ${selector('button')}`)
-		).filter((el): el is HTMLElement => isHTMLElement(el));
+		const items = getToolbarItems(root);
 
 		const currentIndex = items.indexOf(el);
 

--- a/src/lib/builders/toolbar/create.ts
+++ b/src/lib/builders/toolbar/create.ts
@@ -50,16 +50,7 @@ export const createToolbar = (props?: CreateToolbarProps) => {
 				type: 'button',
 			} as const),
 		action: (node: HTMLElement): MeltActionReturn<ToolbarEvents['button']> => {
-			const parentToolbar = node.closest('[data-melt-toolbar]');
-			if (!isHTMLElement(parentToolbar)) return {};
-
-			const items = getToolbarItems(parentToolbar);
-
-			if (items[0] === node) {
-				node.tabIndex = 0;
-			} else {
-				node.tabIndex = -1;
-			}
+			setNodeTabIndex(node);
 
 			const unsub = addMeltEventListener(node, 'keydown', handleKeyDown);
 
@@ -75,16 +66,7 @@ export const createToolbar = (props?: CreateToolbarProps) => {
 				role: 'link',
 			} as const),
 		action: (node: HTMLElement): MeltActionReturn<ToolbarEvents['link']> => {
-			const parentToolbar = node.closest('[data-melt-toolbar]');
-			if (!isHTMLElement(parentToolbar)) return {};
-
-			const items = getToolbarItems(parentToolbar);
-
-			if (items[0] === node) {
-				node.tabIndex = 0;
-			} else {
-				node.tabIndex = -1;
-			}
+			setNodeTabIndex(node);
 
 			const unsub = addMeltEventListener(node, 'keydown', handleKeyDown);
 
@@ -168,6 +150,8 @@ export const createToolbar = (props?: CreateToolbarProps) => {
 				};
 			},
 			action: (node: HTMLElement): MeltActionReturn<ToolbarEvents['item']> => {
+				setNodeTabIndex(node);
+
 				function getNodeProps() {
 					const itemValue = node.dataset.value;
 					const disabled = node.dataset.disabled === 'true';
@@ -189,17 +173,6 @@ export const createToolbar = (props?: CreateToolbarProps) => {
 						}
 						return $value === itemValue ? undefined : itemValue;
 					});
-				}
-
-				const parentToolbar = node.closest('[data-melt-toolbar]');
-				if (!isHTMLElement(parentToolbar)) return {};
-
-				const items = getToolbarItems(parentToolbar);
-
-				if (items[0] === node) {
-					node.tabIndex = 0;
-				} else {
-					node.tabIndex = -1;
 				}
 
 				const unsub = executeCallbacks(
@@ -242,12 +215,6 @@ export const createToolbar = (props?: CreateToolbarProps) => {
 			options,
 		};
 	};
-
-	function getToolbarItems(element: HTMLElement) {
-		return Array.from(
-			element.querySelectorAll(`${selector('item')}, ${selector('button')}, ${selector('link')}`)
-		).filter((el): el is HTMLElement => isHTMLElement(el));
-	}
 
 	function handleKeyDown(e: KeyboardEvent) {
 		const $orientation = orientation.get();
@@ -311,3 +278,30 @@ export const createToolbar = (props?: CreateToolbarProps) => {
 		options,
 	};
 };
+
+/**
+ * Sets the appropriate tabIndex for the node based on its position in the
+ * parent toolbar.
+ */
+function setNodeTabIndex(node: HTMLElement) {
+	const parentToolbar = node.closest('[data-melt-toolbar]');
+
+	if (!isHTMLElement(parentToolbar)) return;
+
+	const items = getToolbarItems(parentToolbar);
+
+	if (items[0] === node) {
+		node.tabIndex = 0;
+	} else {
+		node.tabIndex = -1;
+	}
+}
+
+/**
+ * Returns an array of all toolbar items within the given element.
+ */
+function getToolbarItems(element: HTMLElement) {
+	return Array.from(
+		element.querySelectorAll(`${selector('item')}, ${selector('button')}, ${selector('link')}`)
+	).filter((el): el is HTMLElement => isHTMLElement(el));
+}

--- a/src/tests/toolbar/ToolbarTest.svelte
+++ b/src/tests/toolbar/ToolbarTest.svelte
@@ -25,6 +25,10 @@
 		value: undefined,
 	};
 
+	export let linksFirst = false;
+	export let buttonsFirst = false;
+	export let linksButtonsOnly = false;
+
 	const {
 		elements: { root, button, link, separator },
 		builders: { createToolbarGroup },
@@ -44,19 +48,31 @@
 
 <main>
 	<div use:melt={$root} data-testid="root">
-		<div use:melt={$fontGroup} data-testid="group-1">
-			<button use:melt={$fontItem('item-1')} data-testid="item-1"> item-1 </button>
-			<button use:melt={$fontItem('item-2')} data-testid="item-2"> item-2 </button>
-			<button use:melt={$fontItem('item-3')} data-testid="item-3"> item-3 </button>
-		</div>
-		<div use:melt={$separator} />
-		<div use:melt={$alignGroup} data-testid="group-2">
-			<button use:melt={$alignItem('item-4')} data-testid="item-4"> item-4 </button>
-			<button use:melt={$alignItem('item-5')} data-testid="item-5"> item-5 </button>
-			<button use:melt={$alignItem('item-6')} data-testid="item-6"> item-6</button>
-		</div>
-		<div use:melt={$separator} />
-		<a href="/" use:melt={$link} data-testid="link-1"> link-1 </a>
-		<button use:melt={$button} data-testid="button-1">button-1</button>
+		{#if linksFirst}
+			<a href="/" use:melt={$link} data-testid="link-1"> link-1 </a>
+		{/if}
+		{#if buttonsFirst}
+			<button use:melt={$button} data-testid="button-1"> button-1 </button>
+		{/if}
+		{#if !linksButtonsOnly}
+			<div use:melt={$fontGroup} data-testid="group-1">
+				<button use:melt={$fontItem('item-1')} data-testid="item-1"> item-1 </button>
+				<button use:melt={$fontItem('item-2')} data-testid="item-2"> item-2 </button>
+				<button use:melt={$fontItem('item-3')} data-testid="item-3"> item-3 </button>
+			</div>
+			<div use:melt={$separator} />
+			<div use:melt={$alignGroup} data-testid="group-2">
+				<button use:melt={$alignItem('item-4')} data-testid="item-4"> item-4 </button>
+				<button use:melt={$alignItem('item-5')} data-testid="item-5"> item-5 </button>
+				<button use:melt={$alignItem('item-6')} data-testid="item-6"> item-6</button>
+			</div>
+			<div use:melt={$separator} />
+		{/if}
+		{#if !linksFirst}
+			<a href="/" use:melt={$link} data-testid="link-1"> link-1 </a>
+		{/if}
+		{#if !buttonsFirst}
+			<button use:melt={$button} data-testid="button-1"> button-1 </button>
+		{/if}
 	</div>
 </main>


### PR DESCRIPTION
At present, the tabindex attribute of toolbar items is initialized only for group items, never for simple buttons or links.

As a result, when there is no group item, or the first item is a button/link, the toolbar becomes inaccessible by keyboard navigation.

This patch fixes the problem and introduces a comprehensive suite of regression tests, both by changing the order of items and by removing group items entirely.