### PR TITLE
fix: interact outside transition out bug during unmounting  #1005

### DIFF
--- a/.changeset/silver-rivers-draw.md
+++ b/.changeset/silver-rivers-draw.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+Fixed bug where on outside interaction in several components (popover, menu, link preview, tooltip, listbox), on component unmount, the content jumps during out transition if content was mounted in an else if block

--- a/.changeset/silver-rivers-draw.md
+++ b/.changeset/silver-rivers-draw.md
@@ -2,4 +2,4 @@
 '@melt-ui/svelte': patch
 ---
 
-Fixed bug where on outside interaction in several components (popover, menu, link preview, tooltip, listbox), on component unmount, the content jumps during out transition if content was mounted in an else if block
+Fixed bug where on outside interaction in several components (popover, menu, link preview, tooltip, listbox), on component unmount, the content jumps during out transition if content was mounted in an else if block (closes #1005)

--- a/src/lib/builders/link-preview/create.ts
+++ b/src/lib/builders/link-preview/create.ts
@@ -196,7 +196,8 @@ export function createLinkPreview(props: CreateLinkPreviewProps = {}) {
 							floating: $positioning,
 							modal: {
 								closeOnInteractOutside: $closeOnOutsideClick,
-								onClose: () => {
+								onClose: async () => {
+									await sleep(0);
 									open.set(false);
 									$activeTrigger.focus();
 								},

--- a/src/lib/builders/listbox/create.ts
+++ b/src/lib/builders/listbox/create.ts
@@ -32,6 +32,7 @@ import {
 	prev,
 	removeHighlight,
 	removeScroll,
+	sleep,
 	stripValues,
 	styleToString,
 	toWritableStores,
@@ -226,7 +227,8 @@ export function createListbox<
 	}
 
 	/** Closes the menu & clears the active trigger */
-	function closeMenu() {
+	async function closeMenu() {
+		await sleep(0);
 		open.set(false);
 		highlightedItem.set(null);
 	}

--- a/src/lib/builders/menu/create.ts
+++ b/src/lib/builders/menu/create.ts
@@ -205,7 +205,8 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 										}
 										return true;
 									},
-									onClose: () => {
+									onClose: async () => {
+										await sleep(0);
 										rootOpen.set(false);
 										$rootActiveTrigger.focus();
 									},

--- a/src/lib/builders/popover/create.ts
+++ b/src/lib/builders/popover/create.ts
@@ -18,6 +18,7 @@ import {
 	styleToString,
 	toWritableStores,
 	portalAttr,
+	sleep,
 } from '$lib/internal/helpers/index.js';
 
 import { usePopper, type InteractOutsideEvent } from '$lib/internal/actions/index.js';
@@ -82,7 +83,8 @@ export function createPopover(args?: CreatePopoverProps) {
 		activeTrigger.set(document.getElementById(ids.trigger.get()));
 	});
 
-	function handleClose() {
+	async function handleClose() {
+		await sleep(0);
 		open.set(false);
 		const triggerEl = document.getElementById(ids.trigger.get());
 		handleFocus({ prop: closeFocus.get(), defaultEl: triggerEl });

--- a/src/lib/builders/tooltip/create.ts
+++ b/src/lib/builders/tooltip/create.ts
@@ -27,6 +27,7 @@ import { derived, writable, type Writable } from 'svelte/store';
 import { generateIds } from '../../internal/helpers/id.js';
 import type { TooltipEvents } from './events.js';
 import type { CreateTooltipProps } from './types.js';
+import { onDestroy } from 'svelte';
 
 const defaults = {
 	positioning: {
@@ -125,9 +126,13 @@ export function createTooltip(props?: CreateTooltipProps) {
 				openReason.set(null);
 				if (isBlur) clickedTrigger = false;
 				closeTimeout = null;
-			}, closeDelay.get());
+			}, Math.max(closeDelay.get(), 50));
 		}
 	}
+
+	onDestroy(() => {
+		if (closeTimeout) clearTimeout(closeTimeout);
+	});
 
 	const isVisible = derived([open, forceVisible], ([$open, $forceVisible]) => {
 		return $open || $forceVisible;

--- a/src/lib/builders/tooltip/create.ts
+++ b/src/lib/builders/tooltip/create.ts
@@ -19,6 +19,7 @@ import {
 	styleToString,
 	toWritableStores,
 	portalAttr,
+	sleep,
 } from '$lib/internal/helpers/index.js';
 
 import { useFloating, usePortal } from '$lib/internal/actions/index.js';
@@ -27,7 +28,6 @@ import { derived, writable, type Writable } from 'svelte/store';
 import { generateIds } from '../../internal/helpers/id.js';
 import type { TooltipEvents } from './events.js';
 import type { CreateTooltipProps } from './types.js';
-import { onDestroy } from 'svelte';
 
 const defaults = {
 	positioning: {
@@ -126,13 +126,9 @@ export function createTooltip(props?: CreateTooltipProps) {
 				openReason.set(null);
 				if (isBlur) clickedTrigger = false;
 				closeTimeout = null;
-			}, Math.max(closeDelay.get(), 50));
+			}, closeDelay.get());
 		}
 	}
-
-	onDestroy(() => {
-		if (closeTimeout) clearTimeout(closeTimeout);
-	});
 
 	const isVisible = derived([open, forceVisible], ([$open, $forceVisible]) => {
 		return $open || $forceVisible;
@@ -185,7 +181,10 @@ export function createTooltip(props?: CreateTooltipProps) {
 					if (clickedTrigger) return;
 					openTooltip('focus');
 				}),
-				addMeltEventListener(node, 'blur', () => closeTooltip(true)),
+				addMeltEventListener(node, 'blur', async () => {
+					await sleep(0);
+					closeTooltip(true);
+				}),
 				addMeltEventListener(node, 'keydown', keydownHandler),
 				addEventListener(document, 'keydown', keydownHandler)
 			);


### PR DESCRIPTION
closes #1005, https://github.com/huntabyte/bits-ui/issues/340

The following issue applies to the following components:

- popover
- menu
- date range picker
- date picker
- link preview--activated by keyboard
- tooltip--activated by keyboard
- combobox
- select

In the instance of the popover, if we mount the content using else if condition blocks and have an out transition on the content, if you click outside the content and if that triggers an unmount from a parent component (i.e. clicking on a link that unmounts the page), the out transition plays while the content jumps to the top left of the page.

https://github.com/melt-ui/melt-ui/assets/53095479/b3494fd6-64f4-4140-9244-6cbd22cc86ed

This only happens if the content is in an **else if** block, for example:

```svelte
{#if $open && asChild}
	<slot {content} />
{:else if $open}
	<div use:melt={$content} transition:scale>
		...
	</div>
{/if}
```

So if you mount the content in an if block, this issue doesn't happen.

```svelte
{#if $open}
	<div use:melt={$content} transition:scale>...</div>
{/if}
```

My speculation here is that when you click on an element outside the content that happens to also unmount the whole component, the `interactOutSide` function gets executed and sets the `open` store to `false`, and for some reason the else if block that contains the content gets rerendered and starts the out transition before svelte unmounts the component. 

So then when svelte unmounts the component, it unmounts the trigger, while the content is still being transitioned out, and so the content jumps to the top left of the page because it lost its anchor.

I tried adding test cases but couldn't reproduce this issue in the testing environment.

Here are videos showing the issue happening with the components listed at the top

### Menu Before
https://github.com/melt-ui/melt-ui/assets/53095479/d575e786-1d72-4ea9-a343-1693fbc6d503

### Menu After

https://github.com/melt-ui/melt-ui/assets/53095479/5b020e6b-536b-4939-8322-08e2f41bab16



### Date Range Picker Before - (the issue lies with the popover)

https://github.com/melt-ui/melt-ui/assets/53095479/eb3ba583-0ce2-4ff0-bd39-6dec349b34d4

### Date Range Picker After

https://github.com/melt-ui/melt-ui/assets/53095479/29fc771d-32e9-49d8-bdaf-bfa72d33f636



### Date Picker Before - (the issue lies with the popover)

https://github.com/melt-ui/melt-ui/assets/53095479/5c5ef414-b969-4ff0-b20a-75f2647a0b9f

### Date Picker After


https://github.com/melt-ui/melt-ui/assets/53095479/4ee7c40d-f42e-4eab-a2d9-24f1173724a6


### link preview before - (when opened using the keyboard)

https://github.com/melt-ui/melt-ui/assets/53095479/862aa170-5235-43f0-a796-28ba9c7209b4

### link preview after

https://github.com/melt-ui/melt-ui/assets/53095479/c1e9ff16-642b-4e4c-bc16-f4886c7b7ceb



### tooltip before  - (when opened using the keyboard)

https://github.com/melt-ui/melt-ui/assets/53095479/bdd83e10-f44a-4340-a87a-4db8179ac49e

### tooltip after


https://github.com/melt-ui/melt-ui/assets/53095479/d34ed854-3fd0-476b-9f3a-ad2531513c4b


### Popover Before

https://github.com/melt-ui/melt-ui/assets/53095479/44aacbba-94e4-42b4-a4e1-284ede2dad5d

### Popover After

https://github.com/melt-ui/melt-ui/assets/53095479/85e0998a-684e-4ac6-b01c-5d6e62645dd9



### select before - could not reproduce using only melt. could reproduce with bits-ui, and it was fixed when I changed the logic in melt
https://github.com/huntabyte/bits-ui/assets/53095479/6534e48a-cfd7-460b-8f76-22cdf53a90be

### select after

https://github.com/melt-ui/melt-ui/assets/53095479/98ddab75-a44f-4ee3-91b6-9c3e49c291ab



### combobox before - could not reproduce using only melt. could reproduce with bits-ui, and it was fixed when I changed the logic in melt

https://github.com/huntabyte/bits-ui/assets/53095479/d61869fe-8a99-429b-b020-77781217a451

### combobox after

https://github.com/melt-ui/melt-ui/assets/53095479/39f4772e-6138-4436-911d-c56a61a7430e

### Reproduction

https://melt-interact-outside-out-transition-bug.vercel.app/

https://github.com/anatolzak/melt-interact-outside-out-transition-bug