### PR TITLE
fix(docs): improved mounted tooltip content performance during scroll

### DIFF
--- a/src/docs/components/tooltip.svelte
+++ b/src/docs/components/tooltip.svelte
@@ -8,6 +8,9 @@
 	} = createTooltip({
 		forceVisible: true,
 		openDelay: 500,
+		positioning: {
+			strategy: 'fixed',
+		},
 	});
 
 	export let text = 'Tooltip text';


### PR DESCRIPTION
The tooltip used in the docs is always mounted, and since the positioning strategy is by default `absolute`, whenever you scroll, the tooltip content position gets recalculated. This can be easily avoided by setting positioning strategy to `fixed`

### Before

https://github.com/melt-ui/melt-ui/assets/53095479/cc79cffb-6276-4b77-b31a-2def324b93be

### After


https://github.com/melt-ui/melt-ui/assets/53095479/4c77059c-eefb-4e76-b1a1-67b450e3bf99
