### PR TITLE
fix: clean dead reference to floating content

### DIFF
--- a/.changeset/strange-actors-guess.md
+++ b/.changeset/strange-actors-guess.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+fix(Tooltip, Link Preview, Menu, Popover, Listbox) fixed bug where content jumps to top left of page during external unmounting when using out transition on the content and else if block to render the content (closes #1058, #1039)

--- a/src/lib/builders/listbox/create.ts
+++ b/src/lib/builders/listbox/create.ts
@@ -32,7 +32,6 @@ import {
 	prev,
 	removeHighlight,
 	removeScroll,
-	sleep,
 	stripValues,
 	styleToString,
 	toWritableStores,
@@ -227,8 +226,7 @@ export function createListbox<
 	}
 
 	/** Closes the menu & clears the active trigger */
-	async function closeMenu() {
-		await sleep(0);
+	function closeMenu() {
 		open.set(false);
 		highlightedItem.set(null);
 	}

--- a/src/lib/builders/popover/create.ts
+++ b/src/lib/builders/popover/create.ts
@@ -17,7 +17,6 @@ import {
 	removeScroll,
 	styleToString,
 	toWritableStores,
-	sleep,
 	portalAttr,
 	generateIds,
 } from '$lib/internal/helpers/index.js';
@@ -88,8 +87,7 @@ export function createPopover(args?: CreatePopoverProps) {
 		activeTrigger.set(document.getElementById(ids.trigger.get()));
 	});
 
-	async function handleClose() {
-		await sleep(0);
+	function handleClose() {
 		open.set(false);
 		const triggerEl = document.getElementById(ids.trigger.get());
 		handleFocus({ prop: closeFocus.get(), defaultEl: triggerEl });

--- a/src/lib/builders/tooltip/create.ts
+++ b/src/lib/builders/tooltip/create.ts
@@ -19,7 +19,6 @@ import {
 	styleToString,
 	toWritableStores,
 	removeUndefined,
-	sleep,
 	portalAttr,
 } from '$lib/internal/helpers/index.js';
 
@@ -182,10 +181,7 @@ export function createTooltip(props?: CreateTooltipProps) {
 					if (clickedTrigger) return;
 					openTooltip('focus');
 				}),
-				addMeltEventListener(node, 'blur', async () => {
-					await sleep(0);
-					closeTooltip(true);
-				}),
+				addMeltEventListener(node, 'blur', () => closeTooltip(true)),
 				addMeltEventListener(node, 'keydown', keydownHandler),
 				addEventListener(document, 'keydown', keydownHandler)
 			);

--- a/src/lib/internal/actions/floating/action.ts
+++ b/src/lib/internal/actions/floating/action.ts
@@ -100,7 +100,9 @@ export function useFloating(
 
 	function compute() {
 		if (!reference || !floating) return;
-		if (isHTMLElement(reference) && !document.contains(reference)) return;
+		// if the reference is no longer in the document (e.g. it was removed), ignore it
+		if (isHTMLElement(reference) && !reference.ownerDocument.documentElement.contains(reference))
+			return;
 		const { placement, strategy } = options;
 
 		computePosition(reference, floating, {

--- a/src/lib/internal/actions/floating/action.ts
+++ b/src/lib/internal/actions/floating/action.ts
@@ -100,6 +100,7 @@ export function useFloating(
 
 	function compute() {
 		if (!reference || !floating) return;
+		if (isHTMLElement(reference) && !document.contains(reference)) return;
 		const { placement, strategy } = options;
 
 		computePosition(reference, floating, {

--- a/src/tests/combobox/Combobox.spec.ts
+++ b/src/tests/combobox/Combobox.spec.ts
@@ -315,6 +315,11 @@ describe('Combobox (forceVisible)', () => {
 		const { getByTestId, queryByTestId } = render(ComboboxForceVisibleTest, { options });
 		const input = getByTestId('input');
 		const getMenu = () => queryByTestId('menu');
+		const getFirstItem = () => {
+			const firstItem = getMenu()?.querySelector('[data-melt-combobox-option]');
+			if (!firstItem) throw new Error('No option found');
+			return firstItem;
+		};
 
 		expect(input).not.toHaveValue(options[0].label);
 
@@ -323,10 +328,7 @@ describe('Combobox (forceVisible)', () => {
 		expect(getMenu()).not.toBeNull();
 		expect(getMenu()).toBeVisible();
 
-		const firstItem = getMenu()?.querySelector('[data-melt-combobox-option]');
-		if (!firstItem) throw new Error('No option found');
-
-		await user.click(firstItem);
+		await user.click(getFirstItem());
 
 		expect(getMenu()).toBeNull();
 		expect(input).toHaveValue(options[0].label);
@@ -334,7 +336,7 @@ describe('Combobox (forceVisible)', () => {
 		await user.click(input);
 		expect(getMenu()).not.toBeNull();
 		expect(getMenu()).toBeVisible();
-		expect(firstItem).toHaveAttribute('data-selected');
+		expect(getFirstItem()).toHaveAttribute('data-selected');
 	});
 
 	test('Applies custom ids when provided', async () => {


### PR DESCRIPTION
closes #1058, #1039

https://github.com/melt-ui/melt-ui/assets/53095479/a1ee3f6c-badf-4fac-8049-8a90ea73249c

This has been an ongoing issue with multiple components--the content jumps to the top left of the page when you unmount the component externally while the content is open when using an out transition on the content and when using an else if block to render the content.

The previous workaround that solved this issue for all components but the tooltip was to introduce `sleep(0)` before setting the `$open` state to `false`. So when the component get unmounted externally while the content is open, svelte can unmount the whole component instead of, for some reason, starting the transition out of the content, at which stage the content loses its anchor and causes the content to jump to the top left of the page.

However, for some reason, adding `sleep(0)` to the tooltip as a workaround does not work. It requires adding a pretty significant delay (~80ms) to prevent this issue. However adding a significant delay is not preferable.

I dug deeper into this issue and found out that the reason the content jumps to the top left of the page is because in `useFloating`, the `compute` function reruns to set the new position of the content as it is transitioning out. 

I found out that the client rect of the reference (the anchor) is `{ top: 0, left: 0 }` during the unmounting of the content. The reason for that is that we are holding a reference to the trigger which was already unmounted, but in JavaScript, you can still hold a reference to an html element that is not in the document anymore. An html element that is not the document has client rect of `0`s.

So our code that recomputes the position of the content is rerun with a trigger that is "at the top left of the page", but in reality it's no longer in the document. 

So we should check if the reference is in the document before computing a new position for the content.

And so this finally solves this issue without having to add `delay(0)` to so many builders in addition to the delay not working in the case of the tooltip.

Finally :)