### PR TITLE
feat: Menu Overlays

### DIFF
--- a/.changeset/unlucky-countries-argue.md
+++ b/.changeset/unlucky-countries-argue.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': minor
+---
+
+Menus: add `overlay` element

--- a/src/docs/content/builders/context-menu.md
+++ b/src/docs/content/builders/context-menu.md
@@ -8,6 +8,8 @@ description:
     import { APIReference, KbdTable, Preview } from '$docs/components'
     export let schemas
     export let keyboard
+	export let previews
+	export let snippets
 </script>
 
 ## Anatomy
@@ -23,6 +25,8 @@ description:
 - **Separator**: A visual divider between menu items.
 
 ## Usage
+
+### Basic
 
 The first thing you need to do is create a context menu using the `createContextMenu` function.
 
@@ -83,6 +87,40 @@ occurring.
 	Item 2
 </div>
 ```
+
+### Modal Behavior
+
+To give the context menu complete modal behavior, where an overlay is rendered behind the menu to
+prevent interaction with the rest of the page while open, use the `overlay` builder element.
+
+```svelte
+<script lang="ts">
+	import { createContextMenu, melt } from '@melt-ui/svelte'
+	const {
+		elements: { trigger, menu, item, separator, arrow, overlay }
+	} = createContextMenu()
+</script>
+
+<div use:melt={$trigger}>Right click to open</div>
+<div use:melt={$overlay} />
+<div use:melt={$menu}>
+	<div use:melt={$arrow} />
+	<div use:melt={$item} />
+</div>
+```
+
+The [Modal Context Menu](#modal-context-menu) example below demonstrates this behavior in action.
+
+## Example Components
+
+### Modal Context Menu
+
+An example using the `overlay` builder element to prevent interaction with the rest of the page
+while the menu is open.
+
+<Preview code={snippets.modal}>
+    <svelte:component this={previews.modal} />
+</Preview>
 
 ## API Reference
 

--- a/src/docs/content/builders/dropdown-menu.md
+++ b/src/docs/content/builders/dropdown-menu.md
@@ -115,6 +115,9 @@ The [Modal Dropdown](#modal-dropdown) example below demonstrates this behavior i
 
 ### Modal Dropdown
 
+An example using the `overlay` builder element to prevent interaction with the rest of the page
+while the menu is open.
+
 <Preview code={snippets.modal}>
     <svelte:component this={previews.modal} />
 </Preview>

--- a/src/docs/content/builders/dropdown-menu.md
+++ b/src/docs/content/builders/dropdown-menu.md
@@ -5,9 +5,11 @@ description:
 ---
 
 <script>
-    import { KbdTable, APIReference } from '$docs/components'
+    import { KbdTable, APIReference, Preview } from '$docs/components'
     export let schemas
     export let keyboard
+	export let snippets
+	export let previews
 </script>
 
 ## Anatomy
@@ -23,6 +25,8 @@ description:
 - **Separator**: A visual divider between menu items.
 
 ## Usage
+
+### Basic
 
 The first thing you need to do is create a dropdown menu using the `createDropdownMenu` function.
 
@@ -83,6 +87,37 @@ occurring.
 	Item 2
 </div>
 ```
