### PR TITLE
feat: Combobox `trigger` element builder 

### DIFF
--- a/.changeset/smooth-crabs-carry.md
+++ b/.changeset/smooth-crabs-carry.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': minor
+---
+
+Combobox: add optional `trigger` element builder to toggle the menu

--- a/src/docs/content/builders/combobox.md
+++ b/src/docs/content/builders/combobox.md
@@ -17,6 +17,7 @@ description:
 
 - **Input**: The input that opens, closes, filters the list, and displays the selected value from
   the list
+- **Trigger**: An optional button that opens and closes the menu.
 - **Menu**: The popover menu
   - **Option**: The individual combobox items
   - **Label**: The label for the input

--- a/src/docs/data/builders/combobox.ts
+++ b/src/docs/data/builders/combobox.ts
@@ -81,6 +81,10 @@ const builder = builderSchema(BUILDER_NAME, {
 			description: 'The builder store used to create the collapsible input.',
 		},
 		{
+			name: 'trigger',
+			description: 'An optional button that opens the combobox menu.',
+		},
+		{
 			name: 'item',
 			description: 'The builder store used to create the menu item.',
 		},
@@ -171,7 +175,7 @@ const input = elementSchema('input', {
 		},
 		{
 			name: 'data-disabled',
-			value: ATTRS.DISABLED('`select`'),
+			value: ATTRS.DISABLED('`combobox`'),
 		},
 		{
 			name: 'data-melt-combobox-input',
@@ -179,6 +183,24 @@ const input = elementSchema('input', {
 		},
 	],
 	events: comboboxEvents['input'],
+});
+
+const trigger = elementSchema('trigger', {
+	description: 'An optional button that toggles the menu open and closed when pressed.',
+	dataAttributes: [
+		{
+			name: 'data-state',
+			value: ATTRS.OPEN_CLOSED,
+		},
+		{
+			name: 'data-disabled',
+			value: ATTRS.DISABLED('`combobox`'),
+		},
+		{
+			name: 'data-melt-combobox-trigger',
+			value: ATTRS.MELT('trigger'),
+		},
+	],
 });
 
 const item = elementSchema('item', {
@@ -315,7 +337,7 @@ const keyboard: KeyboardSchema = [
 	},
 ];
 
-const schemas = [builder, menu, input, item, label, group, groupLabel, arrow, hiddenInput];
+const schemas = [builder, menu, input, trigger, item, label, group, groupLabel, arrow, hiddenInput];
 
 const features = [
 	'Full keyboard navigation',

--- a/src/docs/previews/combobox/debounce/tailwind/index.svelte
+++ b/src/docs/previews/combobox/debounce/tailwind/index.svelte
@@ -63,7 +63,7 @@
 	];
 
 	const {
-		elements: { menu, input, option, label },
+		elements: { menu, input, option, label, trigger },
 		states: { open, inputValue, touchedInput },
 		helpers: { isSelected },
 	} = createCombobox({
@@ -111,13 +111,16 @@
 					px-3 pr-12 text-black"
 			placeholder="Best book ever"
 		/>
-		<div class="absolute right-2 top-1/2 z-10 -translate-y-1/2 text-magnum-900">
+		<button
+			use:melt={$trigger}
+			class="absolute right-2 top-1/2 z-10 -translate-y-1/2 text-magnum-900"
+		>
 			{#if $open}
 				<ChevronUp class="size-4" />
 			{:else}
 				<ChevronDown class="size-4" />
 			{/if}
-		</div>
+		</button>
 	</div>
 </div>
 {#if $open}

--- a/src/docs/previews/combobox/group/tailwind/index.svelte
+++ b/src/docs/previews/combobox/group/tailwind/index.svelte
@@ -77,7 +77,7 @@
 	});
 
 	const {
-		elements: { menu, input, option, label, group, groupLabel },
+		elements: { menu, input, option, label, group, groupLabel, trigger },
 		states: { open, inputValue, touchedInput, selected },
 		helpers: { isSelected },
 	} = createCombobox<Manga>({
@@ -123,13 +123,16 @@
 					px-3 pr-12 text-black"
 			placeholder="Best book ever"
 		/>
-		<div class="absolute right-2 top-1/2 z-10 -translate-y-1/2 text-magnum-900">
+		<button
+			use:melt={$trigger}
+			class="absolute right-2 top-1/2 z-10 -translate-y-1/2 text-magnum-900"
+		>
 			{#if $open}
 				<ChevronUp class="size-4" />
 			{:else}
 				<ChevronDown class="size-4" />
 			{/if}
-		</div>
+		</button>
 	</div>
 </div>
 {#if $open}

--- a/src/docs/previews/combobox/main/tailwind/index.svelte
+++ b/src/docs/previews/combobox/main/tailwind/index.svelte
@@ -73,7 +73,7 @@
 	});
 
 	const {
-		elements: { menu, input, option, label },
+		elements: { menu, input, option, label, trigger },
 		states: { open, inputValue, touchedInput, selected },
 		helpers: { isSelected },
 	} = createCombobox<Manga>({
@@ -110,13 +110,16 @@
 					px-3 pr-12 text-black"
 			placeholder="Best book ever"
 		/>
-		<div class="absolute right-2 top-1/2 z-10 -translate-y-1/2 text-magnum-900">
+		<button
+			class="absolute right-2 top-1/2 z-10 -translate-y-1/2 text-magnum-900"
+			use:melt={$trigger}
+		>
 			{#if $open}
 				<ChevronUp class="size-4" />
 			{:else}
 				<ChevronDown class="size-4" />
 			{/if}
-		</div>
+		</button>
 	</div>
 </div>
 {#if $open}

--- a/src/docs/previews/combobox/multi/tailwind/index.svelte
+++ b/src/docs/previews/combobox/multi/tailwind/index.svelte
@@ -63,7 +63,7 @@
 	];
 
 	const {
-		elements: { menu, input, option, label },
+		elements: { menu, input, option, label, trigger },
 		states: { open, inputValue, touchedInput },
 		helpers: { isSelected },
 	} = createCombobox({
@@ -97,13 +97,16 @@
 					px-3 pr-12 text-black"
 			placeholder="Best book ever"
 		/>
-		<div class="absolute right-2 top-1/2 z-10 -translate-y-1/2 text-magnum-900">
+		<button
+			use:melt={$trigger}
+			class="absolute right-2 top-1/2 z-10 -translate-y-1/2 text-magnum-900"
+		>
 			{#if $open}
 				<ChevronUp class="size-4" />
 			{:else}
 				<ChevronDown class="size-4" />
 			{/if}
-		</div>
+		</button>
 	</div>
 </div>
 {#if $open}

--- a/src/lib/builders/combobox/create.ts
+++ b/src/lib/builders/combobox/create.ts
@@ -11,6 +11,7 @@ import {
 	kbd,
 	noop,
 	omit,
+	sleep,
 } from '$lib/internal/helpers/index.js';
 import type { MeltActionReturn } from '$lib/internal/types.js';
 import { get, writable } from 'svelte/store';
@@ -104,11 +105,20 @@ export function createCombobox<
 		action: (node: HTMLElement): MeltActionReturn<ComboboxEvents['trigger']> => {
 			const unsubEvents = executeCallbacks(
 				addMeltEventListener(node, 'click', () => {
-					const inputEl = document.getElementById(get(listbox.elements.trigger).id);
-					if (inputEl) {
-						inputEl.focus();
-					}
-					listbox.states.open.update((curr) => !curr);
+					listbox.states.open.update((curr) => {
+						if (!curr) {
+							// we're opening so focus the input
+							const inputEl = document.getElementById(get(listbox.elements.trigger).id);
+							inputEl?.focus();
+						} else {
+							// by default, when the menu closes it focuses the input
+							// but we want to focus the trigger here since it was just clicked
+							sleep(1).then(() => {
+								node.focus();
+							});
+						}
+						return !curr;
+					});
 				})
 			);
 

--- a/src/lib/builders/combobox/events.ts
+++ b/src/lib/builders/combobox/events.ts
@@ -4,6 +4,7 @@ import { listboxEvents } from '../listbox/events.js';
 export const comboboxEvents = {
 	...listboxEvents,
 	input: ['click', 'keydown', 'input'] as const,
+	trigger: ['click'] as const,
 };
 
 export type ComboboxEvents = GroupedEvents<typeof comboboxEvents>;

--- a/src/lib/builders/listbox/create.ts
+++ b/src/lib/builders/listbox/create.ts
@@ -296,8 +296,10 @@ export function createListbox<
 
 			const unsubscribe = executeCallbacks(
 				addMeltEventListener(node, 'click', () => {
-					node.focus(); // Fix for safari not adding focus on trigger
 					const $open = open.get();
+					if (isInput && $open) return;
+
+					node.focus(); // Fix for safari not adding focus on trigger
 					if ($open) {
 						closeMenu();
 					} else {

--- a/src/tests/combobox/Combobox.spec.ts
+++ b/src/tests/combobox/Combobox.spec.ts
@@ -1,4 +1,4 @@
-import { act, render, waitFor } from '@testing-library/svelte';
+import { act, fireEvent, render, waitFor } from '@testing-library/svelte';
 import { userEvent } from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { describe } from 'vitest';
@@ -198,7 +198,6 @@ describe('Combobox', () => {
 	});
 
 	test('Can programatically open the combobox with the `open` store', async () => {
-		//
 		const user = userEvent.setup();
 		const { getByTestId } = render(ComboboxTest);
 
@@ -209,6 +208,39 @@ describe('Combobox', () => {
 		await user.click(toggleBtn);
 		await sleep(100);
 		expect(menu).toBeVisible();
+	});
+
+	test('Opens the menu when closed and trigger is clicked', async () => {
+		const user = userEvent.setup();
+		const { getByTestId } = render(ComboboxTest);
+
+		const trigger = getByTestId('trigger');
+		const menu = getByTestId('menu');
+		const input = getByTestId('input');
+
+		expect(menu).not.toBeVisible();
+		await user.click(trigger);
+		expect(menu).toBeVisible();
+		expect(input).toHaveFocus();
+		expect(trigger).not.toHaveFocus();
+	});
+
+	test('Closes the menu when the trigger is clicked and the menu is open', async () => {
+		const user = userEvent.setup();
+		const { getByTestId } = render(ComboboxTest);
+
+		const trigger = getByTestId('trigger');
+		const menu = getByTestId('menu');
+		const input = getByTestId('input');
+
+		expect(menu).not.toBeVisible();
+		await user.click(input);
+		expect(menu).toBeVisible();
+		expect(input).toHaveFocus();
+		expect(trigger).not.toHaveFocus();
+		await user.click(trigger);
+		expect(menu).not.toBeVisible();
+		expect(input).toHaveFocus();
 	});
 
 	test.todo('Selects multiple items when `multiple` is true');
@@ -379,7 +411,7 @@ describe('Combobox (forceVisible)', () => {
 
 	test.skip('Closes on outside click by default', async () => {
 		const user = userEvent.setup();
-		const { getByTestId, queryByTestId } = render(ComboboxTest);
+		const { getByTestId, queryByTestId } = render(ComboboxForceVisibleTest);
 		const input = getByTestId('input');
 
 		const getMenu = () => queryByTestId('menu');
@@ -435,6 +467,39 @@ describe('Combobox (forceVisible)', () => {
 		await user.click(toggleBtn);
 		await sleep(100);
 		expect(getMenu()).not.toBeNull();
+	});
+
+	test('Opens the menu when closed and trigger is clicked', async () => {
+		const user = userEvent.setup();
+		const { getByTestId, queryByTestId } = render(ComboboxForceVisibleTest);
+
+		const trigger = getByTestId('trigger');
+		const getMenu = () => queryByTestId('menu');
+		const input = getByTestId('input');
+
+		expect(getMenu()).toBeNull();
+		await user.click(trigger);
+		expect(getMenu()).not.toBeNull();
+		expect(input).toHaveFocus();
+		expect(trigger).not.toHaveFocus();
+	});
+
+	test('Closes the menu when the trigger is clicked and the menu is open', async () => {
+		const user = userEvent.setup();
+		const { getByTestId, queryByTestId } = render(ComboboxForceVisibleTest);
+
+		const trigger = getByTestId('trigger');
+		const getMenu = () => queryByTestId('menu');
+		const input = getByTestId('input');
+
+		expect(getMenu()).toBeNull();
+		await user.click(input);
+		expect(getMenu()).not.toBeNull();
+		expect(input).toHaveFocus();
+		expect(trigger).not.toHaveFocus();
+		await user.click(trigger);
+		expect(getMenu()).toBeNull();
+		expect(input).toHaveFocus();
 	});
 
 	test.todo('Selects multiple items when `multiple` is true');

--- a/src/tests/combobox/Combobox.spec.ts
+++ b/src/tests/combobox/Combobox.spec.ts
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, waitFor } from '@testing-library/svelte';
+import { act, render, waitFor } from '@testing-library/svelte';
 import { userEvent } from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { describe } from 'vitest';
@@ -27,7 +27,7 @@ describe('Combobox', () => {
 		expect(await axe(container)).toHaveNoViolations();
 	});
 
-	test('Opens/Closes when input is clicked', async () => {
+	test('Opens when input is clicked', async () => {
 		const { getByTestId } = render(ComboboxTest);
 		const input = getByTestId('input');
 		const menu = getByTestId('menu');
@@ -36,9 +36,19 @@ describe('Combobox', () => {
 		expect(menu).not.toBeVisible();
 		await user.click(input);
 		expect(getByTestId('menu')).toBeVisible();
+	});
 
-		await user.click(input);
+	test("Doesn't close when the input is clicked again while open", async () => {
+		const { getByTestId } = render(ComboboxTest);
+		const input = getByTestId('input');
+		const menu = getByTestId('menu');
+		const user = userEvent.setup();
+
 		expect(menu).not.toBeVisible();
+		await user.click(input);
+		expect(menu).toBeVisible();
+		await user.click(input);
+		expect(menu).toBeVisible();
 	});
 
 	test.each(OPEN_KEYS)('Opens when %s is pressed', async (key) => {
@@ -240,7 +250,7 @@ describe('Combobox', () => {
 		expect(trigger).not.toHaveFocus();
 		await user.click(trigger);
 		expect(menu).not.toBeVisible();
-		expect(input).toHaveFocus();
+		expect(trigger).toHaveFocus();
 	});
 
 	test.todo('Selects multiple items when `multiple` is true');
@@ -266,7 +276,19 @@ describe('Combobox (forceVisible)', () => {
 		expect(await axe(container)).toHaveNoViolations();
 	});
 
-	test('Opens/Closes when input is clicked', async () => {
+	test('Opens when input is clicked', async () => {
+		const user = userEvent.setup();
+		const { getByTestId, queryByTestId } = render(ComboboxForceVisibleTest);
+		const input = getByTestId('input');
+		const getMenu = () => queryByTestId('menu');
+
+		expect(getMenu()).toBeNull();
+
+		await user.click(input);
+		expect(getMenu()).not.toBeNull();
+	});
+
+	test("Doesn't close when the input is clicked again while open", async () => {
 		const user = userEvent.setup();
 		const { getByTestId, queryByTestId } = render(ComboboxForceVisibleTest);
 		const input = getByTestId('input');
@@ -278,7 +300,7 @@ describe('Combobox (forceVisible)', () => {
 		expect(getMenu()).not.toBeNull();
 
 		await user.click(input);
-		expect(getMenu()).toBeNull();
+		expect(getMenu()).not.toBeNull();
 	});
 
 	test.each(OPEN_KEYS)('Opens when %s is pressed', async (key) => {
@@ -499,7 +521,7 @@ describe('Combobox (forceVisible)', () => {
 		expect(trigger).not.toHaveFocus();
 		await user.click(trigger);
 		expect(getMenu()).toBeNull();
-		expect(input).toHaveFocus();
+		expect(trigger).toHaveFocus();
 	});
 
 	test.todo('Selects multiple items when `multiple` is true');

--- a/src/tests/combobox/ComboboxForceVisibleTest.svelte
+++ b/src/tests/combobox/ComboboxForceVisibleTest.svelte
@@ -21,7 +21,7 @@
 	export let closeOnEscape: CreateComboboxProps<unknown>['closeOnEscape'] = undefined;
 
 	const {
-		elements: { menu, input, option, label },
+		elements: { menu, input, option, label, trigger },
 		states: { open, inputValue, selected },
 	} = createCombobox(
 		removeUndefined({
@@ -51,6 +51,7 @@
 	<label use:melt={$label} data-testid="label">Label</label>
 
 	<input use:melt={$input} data-testid="input" />
+	<button use:melt={$trigger} data-testid="trigger">Toggle</button>
 
 	{#if $open}
 		<ul use:melt={$menu} data-testid="menu">

--- a/src/tests/combobox/ComboboxTest.svelte
+++ b/src/tests/combobox/ComboboxTest.svelte
@@ -21,7 +21,7 @@
 	export let closeOnEscape: CreateComboboxProps<unknown>['closeOnEscape'] = undefined;
 
 	const {
-		elements: { menu, input, option, label },
+		elements: { menu, input, option, label, trigger },
 		states: { open, inputValue, selected },
 	} = createCombobox(
 		removeUndefined({
@@ -48,8 +48,9 @@
 	>
 	<!-- svelte-ignore a11y-label-has-associated-control - $label contains the 'for' attribute -->
 	<label use:melt={$label} data-testid="label">Label</label>
-
 	<input use:melt={$input} data-testid="input" />
+	<button use:melt={$trigger} data-testid="trigger">Toggle</button>
+	<button data-testid="outside-click">Outside click</button>
 
 	<ul use:melt={$menu} data-testid="menu">
 		<!-- svelte-ignore a11y-no-noninteractive-tabindex -->
@@ -66,5 +67,4 @@
 			{/each}
 		</div>
 	</ul>
-	<div data-testid="outside-click" />
 </main>


### PR DESCRIPTION
This PR adds the `trigger` element builder to the `createCombobox` return elements.

It is optional and can be used to toggle the menu open and closed.

Closes: #1024 