### PR TITLE
fix: `multiple` change function `curr` and `next` always being equal

### DIFF
--- a/.changeset/pretty-kiwis-search.md
+++ b/.changeset/pretty-kiwis-search.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+Listbox: fixed bug causing `multiple` change function `curr` and `next` always being equal (Closes #1019)

--- a/src/lib/builders/listbox/create.ts
+++ b/src/lib/builders/listbox/create.ts
@@ -182,7 +182,7 @@ export function createListbox<
 		selected.update(($option) => {
 			const $multiple = multiple.get();
 			if ($multiple) {
-				const optionArr = Array.isArray($option) ? $option : [];
+				const optionArr = Array.isArray($option) ? [...$option] : [];
 				return toggle(newOption, optionArr, (itemA, itemB) =>
 					deepEqual(itemA.value, itemB.value)
 				) as S;


### PR DESCRIPTION
Closes: #1019