### PR TITLE
refactor listbox

### DIFF
--- a/src/lib/builders/listbox/create.ts
+++ b/src/lib/builders/listbox/create.ts
@@ -444,6 +444,7 @@ export function createListbox<
 
 			return {
 				destroy() {
+					activeTrigger.set(null);
 					unsubscribe();
 					unsubEscapeKeydown();
 				},


### PR DESCRIPTION
Listbox Refactor:
- setting `activeTrigger` in trigger action instead of in `openMenu` and in `safeOnMount` and in `effect([open])`
- using early return in `effect([open])` for cleaner code