### PR TITLE
fix(docs): tooltip transition

### DIFF
--- a/src/docs/components/tooltip.svelte
+++ b/src/docs/components/tooltip.svelte
@@ -36,7 +36,7 @@
 	[data-melt-tooltip-content] {
 		opacity: 0;
 		visibility: hidden;
-		transition: 150ms ease;
+		transition: opacity 150ms ease;
 
 		&[data-open] {
 			opacity: 1;


### PR DESCRIPTION
This issue is that the tooltip content transitions all properties which includes the `left` css property, so when the content is opened or closed, and because we don't unmount the tooltip content, the content starts as visually hidden and is placed on the left side of the page, and then gets transitioned from the initial position to the trigger position.

This is easily solved by only transitioning `opacity`. 

On a different note, I find it odd that when the content is closed but not unmounted, that it has the same `top` value as when it was mounted, but it resets the `left` value. 

Before

https://github.com/melt-ui/melt-ui/assets/53095479/b87e5566-afb9-4dd3-862a-94f7813bcee7

After

https://github.com/melt-ui/melt-ui/assets/53095479/66b6b39a-db7f-4ca5-90e7-0a2485dd130e

