### PR TITLE
fix: portal & outside interactions (the right way)

### DIFF
--- a/.changeset/large-countries-laugh.md
+++ b/.changeset/large-countries-laugh.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+fixed issues with portals and outside interactions (Closes #992)

--- a/src/lib/builders/dialog/create.ts
+++ b/src/lib/builders/dialog/create.ts
@@ -17,6 +17,7 @@ import {
 	removeScroll,
 	styleToString,
 	toWritableStores,
+	portalAttr,
 } from '$lib/internal/helpers/index.js';
 import { withGet } from '$lib/internal/helpers/withGet.js';
 import type { Defaults, MeltActionReturn } from '$lib/internal/types.js';
@@ -42,7 +43,7 @@ const defaults = {
 	closeOnOutsideClick: true,
 	role: 'dialog',
 	defaultOpen: false,
-	portal: 'body',
+	portal: undefined,
 	forceVisible: false,
 	openFocus: undefined,
 	closeFocus: undefined,
@@ -256,11 +257,11 @@ export function createDialog(props?: CreateDialogProps) {
 	const portalled = makeElement(name('portalled'), {
 		stores: portal,
 		returned: ($portal) => ({
-			'data-portal': $portal ? '' : undefined,
+			'data-portal': portalAttr($portal),
 		}),
 		action: (node: HTMLElement) => {
 			const unsubPortal = effect([portal], ([$portal]) => {
-				if (!$portal) return noop;
+				if ($portal === null) return noop;
 				const portalDestination = getPortalDestination(node, $portal);
 				if (portalDestination === null) return noop;
 				const portalAction = usePortal(node, portalDestination);

--- a/src/lib/builders/link-preview/create.ts
+++ b/src/lib/builders/link-preview/create.ts
@@ -42,7 +42,7 @@ const defaults = {
 	arrowSize: 8,
 	closeOnOutsideClick: true,
 	forceVisible: false,
-	portal: 'body',
+	portal: undefined,
 	closeOnEscape: true,
 	onOutsideClick: undefined,
 } satisfies CreateLinkPreviewProps;

--- a/src/lib/builders/link-preview/create.ts
+++ b/src/lib/builders/link-preview/create.ts
@@ -18,6 +18,7 @@ import {
 	sleep,
 	styleToString,
 	toWritableStores,
+	portalAttr,
 } from '$lib/internal/helpers/index.js';
 import { safeOnMount } from '$lib/internal/helpers/lifecycle.js';
 import { withGet, type WithGet } from '$lib/internal/helpers/withGet.js';
@@ -161,7 +162,7 @@ export function createLinkPreview(props: CreateLinkPreviewProps = {}) {
 				}),
 				id: $contentId,
 				'data-state': $isVisible ? 'open' : 'closed',
-				'data-portal': $portal ? '' : undefined,
+				'data-portal': portalAttr($portal),
 			};
 		},
 		action: (node: HTMLElement): MeltActionReturn<LinkPreviewEvents['content']> => {
@@ -193,24 +194,21 @@ export function createLinkPreview(props: CreateLinkPreviewProps = {}) {
 						open: open,
 						options: {
 							floating: $positioning,
-							clickOutside: $closeOnOutsideClick
-								? {
-										handler: async (e) => {
-											await sleep(0);
-
-											onOutsideClick.get()?.(e);
-											if (e.defaultPrevented) return;
-
-											if (
-												isHTMLElement($activeTrigger) &&
-												!$activeTrigger.contains(e.target as Element)
-											) {
-												open.set(false);
-												$activeTrigger.focus();
-											}
-										},
-								  }
-								: null,
+							modal: {
+								closeOnInteractOutside: $closeOnOutsideClick,
+								onClose: () => {
+									open.set(false);
+									$activeTrigger.focus();
+								},
+								shouldCloseOnInteractOutside: (e) => {
+									onOutsideClick.get()?.(e);
+									if (e.defaultPrevented) return false;
+									if (isHTMLElement($activeTrigger) && $activeTrigger.contains(e.target as Element))
+										return false;
+									return true;
+								},
+								open: $isVisible,
+							},
 							portal: getPortalDestination(node, $portal),
 							focusTrap: null,
 							escapeKeydown: $closeOnEscape ? undefined : null,

--- a/src/lib/builders/link-preview/types.ts
+++ b/src/lib/builders/link-preview/types.ts
@@ -1,4 +1,4 @@
-import type { FloatingConfig } from '$lib/internal/actions/index.js';
+import type { FloatingConfig, InteractOutsideEvent } from '$lib/internal/actions/index.js';
 import type { ChangeFn, IdObj } from '$lib/internal/helpers/index.js';
 import type { BuilderReturn } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
@@ -63,7 +63,7 @@ export type CreateLinkPreviewProps = {
 	 * If `event.preventDefault()` is called within the function,
 	 * the dialog will not close when the user clicks outside of it.
 	 */
-	onOutsideClick?: (event: PointerEvent) => void;
+	onOutsideClick?: (event: InteractOutsideEvent) => void;
 
 	/**
 	 * Whether or not to close the linkpreview when the escape key is pressed

--- a/src/lib/builders/listbox/create.ts
+++ b/src/lib/builders/listbox/create.ts
@@ -489,22 +489,24 @@ export function createListbox<
 							options: {
 								floating: $positioning,
 								focusTrap: null,
-								clickOutside: $closeOnOutsideClick
-									? {
-											handler: (e) => {
-												onOutsideClick.get()?.(e);
-												if (e.defaultPrevented) return;
+								modal: {
+									closeOnInteractOutside: $closeOnOutsideClick,
+									onClose: closeMenu,
+									open: $isVisible,
+									shouldCloseOnInteractOutside: (e) => {
+										onOutsideClick.get()?.(e);
+										if (e.defaultPrevented) return false;
+										const target = e.target;
+										if (!isElement(target)) return false;
+										if (target === $activeTrigger || $activeTrigger.contains(target)) {
+											return false;
+										}
+										// return opposite of the result of the ignoreHandler
+										if (ignoreHandler(e)) return false;
+										return true;
+									},
+								},
 
-												const target = e.target;
-												if (!isElement(target)) return;
-												if (target === $activeTrigger || $activeTrigger.contains(target)) {
-													return;
-												}
-												closeMenu();
-											},
-											ignore: ignoreHandler,
-									  }
-									: null,
 								escapeKeydown: null,
 								portal: getPortalDestination(node, $portal),
 							},

--- a/src/lib/builders/listbox/types.ts
+++ b/src/lib/builders/listbox/types.ts
@@ -1,4 +1,4 @@
-import type { FloatingConfig } from '$lib/internal/actions/index.js';
+import type { FloatingConfig, InteractOutsideEvent } from '$lib/internal/actions/index.js';
 import type { ChangeFn, IdObj } from '$lib/internal/helpers/index.js';
 import type { BuilderReturn, WhenTrue } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
@@ -117,7 +117,7 @@ export type CreateListboxProps<
 	 * If `event.preventDefault()` is called within the function,
 	 * the dialog will not close when the user clicks outside of it.
 	 */
-	onOutsideClick?: (event: PointerEvent) => void;
+	onOutsideClick?: (event: InteractOutsideEvent) => void;
 
 	/**
 	 * Whether or not to prevent scrolling the page when the

--- a/src/lib/builders/menu/create.ts
+++ b/src/lib/builders/menu/create.ts
@@ -31,6 +31,7 @@ import {
 	sleep,
 	styleToString,
 	toWritableStores,
+	portalAttr,
 } from '$lib/internal/helpers/index.js';
 import type { Defaults, MeltActionReturn, TextDirection } from '$lib/internal/types.js';
 import { tick } from 'svelte';
@@ -70,7 +71,7 @@ const defaults = {
 	preventScroll: true,
 	closeOnEscape: true,
 	closeOnOutsideClick: true,
-	portal: 'body',
+	portal: undefined,
 	loop: false,
 	dir: 'ltr',
 	defaultOpen: false,
@@ -164,7 +165,7 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 				id: $rootMenuId,
 				'aria-labelledby': $rootTriggerId,
 				'data-state': $isVisible ? 'open' : 'closed',
-				'data-portal': $portal ? '' : undefined,
+				'data-portal': portalAttr($portal),
 				tabindex: -1,
 			} as const;
 		},
@@ -190,24 +191,26 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 							open: rootOpen,
 							options: {
 								floating: $positioning,
-								clickOutside: $closeOnOutsideClick
-									? {
-											handler: async (e) => {
-												await sleep(0);
+								modal: {
+									closeOnInteractOutside: $closeOnOutsideClick,
+									shouldCloseOnInteractOutside: (e) => {
+										onOutsideClick.get()?.(e);
+										if (e.defaultPrevented) return false;
 
-												onOutsideClick.get()?.(e);
-												if (e.defaultPrevented) return;
-
-												if (
-													isHTMLElement($rootActiveTrigger) &&
-													!$rootActiveTrigger.contains(e.target as Element)
-												) {
-													rootOpen.set(false);
-													$rootActiveTrigger.focus();
-												}
-											},
-									  }
-									: null,
+										if (
+											isHTMLElement($rootActiveTrigger) &&
+											$rootActiveTrigger.contains(e.target as Element)
+										) {
+											return false;
+										}
+										return true;
+									},
+									onClose: () => {
+										rootOpen.set(false);
+										$rootActiveTrigger.focus();
+									},
+									open: $isVisible,
+								},
 								portal: getPortalDestination(node, $portal),
 								escapeKeydown: $closeOnEscape ? undefined : null,
 							},
@@ -747,7 +750,7 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 								options: {
 									floating: $positioning,
 									portal: isHTMLElement(parentMenuEl) ? parentMenuEl : undefined,
-									clickOutside: null,
+									modal: null,
 									focusTrap: null,
 									escapeKeydown: null,
 								},

--- a/src/lib/builders/menu/types.ts
+++ b/src/lib/builders/menu/types.ts
@@ -1,4 +1,4 @@
-import type { FloatingConfig } from '$lib/internal/actions/index.js';
+import type { FloatingConfig, InteractOutsideEvent } from '$lib/internal/actions/index.js';
 import type { TextDirection } from '$lib/internal/types.js';
 import type { ChangeFn, FocusProp, IdObj } from '$lib/internal/helpers/index.js';
 import type { Writable } from 'svelte/store';
@@ -67,7 +67,7 @@ export type _CreateMenuProps = {
 	 * If `event.preventDefault()` is called within the function,
 	 * the dialog will not close when the user clicks outside of it.
 	 */
-	onOutsideClick?: (event: PointerEvent) => void;
+	onOutsideClick?: (event: InteractOutsideEvent) => void;
 
 	/**
 	 * Whether or not to loop the menu navigation.
@@ -190,7 +190,7 @@ export type _MenuBuilderOptions = {
 		closeFocus: WithGet<Writable<FocusProp | undefined>>;
 		disableFocusFirstItem: WithGet<Writable<boolean>>;
 		closeOnItemClick: WithGet<Writable<boolean>>;
-		onOutsideClick: WithGet<Writable<((event: PointerEvent) => void) | undefined>>;
+		onOutsideClick: WithGet<Writable<((event: InteractOutsideEvent) => void) | undefined>>;
 	};
 
 	nextFocusable: WithGet<Writable<HTMLElement | null>>;

--- a/src/lib/builders/menubar/create.ts
+++ b/src/lib/builders/menubar/create.ts
@@ -25,6 +25,7 @@ import {
 	removeScroll,
 	styleToString,
 	toWritableStores,
+	portalAttr,
 } from '$lib/internal/helpers/index.js';
 import { safeOnDestroy, safeOnMount } from '$lib/internal/helpers/lifecycle.js';
 import type { MeltActionReturn } from '$lib/internal/types.js';
@@ -148,7 +149,7 @@ export function createMenubar(props?: CreateMenubarProps) {
 					'aria-labelledby': $triggerId,
 					'data-state': $isVisible ? 'open' : 'closed',
 					'data-melt-scope': $menubarId,
-					'data-portal': $portal ? '' : undefined,
+					'data-portal': portalAttr($portal),
 					tabindex: -1,
 				} as const;
 			},
@@ -168,21 +169,22 @@ export function createMenubar(props?: CreateMenubarProps) {
 								options: {
 									floating: $positioning,
 									portal: getPortalDestination(node, $portal),
-									clickOutside: $closeOnOutsideClick
-										? {
-												ignore: (e) => {
-													const target = e.target;
-													const menubarEl = document.getElementById(ids.menubar.get());
-													if (!menubarEl || !isElement(target)) return false;
-													return menubarEl.contains(target);
-												},
-												handler: (e) => {
-													onOutsideClick.get()?.(e);
-													if (e.defaultPrevented) return;
-													activeMenu.set('');
-												},
-										  }
-										: null,
+									modal: {
+										closeOnInteractOutside: $closeOnOutsideClick,
+										shouldCloseOnInteractOutside: (e) => {
+											onOutsideClick.get()?.(e);
+											if (e.defaultPrevented) return false;
+											const target = e.target;
+											const menubarEl = document.getElementById(ids.menubar.get());
+											if (!menubarEl || !isElement(target)) return true;
+											if (menubarEl.contains(target)) return false;
+											return true;
+										},
+										onClose: () => {
+											activeMenu.set('');
+										},
+										open: $rootOpen,
+									},
 								},
 							});
 

--- a/src/lib/builders/popover/create.ts
+++ b/src/lib/builders/popover/create.ts
@@ -18,9 +18,10 @@ import {
 	styleToString,
 	toWritableStores,
 	sleep,
+	portalAttr,
 } from '$lib/internal/helpers/index.js';
 
-import { usePopper } from '$lib/internal/actions/index.js';
+import { usePopper, type InteractOutsideEvent } from '$lib/internal/actions/index.js';
 import { safeOnMount } from '$lib/internal/helpers/lifecycle.js';
 import type { Defaults, MeltActionReturn } from '$lib/internal/types.js';
 import { tick } from 'svelte';
@@ -102,7 +103,7 @@ export function createPopover(args?: CreatePopoverProps) {
 				}),
 				id: $contentId,
 				'data-state': $isVisible ? 'open' : 'closed',
-				'data-portal': $portal ? '' : undefined,
+				'data-portal': portalAttr($portal),
 			};
 		},
 		action: (node: HTMLElement) => {
@@ -142,11 +143,12 @@ export function createPopover(args?: CreatePopoverProps) {
 										clickOutsideDeactivates: true,
 										escapeDeactivates: true,
 								  },
-							clickOutside: $closeOnOutsideClick
-								? {
-										handler: handleClickOutside,
-								  }
-								: null,
+							modal: {
+								shouldCloseOnInteractOutside: shouldCloseOnInteractOutside,
+								onClose: handleClose,
+								open: $isVisible,
+								closeOnInteractOutside: $closeOnOutsideClick,
+							},
 							escapeKeydown: $closeOnEscape
 								? {
 										handler: () => {
@@ -181,17 +183,16 @@ export function createPopover(args?: CreatePopoverProps) {
 			activeTrigger.set(triggerEl);
 		}
 	}
-
-	function handleClickOutside(e: PointerEvent) {
+	function shouldCloseOnInteractOutside(e: InteractOutsideEvent) {
 		onOutsideClick.get()?.(e);
-		if (e.defaultPrevented) return;
+		if (e.defaultPrevented) return false;
 		const target = e.target;
 		const triggerEl = document.getElementById(ids.trigger.get());
 
 		if (triggerEl && isElement(target)) {
-			if (target === triggerEl || triggerEl.contains(target)) return;
+			if (target === triggerEl || triggerEl.contains(target)) return false;
 		}
-		handleClose();
+		return true;
 	}
 
 	const trigger = makeElement(name('trigger'), {

--- a/src/lib/builders/popover/types.ts
+++ b/src/lib/builders/popover/types.ts
@@ -1,4 +1,4 @@
-import type { FloatingConfig } from '$lib/internal/actions/index.js';
+import type { FloatingConfig, InteractOutsideEvent } from '$lib/internal/actions/index.js';
 import type { ChangeFn, FocusProp, IdObj } from '$lib/internal/helpers/index.js';
 import type { BuilderReturn } from '$lib/internal/types.js';
 import type { Writable } from 'svelte/store';
@@ -66,7 +66,7 @@ export type CreatePopoverProps = {
 	 * If `event.preventDefault()` is called within the function,
 	 * the dialog will not close when the user clicks outside of it.
 	 */
-	onOutsideClick?: (event: PointerEvent) => void;
+	onOutsideClick?: (event: InteractOutsideEvent) => void;
 
 	/**
 	 * Whether or not to prevent scrolling when the popover is open.

--- a/src/lib/builders/tooltip/create.ts
+++ b/src/lib/builders/tooltip/create.ts
@@ -226,7 +226,7 @@ export function createTooltip(props?: CreateTooltipProps) {
 
 					const floatingReturn = useFloating(triggerEl, node, $positioning);
 					unsubFloating = floatingReturn.destroy;
-					if (!$portal) {
+					if ($portal === null) {
 						unsubPortal();
 						return;
 					}

--- a/src/lib/builders/tooltip/create.ts
+++ b/src/lib/builders/tooltip/create.ts
@@ -19,6 +19,7 @@ import {
 	styleToString,
 	toWritableStores,
 	sleep,
+	portalAttr,
 } from '$lib/internal/helpers/index.js';
 
 import { useFloating, usePortal } from '$lib/internal/actions/index.js';
@@ -205,7 +206,7 @@ export function createTooltip(props?: CreateTooltipProps) {
 					display: $isVisible ? undefined : 'none',
 				}),
 				id: $contentId,
-				'data-portal': $portal ? '' : undefined,
+				'data-portal': portalAttr($portal),
 				'data-state': $open ? 'open' : 'closed',
 			};
 		},

--- a/src/lib/builders/tooltip/create.ts
+++ b/src/lib/builders/tooltip/create.ts
@@ -39,7 +39,7 @@ const defaults = {
 	openDelay: 1000,
 	closeDelay: 0,
 	forceVisible: false,
-	portal: 'body',
+	portal: undefined,
 	closeOnEscape: true,
 	disableHoverableContent: false,
 	group: undefined,

--- a/src/lib/internal/actions/modal/action.ts
+++ b/src/lib/internal/actions/modal/action.ts
@@ -33,6 +33,7 @@ export function useModal(node: HTMLElement, config: ModalConfig) {
 			// we only want to call onClose if this is the topmost modal
 			if (isLastModal() && onClose) {
 				onClose();
+				removeNodeFromVisibleModals();
 			}
 		}
 		function onInteractOutsideStart(e: InteractOutsideEvent) {

--- a/src/lib/internal/actions/modal/types.ts
+++ b/src/lib/internal/actions/modal/types.ts
@@ -4,7 +4,7 @@ export type ModalConfig = {
 	/**
 	 * Whether the modal is currently open.
 	 */
-	open: boolean;
+	open?: boolean;
 
 	/**
 	 * Handler called when the overlay closes.

--- a/src/lib/internal/actions/popper/action.ts
+++ b/src/lib/internal/actions/popper/action.ts
@@ -1,6 +1,5 @@
 import {
 	createFocusTrap,
-	useClickOutside,
 	useEscapeKeydown,
 	useFloating,
 	usePortal,
@@ -13,11 +12,12 @@ import {
 } from '$lib/internal/helpers/index.js';
 import type { Action } from 'svelte/action';
 import type { PopperArgs, PopperConfig } from './types.js';
+import { useModal } from '../modal/action.js';
 
 const defaultConfig = {
 	floating: {},
 	focusTrap: {},
-	clickOutside: {},
+	modal: {},
 	escapeKeydown: {},
 	portal: 'body',
 } satisfies PopperConfig;
@@ -60,19 +60,25 @@ export const usePopper: Action<HTMLElement, PopperArgs> = (popperElement, args) 
 		}
 	}
 
-	if (opts.clickOutside !== null) {
+	if (opts.modal !== null) {
 		callbacks.push(
-			useClickOutside(popperElement, {
-				enabled: open,
-				handler: (e: PointerEvent) => {
-					if (e.defaultPrevented) return;
-
-					if (isHTMLElement(anchorElement) && !anchorElement.contains(e.target as Element)) {
+			useModal(popperElement, {
+				onClose: () => {
+					if (isHTMLElement(anchorElement)) {
 						open.set(false);
 						anchorElement.focus();
 					}
 				},
-				...opts.clickOutside,
+				shouldCloseOnInteractOutside: (e) => {
+					if (e.defaultPrevented) return false;
+
+					if (isHTMLElement(anchorElement) && anchorElement.contains(e.target as Element)) {
+						return false;
+					}
+
+					return true;
+				},
+				...opts.modal,
 			}).destroy
 		);
 	}

--- a/src/lib/internal/actions/popper/types.ts
+++ b/src/lib/internal/actions/popper/types.ts
@@ -1,5 +1,4 @@
 import type {
-	ClickOutsideConfig,
 	FloatingConfig,
 	FocusTrapConfig,
 	PortalConfig,
@@ -7,11 +6,12 @@ import type {
 } from '$lib/internal/actions/index.js';
 import type { VirtualElement } from '@floating-ui/core';
 import type { Writable } from 'svelte/store';
+import type { ModalConfig } from '../modal/types.js';
 
 export type PopperConfig = {
 	floating?: FloatingConfig;
 	focusTrap?: FocusTrapConfig | null;
-	clickOutside?: ClickOutsideConfig | null;
+	modal?: ModalConfig | null;
 	portal?: PortalConfig | null;
 	escapeKeydown?: EscapeKeydownConfig | null;
 };

--- a/src/lib/internal/helpers/attr.ts
+++ b/src/lib/internal/helpers/attr.ts
@@ -17,3 +17,14 @@ export const hiddenInputAttrs = {
 		transform: 'translateX(-100%)',
 	}),
 };
+
+/**
+ * @param portal The value of the `portal` option store.
+ * @returns the value of the `data-portal` attribute.
+ */
+export function portalAttr(portal: string | HTMLElement | null | undefined) {
+	if (portal !== null) {
+		return portal;
+	}
+	return undefined;
+}

--- a/src/lib/internal/helpers/elements.ts
+++ b/src/lib/internal/helpers/elements.ts
@@ -9,14 +9,15 @@ function getPortalParent(node: HTMLElement) {
 	while (isHTMLElement(parent) && !parent.hasAttribute('data-portal')) {
 		parent = parent.parentElement;
 	}
-	return parent || document.body;
+	return parent || 'body';
 }
 
 export function getPortalDestination(
 	node: HTMLElement,
 	portalProp: string | HTMLElement | undefined | null
 ) {
-	if (portalProp === null) return null;
 	if (portalProp !== undefined) return portalProp;
-	return getPortalParent(node);
+	const portalParent = getPortalParent(node);
+	if (portalParent === 'body') return document.body;
+	return null;
 }

--- a/src/lib/internal/helpers/elements.ts
+++ b/src/lib/internal/helpers/elements.ts
@@ -9,15 +9,14 @@ function getPortalParent(node: HTMLElement) {
 	while (isHTMLElement(parent) && !parent.hasAttribute('data-portal')) {
 		parent = parent.parentElement;
 	}
-	return parent || 'body';
+	return parent || document.body;
 }
 
 export function getPortalDestination(
 	node: HTMLElement,
 	portalProp: string | HTMLElement | undefined | null
 ) {
-	const portalParent = getPortalParent(node);
+	if (portalProp === null) return null;
 	if (portalProp !== undefined) return portalProp;
-	if (portalParent === 'body') return document.body;
-	return null;
+	return getPortalParent(node);
 }

--- a/src/lib/internal/helpers/elements.ts
+++ b/src/lib/internal/helpers/elements.ts
@@ -12,12 +12,26 @@ function getPortalParent(node: HTMLElement) {
 	return parent || 'body';
 }
 
+/**
+ * Gets the destination for a portal given the node and a user-specified portal prop.
+ * If a portal prop is not `undefined`, it is used as the destination.
+ */
 export function getPortalDestination(
 	node: HTMLElement,
 	portalProp: string | HTMLElement | undefined | null
 ) {
+	// user-specified portal prop, use it
 	if (portalProp !== undefined) return portalProp;
+
+	// find the closest portal parent, or the body if none is found
 	const portalParent = getPortalParent(node);
+
+	// if the portalParent is the body, we portal to the body
+	// making it a "top-level" portal
 	if (portalParent === 'body') return document.body;
+
+	// if the portalParent is not the body, we have a portal parent
+	// and shouldn't portal to anything so it remains within that parent
+	// so we return `null`
 	return null;
 }

--- a/src/lib/internal/helpers/ignore.ts
+++ b/src/lib/internal/helpers/ignore.ts
@@ -1,7 +1,8 @@
 import { getElementByMeltId, isElement, isHTMLLabelElement } from '$lib/internal/helpers/index.js';
+import type { InteractOutsideEvent } from '../actions/index.js';
 
 export function createClickOutsideIgnore(meltId: string) {
-	return (e: PointerEvent) => {
+	return (e: InteractOutsideEvent) => {
 		const target = e.target;
 		const triggerEl = getElementByMeltId(meltId);
 		if (!triggerEl || !isElement(target)) return false;

--- a/src/lib/shared/index.ts
+++ b/src/lib/shared/index.ts
@@ -7,6 +7,7 @@
 import type { SegmentPart, EditableSegmentPart } from '$lib/builders/date-field/_internal/types.js';
 import type { Granularity, Matcher, DateRange, Month } from '$lib/internal/helpers/date/index.js';
 import type { FocusProp, FocusTarget } from '$lib/internal/helpers/index.js';
+import type { InteractOutsideEvent } from '$lib/internal/actions/index.js';
 
 export type {
 	Granularity,
@@ -17,4 +18,5 @@ export type {
 	Month,
 	SegmentPart,
 	EditableSegmentPart,
+	InteractOutsideEvent,
 };

--- a/src/routes/(landing-ui)/search.svelte
+++ b/src/routes/(landing-ui)/search.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import { Tooltip } from '$docs/components/index.js';
-	import { createCombobox, createDialog, createSync, melt } from '$lib/index.js';
+	import { createCombobox, createDialog, melt } from '$lib/index.js';
 	import { CornerDownRight, LoaderIcon, Search as SearchIcon } from '$icons/index.js';
 	import { onMount } from 'svelte';
 	import type { Pagefind, PagefindSearchFragment, PagefindSubResult } from '../../pagefind.js';

--- a/src/tests/context-menu/ContextMenu.spec.ts
+++ b/src/tests/context-menu/ContextMenu.spec.ts
@@ -5,6 +5,7 @@ import { userEvent } from '@testing-library/user-event';
 import { testKbd as kbd } from '../utils.js';
 import ContextMenuTest from './ContextMenuTest.svelte';
 import type { CreateContextMenuProps } from '$lib/index.js';
+import { sleep } from '$lib/internal/helpers/sleep.js';
 
 function setup(props: CreateContextMenuProps = {}) {
 	const user = userEvent.setup();
@@ -147,6 +148,8 @@ describe('Context Menu', () => {
 	test('Should close on outside click by default', async () => {
 		const { user, getByTestId, queryByTestId } = await open();
 		const outsideClick = getByTestId('outside-click');
+		await sleep(100);
+		expect(outsideClick).toBeVisible();
 		await user.click(outsideClick);
 		await waitFor(() => expect(queryByTestId('menu')).toBeNull());
 	});

--- a/src/tests/popover/Popover.spec.ts
+++ b/src/tests/popover/Popover.spec.ts
@@ -53,7 +53,10 @@ describe('Popover (Default)', () => {
 		await user.click(content);
 		await waitFor(() => expect(content).toBeVisible());
 		const outside = getByTestId('outside');
+		await sleep(100);
+		expect(outside).toBeVisible();
 		await user.click(outside);
+		await sleep(100);
 		await waitFor(() => expect(content).not.toBeVisible());
 	});
 
@@ -71,6 +74,10 @@ describe('Popover (Default)', () => {
 		await waitFor(() => expect(content).toBeVisible());
 		const outside = getByTestId('outside');
 		await user.click(outside);
+		await sleep(100);
+		expect(outside).toBeVisible();
+		await user.click(outside);
+		await sleep(100);
 		await waitFor(() => expect(content).toBeVisible());
 	});
 

--- a/src/tests/portal/PortalNested.spec.ts
+++ b/src/tests/portal/PortalNested.spec.ts
@@ -1,9 +1,12 @@
 import { render, screen } from '@testing-library/svelte';
 import { userEvent } from '@testing-library/user-event';
 import PortalNestedTest, { structure, type Structure } from './PortalNested.svelte';
+import { testKbd as kbd } from '../utils.js';
+
+type UserEventUser = ReturnType<typeof userEvent.setup>;
 
 // Recursive function to test the components
-const testComponent = async (component: Structure, level = 0) => {
+const testComponent = async (component: Structure, level: number, user: UserEventUser) => {
 	// Get the elements
 	const trigger = screen.getByTestId(`${component.name}-trigger-${level}`);
 	const content = screen.getByTestId(`${component.name}-content-${level}`);
@@ -15,7 +18,7 @@ const testComponent = async (component: Structure, level = 0) => {
 	expect(content).not.toBeVisible();
 
 	// Click the trigger
-	await userEvent.click(trigger);
+	await user.click(trigger);
 
 	// After clicking the root trigger, all its elements must be visible.
 	expect(trigger).toBeVisible();
@@ -37,13 +40,13 @@ const testComponent = async (component: Structure, level = 0) => {
 			}
 
 			// Recursively test the child components
-			await testComponent(child, level + 1);
+			await testComponent(child, level + 1, user);
 		}
 	}
 
 	// Testing closing
 	// By clicking escape
-	await userEvent.keyboard('{Escape}');
+	await user.keyboard(kbd.ESCAPE);
 	expect(trigger).toBeVisible();
 	expect(content).not.toBeVisible();
 	expect(outside).toBeVisible();
@@ -64,6 +67,7 @@ const testComponent = async (component: Structure, level = 0) => {
 
 // Execute the test
 test('recursive component test', async () => {
-	await render(PortalNestedTest);
-	await testComponent(structure);
+	const user = userEvent.setup();
+	render(PortalNestedTest);
+	await testComponent(structure, 0, user);
 });


### PR DESCRIPTION
Closes: #992 

Alright, I was able to pinpoint the root of the issue with the previous iteration of this, which had to do with the `getPortalDestination` function's logic being confusing (even though I originally wrote it).

If we find a portalParent and the user didn't specify a manual override via the `portalProp`, we want to return `null` for the portal so that it stays within it's appropriate `portalParent`.

The docs search works as expected and doesn't close on the input being clicked twice or anything else weird that I'm able to see.

I'll be in and out this week as I'm traveling for work, so feel free to make any modifications/add any additional regression cases you can think of to this PR to get it merged and have those other issues addressed.