### PR TITLE
fix(table of contents) browser back forward scroll

### DIFF
--- a/.changeset/curvy-gorillas-talk.md
+++ b/.changeset/curvy-gorillas-talk.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+Fixed bug in Table of Contents where navigating with the browser's back and forward buttons failed to automatically scroll to the element specified by the `location.hash`. (closes #1062)

--- a/src/lib/builders/table-of-contents/create.ts
+++ b/src/lib/builders/table-of-contents/create.ts
@@ -18,6 +18,7 @@ import type {
 	HeadingParentsLU,
 	TableOfContentsItem,
 } from './types.js';
+import { pushState } from '$app/navigation';
 
 const defaults = {
 	exclude: ['h1'],
@@ -373,7 +374,7 @@ export function createTableOfContents(args: CreateTableOfContentsArgs) {
 
 					// Add items hash to URL
 					if (id) {
-						history.pushState({}, '', `#${id}`);
+						pushState(`#${id}`, {});
 					}
 				})
 			);


### PR DESCRIPTION
closes https://github.com/melt-ui/melt-ui/issues/1062

When using native html elements with ids and clicking on multiple anchor tags with a hash in the current page, when clicking the back and forward navigation buttons in the browser, the page scrolls back to that element.

As of right now, when using melt-ui's table of contents and clicking the back and forward navigation buttons in the browser, the page does not scrolls back to the correct element.

This PR fixes this by using `pushState` from `$app/navigation` instead of `history.pushState(...)`, which is recommended from the warning I was previously getting in the console with our current implementation.

> Avoid using history.pushState(...) and history.replaceState(...) as these will conflict with SvelteKit's router. Use the pushState and replaceState imports from $app/navigation instead.

### Before

https://github.com/melt-ui/melt-ui/assets/53095479/8c709046-aece-4c84-b423-87137525d0be

### After

https://github.com/melt-ui/melt-ui/assets/53095479/b3336e85-27bf-4023-bd4d-84d7011657f3

