### PR TITLE
fix interfact outside interaction in different portal

### DIFF
--- a/.changeset/warm-bees-tell.md
+++ b/.changeset/warm-bees-tell.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+Fixed Outside Interaction Handling Across Portals: Modified the interact outside logic to ignore events originating from different portals. (closes #1036)

--- a/src/lib/internal/actions/interact-outside/action.ts
+++ b/src/lib/internal/actions/interact-outside/action.ts
@@ -109,7 +109,13 @@ function isValidEvent(e: InteractOutsideEvent, node: HTMLElement): boolean {
 		return false;
 	}
 
-	return node && !isOrContainsTarget(node, target);
+	return node && !isOrContainsTarget(node, target) && !isEventInsideDifferentPortal(e, node);
+}
+
+function isEventInsideDifferentPortal(e: InteractOutsideEvent, node: HTMLElement): boolean {
+	const targetPortal = isElement(e.target) && e.target.closest('[data-portal]');
+	const nodePortal = node.closest('[data-portal]');
+	return !!targetPortal && targetPortal !== nodePortal;
 }
 
 function isOrContainsTarget(node: HTMLElement, target: Element) {


### PR DESCRIPTION
closes #1036

as @huntabyte said, in interact outside logic, we should ignore events coming from a different portal

### Before

https://github.com/melt-ui/melt-ui/assets/53095479/f6953850-1fe4-4e5f-af73-daabfb550a99

### After


https://github.com/melt-ui/melt-ui/assets/53095479/65056a17-402b-416e-bcad-3e600b6de40d



