### PR TITLE
[link preview] fix content showing up at top left after remounting trigger

### DIFF
--- a/.changeset/dry-dolls-greet.md
+++ b/.changeset/dry-dolls-greet.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+fix(link preview): Fixed bug where content shows up at top left of the page after remounting trigger (fixes #1060)

--- a/src/lib/builders/link-preview/create.ts
+++ b/src/lib/builders/link-preview/create.ts
@@ -20,7 +20,6 @@ import {
 	toWritableStores,
 	portalAttr,
 } from '$lib/internal/helpers/index.js';
-import { safeOnMount } from '$lib/internal/helpers/lifecycle.js';
 import { withGet, type WithGet } from '$lib/internal/helpers/withGet.js';
 import type { MeltActionReturn } from '$lib/internal/types.js';
 import { writable, type Readable } from 'svelte/store';
@@ -124,6 +123,7 @@ export function createLinkPreview(props: CreateLinkPreviewProps = {}) {
 			};
 		},
 		action: (node: HTMLElement): MeltActionReturn<LinkPreviewEvents['trigger']> => {
+			activeTrigger.set(node);
 			const unsub = executeCallbacks(
 				addMeltEventListener(node, 'pointerenter', (e) => {
 					if (isTouch(e)) return;
@@ -290,12 +290,6 @@ export function createLinkPreview(props: CreateLinkPreviewProps = {}) {
 			contentElement.style.userSelect = originalContentUserSelect;
 			contentElement.style.webkitUserSelect = originalContentUserSelect;
 		};
-	});
-
-	safeOnMount(() => {
-		const triggerEl = document.getElementById(ids.trigger.get());
-		if (!triggerEl) return;
-		activeTrigger.set(triggerEl);
 	});
 
 	effect([open], ([$open]) => {


### PR DESCRIPTION
closes https://github.com/melt-ui/melt-ui/issues/1060

setting `activeTrigger` in trigger action (when trigger is mounted) instead of in `safeOnMount`. This makes sure that we always have a reference to the up-to-date trigger every time a new trigger mounts. Currently, if you just unmount the trigger and remount it, we have a stale `activeTrigger` which breaks the behavior of the component as seen in the mentioned issue above

### Before

https://github.com/melt-ui/melt-ui/assets/53095479/c2dbc10c-314b-44a7-b91e-7330d74d66e5

### After

https://github.com/melt-ui/melt-ui/assets/53095479/2d571348-4695-4307-9735-927e17c3d923