+
+### Modal Behavior
+
+To give the dropdown menu complete modal behavior, where an overlay is rendered behind the menu to
+prevent interaction with the rest of the page while open, use the `overlay` builder element.
+
+```svelte
+<script lang="ts">
+	import { createDropdownMenu, melt } from '@melt-ui/svelte'
+	const {
+		elements: { trigger, menu, item, separator, arrow, overlay }
+	} = createDropdownMenu()
+</script>
+
+<button type="button" use:melt={$trigger}> Open </button>
+<div use:melt={$overlay} />
+<div use:melt={$menu}>
+	<div use:melt={$arrow} />
+	<div use:melt={$item} />
+</div>
+```
+
+The [Modal Dropdown](#modal-dropdown) example below demonstrates this behavior in action.
+
+## Example Components
+
+### Modal Dropdown
+
+<Preview code={snippets.modal}>
+    <svelte:component this={previews.modal} />
+</Preview>
 
 ## API Reference
 

--- a/src/docs/data/builders/context-menu.ts
+++ b/src/docs/data/builders/context-menu.ts
@@ -38,6 +38,7 @@ const {
 	subTrigger,
 	group,
 	groupLabel,
+	overlay,
 } = getMenuSchemas(BUILDER_NAME);
 
 const TRIGGER_NAME = 'trigger' as const;
@@ -54,6 +55,7 @@ const schemas = [
 	trigger,
 	menu,
 	item,
+	overlay,
 	separator,
 	arrow,
 	checkboxItemBuilder,

--- a/src/docs/data/builders/dropdown-menu.ts
+++ b/src/docs/data/builders/dropdown-menu.ts
@@ -28,6 +28,7 @@ const {
 	checkboxItemBuilder,
 	group,
 	groupLabel,
+	overlay,
 } = getMenuSchemas(BUILDER_NAME);
 
 const { elements, builders, states, options } = getMenuBuilderReturns(BUILDER_NAME);
@@ -56,6 +57,7 @@ const schemas = [
 	trigger,
 	menu,
 	item,
+	overlay,
 	separator,
 	arrow,
 	checkboxItemBuilder,

--- a/src/docs/data/builders/menu.ts
+++ b/src/docs/data/builders/menu.ts
@@ -49,6 +49,7 @@ export function getMenuSchemas(name: Menu) {
 	return {
 		menu: getMenuMenuSchema(name),
 		arrow: getMenuArrowSchema(name),
+		overlay: getMenuOverlaySchema(name),
 		submenuBuilder: getMenuSubmenuBuilderSchema(),
 		submenu: getMenuSubmenuSchema(name),
 		subTrigger: getMenuSubTriggerSchema(name),
@@ -203,6 +204,23 @@ function getMenuMenuSchema(builderName: string) {
 			},
 		],
 		events: menuEvents['menu'],
+	});
+}
+
+function getMenuOverlaySchema(builderName: string) {
+	return elementSchema('overlay', {
+		description:
+			'An optional overlay element to prevent interaction with the rest of the page while the menu is open',
+		dataAttributes: [
+			{
+				name: 'data-state',
+				value: ATTRS.OPEN_CLOSED,
+			},
+			{
+				name: `data-melt-${toKebabCase(builderName)}-overlay`,
+				value: ATTRS.MELT('overlay'),
+			},
+		],
 	});
 }
 

--- a/src/docs/previews/context-menu/modal/tailwind/index.svelte
+++ b/src/docs/previews/context-menu/modal/tailwind/index.svelte
@@ -1,0 +1,151 @@
+<script lang="ts">
+	import { createContextMenu, melt } from '$lib/index.js';
+	import { writable } from 'svelte/store';
+	import { ChevronRight, Check } from '$icons/index.js';
+
+	const settingsSync = writable(true);
+	const hideMeltUI = writable(false);
+
+	const {
+		elements: { trigger, menu, item, separator, overlay },
+		builders: { createSubmenu, createMenuRadioGroup, createCheckboxItem },
+	} = createContextMenu({
+		loop: true,
+	});
+
+	const {
+		elements: { subMenu: subMenuA, subTrigger: subTriggerA },
+	} = createSubmenu();
+
+	const {
+		elements: { radioGroup, radioItem },
+		helpers: { isChecked },
+	} = createMenuRadioGroup({
+		defaultValue: 'Hunter Johnston',
+	});
+
+	const {
+		elements: { checkboxItem },
+	} = createCheckboxItem({
+		checked: settingsSync,
+	});
+
+	const {
+		elements: { checkboxItem: checkboxItemA },
+	} = createCheckboxItem({
+		checked: hideMeltUI,
+	});
+
+	const personsArr = [
+		'Hunter Johnston',
+		'Thomas G. Lopes',
+		'Adrian Gonz',
+		'Franck Poingt',
+	];
+</script>
+
+<span class="trigger" use:melt={$trigger} aria-label="Update dimensions">
+	Right click me.
+</span>
+<div use:melt={$overlay} class="fixed inset-0 z-40" />
+<div class="force-dark menu" use:melt={$menu}>
+	<div class="item" use:melt={$item}>About Melt UI</div>
+	<div class="item" use:melt={$item}>Check for Updates...</div>
+	<div class="separator" use:melt={$separator} />
+	<div class="item" use:melt={$checkboxItem}>
+		<div class="check">
+			{#if $settingsSync}
+				<Check class="size-4" />
+			{/if}
+		</div>
+		Settings Sync is On
+	</div>
+	<div class="item" use:melt={$subTriggerA}>
+		Profiles
+		<div class="rightSlot">
+			<ChevronRight class="size-4" />
+		</div>
+	</div>
+	<div class="menu subMenu" use:melt={$subMenuA}>
+		<div class="text">People</div>
+		<div use:melt={$radioGroup}>
+			{#each personsArr as person}
+				<div class="item" use:melt={$radioItem({ value: person })}>
+					<div class="check">
+						{#if $isChecked(person)}
+							<div class="dot" />
+						{/if}
+					</div>
+					{person}
+				</div>
+			{/each}
+		</div>
+	</div>
+	<div use:melt={$separator} class="separator" />
+
+	<div class="item" use:melt={$checkboxItemA}>
+		<div class="check">
+			{#if $hideMeltUI}
+				<Check class="size-4" />
+			{/if}
+		</div>
+		Hide Melt UI
+		<div class="rightSlot">⌘H</div>
+	</div>
+	<div class="item" use:melt={$item} data-disabled>
+		Show All Components
+		<div class="rightSlot">⇧⌘N</div>
+	</div>
+	<div use:melt={$separator} class="separator" />
+	<div class="item" use:melt={$item}>
+		Quit Melt UI
+		<div class="rightSlot">⌘Q</div>
+	</div>
+</div>
+
+<style lang="postcss">
+	.menu {
+		@apply z-40 flex max-h-[300px] min-w-[220px] flex-col shadow;
+		@apply rounded-lg bg-white p-1 lg:max-h-none;
+		@apply ring-0 !important;
+	}
+	.subMenu {
+		@apply min-w-[220px] shadow-md shadow-neutral-900/30;
+	}
+	.item {
+		@apply relative h-6 min-h-[24px] select-none rounded-md pl-6 pr-1;
+		@apply z-40 text-magnum-900 outline-none;
+		@apply data-[highlighted]:bg-magnum-200 data-[highlighted]:text-magnum-900;
+		@apply data-[disabled]:text-neutral-300;
+		@apply flex items-center text-sm leading-none;
+		@apply ring-0 !important;
+	}
+
+	.trigger {
+		@apply block rounded-xl border-2 border-dashed border-magnum-900 font-semibold text-magnum-700;
+		@apply w-[300px] bg-magnum-100 py-12 text-center shadow;
+	}
+	.check {
+		@apply absolute left-2 top-1/2 text-magnum-500;
+		translate: 0 calc(-50% + 1px);
+	}
+
+	.dot {
+		@apply h-[4.75px] w-[4.75px] rounded-full bg-magnum-900;
+	}
+
+	.separator {
+		@apply m-[5px] h-[1px] bg-magnum-200;
+	}
+
+	.rightSlot {
+		@apply ml-auto pl-5;
+	}
+
+	.check {
+		@apply absolute left-0 inline-flex w-6 items-center justify-center;
+	}
+	.text {
+		@apply pl-6 text-xs leading-6 text-neutral-600;
+	}
+</style>

--- a/src/docs/previews/dropdown-menu/modal/tailwind/index.svelte
+++ b/src/docs/previews/dropdown-menu/modal/tailwind/index.svelte
@@ -8,7 +8,7 @@
 	const hideMeltUI = writable(false);
 
 	const {
-		elements: { trigger, menu, item, separator, arrow },
+		elements: { trigger, menu, item, separator, arrow, overlay },
 		builders: { createSubmenu, createMenuRadioGroup, createCheckboxItem },
 		states: { open },
 	} = createDropdownMenu({
@@ -59,6 +59,7 @@
 </button>
 
 {#if $open}
+	<div use:melt={$overlay} class="fixed inset-0 z-40" />
 	<div
 		class="force-dark menu"
 		use:melt={$menu}

--- a/src/lib/builders/context-menu/create.ts
+++ b/src/lib/builders/context-menu/create.ts
@@ -74,18 +74,7 @@ export function createContextMenu(props?: CreateContextMenuProps) {
 	const nextFocusable = withGet.writable<HTMLElement | null>(null);
 	const prevFocusable = withGet.writable<HTMLElement | null>(null);
 
-	const {
-		item,
-		createCheckboxItem,
-		arrow,
-		createSubmenu,
-		createMenuRadioGroup,
-		ids,
-		separator,
-		handleTypeaheadSearch,
-		group,
-		groupLabel,
-	} = createMenuBuilder({
+	const { elements, builders, ids, options, helpers, states } = createMenuBuilder({
 		rootOpen,
 		rootOptions,
 		rootActiveTrigger: withGet(rootActiveTrigger),
@@ -95,6 +84,8 @@ export function createContextMenu(props?: CreateContextMenuProps) {
 		removeScroll: true,
 		ids: withDefaults.ids,
 	});
+
+	const { handleTypeaheadSearch } = helpers;
 
 	const point = writable<Point | null>(null);
 	const virtual: WithGet<Readable<VirtualElement | null>> = withGet(
@@ -317,23 +308,13 @@ export function createContextMenu(props?: CreateContextMenuProps) {
 	return {
 		ids,
 		elements: {
+			...elements,
 			menu,
 			trigger,
-			item,
-			arrow,
-			separator,
-			group,
-			groupLabel,
 		},
-		states: {
-			open: rootOpen,
-		},
-		builders: {
-			createSubmenu,
-			createCheckboxItem,
-			createMenuRadioGroup,
-		},
-		options: rootOptions,
+		states,
+		builders,
+		options,
 	};
 }
 

--- a/src/lib/builders/dropdown-menu/create.ts
+++ b/src/lib/builders/dropdown-menu/create.ts
@@ -37,19 +37,7 @@ export function createDropdownMenu(props?: CreateDropdownMenuProps) {
 	const nextFocusable = withGet(writable<HTMLElement | null>(null));
 	const prevFocusable = withGet(writable<HTMLElement | null>(null));
 
-	const {
-		trigger,
-		menu,
-		item,
-		arrow,
-		createSubmenu,
-		createCheckboxItem,
-		createMenuRadioGroup,
-		separator,
-		group,
-		groupLabel,
-		ids,
-	} = createMenuBuilder({
+	const { elements, builders, ids, states, options } = createMenuBuilder({
 		rootOptions,
 		rootOpen,
 		rootActiveTrigger: withGet(rootActiveTrigger),
@@ -62,23 +50,9 @@ export function createDropdownMenu(props?: CreateDropdownMenuProps) {
 
 	return {
 		ids,
-		elements: {
-			trigger,
-			menu,
-			item,
-			arrow,
-			separator,
-			group,
-			groupLabel,
-		},
-		states: {
-			open: rootOpen,
-		},
-		builders: {
-			createCheckboxItem,
-			createSubmenu,
-			createMenuRadioGroup,
-		},
-		options: rootOptions,
+		elements,
+		states,
+		builders,
+		options,
 	};
 }

--- a/src/lib/builders/menu/create.ts
+++ b/src/lib/builders/menu/create.ts
@@ -1,5 +1,5 @@
 import { createSeparator } from '$lib/builders/index.js';
-import { usePopper } from '$lib/internal/actions/index.js';
+import { useEscapeKeydown, usePopper, usePortal } from '$lib/internal/actions/index.js';
 import {
 	FIRST_LAST_KEYS,
 	SELECTION_KEYS,
@@ -334,6 +334,56 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 				height: `var(--arrow-size, ${$arrowSize}px)`,
 			}),
 		}),
+	});
+
+	const overlay = makeElement(name('overlay'), {
+		stores: [isVisible],
+		returned: ([$isVisible]) => {
+			return {
+				hidden: $isVisible ? undefined : true,
+				tabindex: -1,
+				style: styleToString({
+					display: $isVisible ? undefined : 'none',
+				}),
+				'aria-hidden': 'true',
+				'data-state': stateAttr($isVisible),
+			} as const;
+		},
+		action: (node: HTMLElement) => {
+			let unsubEscapeKeydown = noop;
+
+			if (closeOnEscape.get()) {
+				const escapeKeydown = useEscapeKeydown(node, {
+					handler: () => {
+						rootOpen.set(false);
+						const $rootActiveTrigger = rootActiveTrigger.get();
+						if ($rootActiveTrigger) $rootActiveTrigger.focus();
+					},
+				});
+				if (escapeKeydown && escapeKeydown.destroy) {
+					unsubEscapeKeydown = escapeKeydown.destroy;
+				}
+			}
+
+			const unsubPortal = effect([portal], ([$portal]) => {
+				if ($portal === null) return noop;
+				const portalDestination = getPortalDestination(node, $portal);
+				if (portalDestination === null) return noop;
+				const portalAction = usePortal(node, portalDestination);
+				if (portalAction && portalAction.destroy) {
+					return portalAction.destroy;
+				} else {
+					return noop;
+				}
+			});
+
+			return {
+				destroy() {
+					unsubEscapeKeydown();
+					unsubPortal();
+				},
+			};
+		},
 	});
 
 	const item = makeElement(name('item'), {
@@ -1368,20 +1418,29 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 	}
 
 	return {
+		elements: {
+			trigger: rootTrigger,
+			menu: rootMenu,
+			overlay,
+			item,
+			group,
+			groupLabel,
+			arrow: rootArrow,
+			separator,
+		},
+		builders: {
+			createCheckboxItem,
+			createSubmenu,
+			createMenuRadioGroup,
+		},
+		states: {
+			open: rootOpen,
+		},
+		helpers: {
+			handleTypeaheadSearch,
+		},
 		ids: rootIds,
-		trigger: rootTrigger,
-		menu: rootMenu,
-		open: rootOpen,
-		item,
-		group,
-		groupLabel,
-		arrow: rootArrow,
 		options: opts.rootOptions,
-		createCheckboxItem,
-		createSubmenu,
-		createMenuRadioGroup,
-		separator,
-		handleTypeaheadSearch,
 	};
 }
 
@@ -1558,4 +1617,8 @@ function isFocusWithinSubmenu(submenuId: string) {
 	// so we're using a data attribute.
 	const submenuEl = activeEl.closest(`[data-id="${submenuId}"]`);
 	return isHTMLElement(submenuEl);
+}
+
+function stateAttr(open: boolean) {
+	return open ? 'open' : 'closed';
 }

--- a/src/lib/builders/menu/types.ts
+++ b/src/lib/builders/menu/types.ts
@@ -210,6 +210,7 @@ export type _MenuParts =
 	| 'arrow'
 	| 'checkbox-item'
 	| 'item'
+	| 'overlay'
 	| 'radio-group'
 	| 'radio-item'
 	| 'submenu'

--- a/src/lib/builders/menubar/create.ts
+++ b/src/lib/builders/menubar/create.ts
@@ -234,7 +234,7 @@ export function createMenubar(props?: CreateMenubarProps) {
 						const isCharacterKey = e.key.length === 1;
 						const isModifierKey = e.ctrlKey || e.altKey || e.metaKey;
 						if (!isModifierKey && isCharacterKey) {
-							m.handleTypeaheadSearch(e.key, getMenuItems(menuEl));
+							m.helpers.handleTypeaheadSearch(e.key, getMenuItems(menuEl));
 						}
 					})
 				);
@@ -410,22 +410,12 @@ export function createMenubar(props?: CreateMenubarProps) {
 		return {
 			ids: m.ids,
 			elements: {
+				...m.elements,
 				menu,
 				trigger,
-				item: m.item,
-				arrow: m.arrow,
-				separator: m.separator,
-				group: m.group,
-				groupLabel: m.groupLabel,
 			},
-			builders: {
-				createCheckboxItem: m.createCheckboxItem,
-				createSubmenu: m.createSubmenu,
-				createMenuRadioGroup: m.createMenuRadioGroup,
-			},
-			states: {
-				open: rootOpen,
-			},
+			builders: m.builders,
+			states: m.states,
 			options,
 		};
 	};

--- a/src/lib/builders/popover/create.ts
+++ b/src/lib/builders/popover/create.ts
@@ -19,6 +19,7 @@ import {
 	toWritableStores,
 	sleep,
 	portalAttr,
+	generateIds,
 } from '$lib/internal/helpers/index.js';
 
 import { usePopper, type InteractOutsideEvent } from '$lib/internal/actions/index.js';
@@ -26,7 +27,6 @@ import { safeOnMount } from '$lib/internal/helpers/lifecycle.js';
 import type { Defaults, MeltActionReturn } from '$lib/internal/types.js';
 import { tick } from 'svelte';
 import { writable } from 'svelte/store';
-import { generateIds } from '../../internal/helpers/id.js';
 import type { PopoverEvents } from './events.js';
 import type { CreatePopoverProps } from './types.js';
 


### PR DESCRIPTION
This PR adds an optional `overlay` builder element to the Dropdown & Context Menus to enable modal behavior where outside interactions can be blocked by the overlay while the menu is open.

Closes #959 