### PR TITLE
fix: datepicker not syncing with calendar

### DIFF
--- a/.changeset/perfect-otters-shout.md
+++ b/.changeset/perfect-otters-shout.md
@@ -1,5 +1,5 @@
 ---
-'@melt-ui/svelte': patch
+'@melt-ui/svelte': minor
 ---
 
-fix: datepicker not syncing with calendar
+fix: datepicker not syncing with calendar + add defaults from calendar to datepicker

--- a/.changeset/perfect-otters-shout.md
+++ b/.changeset/perfect-otters-shout.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+fix: datepicker not syncing with calendar

--- a/src/lib/builders/calendar/create.ts
+++ b/src/lib/builders/calendar/create.ts
@@ -44,7 +44,7 @@ import { derived, writable } from 'svelte/store';
 import type { CalendarEvents } from './events.js';
 import type { CalendarValue, CreateCalendarProps } from './types.js';
 
-const defaults = {
+export const defaults = {
 	isDateDisabled: undefined,
 	isDateUnavailable: undefined,
 	value: undefined,

--- a/src/lib/builders/date-picker/create.ts
+++ b/src/lib/builders/date-picker/create.ts
@@ -163,7 +163,7 @@ export function createDatePicker(props?: CreateDatePickerProps) {
 		'minValue',
 		'maxValue'
 	);
-	let calendarOptions = omit(
+	const calendarOptions = omit(
 		calendar.options,
 		'locale',
 		'disabled',

--- a/src/lib/builders/date-picker/create.ts
+++ b/src/lib/builders/date-picker/create.ts
@@ -131,6 +131,30 @@ export function createDatePicker(props?: CreateDatePickerProps) {
 		calendar.options.maxValue.set($maxValue);
 	});
 
+	if (options.numberOfMonths != undefined) {
+		effect([options.numberOfMonths], ([$numberOfMonths]) => {
+			if ($numberOfMonths != undefined) {
+				calendar.options.numberOfMonths.set($numberOfMonths);
+			}
+		});
+	}
+
+	if (options.fixedWeeks != undefined) {
+		effect([options.fixedWeeks], ([$fixedWeeks]) => {
+			if ($fixedWeeks != undefined) {
+				calendar.options.fixedWeeks.set($fixedWeeks);
+			}
+		});
+	}
+
+	if (options.weekStartsOn != undefined) {
+		effect([options.weekStartsOn], ([$weekStartsOn]) => {
+			if ($weekStartsOn != undefined) {
+				calendar.options.weekStartsOn.set($weekStartsOn);
+			}
+		});
+	}
+
 	const dateFieldOptions = omit(
 		dateField.options,
 		'locale',
@@ -139,7 +163,7 @@ export function createDatePicker(props?: CreateDatePickerProps) {
 		'minValue',
 		'maxValue'
 	);
-	const calendarOptions = omit(
+	let calendarOptions = omit(
 		calendar.options,
 		'locale',
 		'disabled',

--- a/src/lib/builders/date-picker/create.ts
+++ b/src/lib/builders/date-picker/create.ts
@@ -16,6 +16,7 @@ import { pickerOpenFocus } from '$lib/internal/helpers/date/focus.js';
 import { createFormatter, dateStore, getDefaultDate } from '$lib/internal/helpers/date/index.js';
 import type { MeltActionReturn } from '$lib/internal/types.js';
 import type { DatePickerEvents } from './events.js';
+import { defaults as calendarDefaults } from '../calendar/create.js';
 
 const defaults = {
 	isDateDisabled: undefined,
@@ -36,6 +37,18 @@ const defaults = {
 	minValue: undefined,
 	maxValue: undefined,
 	weekdayFormat: 'narrow',
+	...omit(
+		calendarDefaults,
+		'isDateDisabled',
+		'isDateUnavailable',
+		'value',
+		'locale',
+		'disabled',
+		'readonly',
+		'minValue',
+		'maxValue',
+		'weekdayFormat'
+	),
 } satisfies CreateDatePickerProps;
 
 export function createDatePicker(props?: CreateDatePickerProps) {
@@ -131,29 +144,17 @@ export function createDatePicker(props?: CreateDatePickerProps) {
 		calendar.options.maxValue.set($maxValue);
 	});
 
-	if (options.numberOfMonths != undefined) {
-		effect([options.numberOfMonths], ([$numberOfMonths]) => {
-			if ($numberOfMonths != undefined) {
-				calendar.options.numberOfMonths.set($numberOfMonths);
-			}
-		});
-	}
+	effect([options.numberOfMonths], ([$numberOfMonths]) => {
+		calendar.options.numberOfMonths.set($numberOfMonths);
+	});
 
-	if (options.fixedWeeks != undefined) {
-		effect([options.fixedWeeks], ([$fixedWeeks]) => {
-			if ($fixedWeeks != undefined) {
-				calendar.options.fixedWeeks.set($fixedWeeks);
-			}
-		});
-	}
+	effect([options.fixedWeeks], ([$fixedWeeks]) => {
+		calendar.options.fixedWeeks.set($fixedWeeks);
+	});
 
-	if (options.weekStartsOn != undefined) {
-		effect([options.weekStartsOn], ([$weekStartsOn]) => {
-			if ($weekStartsOn != undefined) {
-				calendar.options.weekStartsOn.set($weekStartsOn);
-			}
-		});
-	}
+	effect([options.weekStartsOn], ([$weekStartsOn]) => {
+		calendar.options.weekStartsOn.set($weekStartsOn);
+	});
 
 	const dateFieldOptions = omit(
 		dateField.options,

--- a/src/tests/calendar/Calendar.spec.ts
+++ b/src/tests/calendar/Calendar.spec.ts
@@ -720,7 +720,7 @@ describe('Calendar', () => {
 		}
 	});
 
-	test('dynamically change weekStartsOn option', async () => {
+	test('dynamically change fixedWeeks option', async () => {
 		const { getByTestId, queryByTestId, user } = setup();
 
 		const nextButton = getByTestId('next-button');

--- a/src/tests/date-picker/DatePicker.spec.ts
+++ b/src/tests/date-picker/DatePicker.spec.ts
@@ -560,4 +560,66 @@ describe('DatePicker', () => {
 
 		expect(trigger).toBeDisabled();
 	});
+
+	test('dynamically change numberOfMonths option even if numberOfMonths is specified as an option', async () => {
+		const { queryByTestId, getByTestId, user } = setup({
+			numberOfMonths: 1,
+		});
+
+		let grid0 = queryByTestId('grid-0');
+		let grid1 = queryByTestId('grid-1');
+		expect(grid0).toBeInTheDocument();
+		expect(grid1).toBeNull();
+
+		const numberOfMonthsButton = getByTestId('numberOfMonths');
+		await user.click(numberOfMonthsButton);
+
+		grid0 = queryByTestId('grid-0');
+		grid1 = queryByTestId('grid-1');
+		expect(grid0).toBeInTheDocument();
+		expect(grid1).toBeInTheDocument();
+	});
+
+	test('dynamically change weekStartsOn option even if weekStartsOn option is set', async () => {
+		const { getByTestId, user } = setup({
+			weekStartsOn: 0,
+		});
+
+		const weekDaysCopy = [...narrowWeekdays];
+
+		let weekdayElement = getByTestId(`weekdays`);
+
+		for (let i = 0; i < weekDaysCopy.length; i++) {
+			expect(weekdayElement.children[i]).toHaveTextContent(weekDaysCopy[i]);
+		}
+
+		const weekStartsOnButton = getByTestId('weekStartsOn');
+		await user.click(weekStartsOnButton);
+		const first = weekDaysCopy.shift();
+		if (first) {
+			weekDaysCopy.push(first);
+		}
+
+		weekdayElement = getByTestId(`weekdays`);
+		for (let i = 0; i < weekDaysCopy.length; i++) {
+			expect(weekdayElement.children[i]).toHaveTextContent(weekDaysCopy[i]);
+		}
+	});
+
+	test('dynamically change fixedWeeks option even if fixedWeeks option is set', async () => {
+		const { getByTestId, queryByTestId, user } = setup({
+			fixedWeeks: false,
+		});
+
+		const nextButton = getByTestId('next-button');
+
+		while (queryByTestId('week-6') !== null) {
+			await user.click(nextButton);
+		}
+
+		const fixedWeeksButton = getByTestId('fixedWeeks');
+		await user.click(fixedWeeksButton);
+
+		expect(queryByTestId('week-6')).not.toBeNull();
+	});
 });

--- a/src/tests/date-picker/DatePickerTest.svelte
+++ b/src/tests/date-picker/DatePickerTest.svelte
@@ -27,6 +27,7 @@
 	export let placeholder: CreateDatePickerProps['placeholder'] = undefined;
 	export let weekStartsOn: CreateDatePickerProps['weekStartsOn'] = undefined;
 	export let weekdayFormat: CreateDatePickerProps['weekdayFormat'] = undefined;
+	export let fixedWeeks: CreateDatePickerProps['fixedWeeks'] = undefined;
 	export let onOutsideClick: CreateDatePickerProps['onOutsideClick'] = undefined;
 
 	const {
@@ -45,7 +46,13 @@
 			validation,
 		},
 		states: { value: insideValue, months, headingValue, weekdays, segmentContents },
-		options: { locale: insideLocale, weekdayFormat: weekdayFormatOption },
+		options: {
+			locale: insideLocale,
+			weekdayFormat: weekdayFormatOption,
+			numberOfMonths: numberOfMonthsOption,
+			fixedWeeks: fixedWeeksOption,
+			weekStartsOn: weekStartsOnOption,
+		},
 	} = createDatePicker(
 		removeUndefined({
 			value,
@@ -72,8 +79,13 @@
 			weekdayFormat,
 			popoverIds,
 			onOutsideClick,
+			fixedWeeks,
 		})
 	);
+
+	function cycleWeekStart() {
+		$weekStartsOnOption = ((($weekStartsOnOption ?? 0) + 1) % 7) as typeof $weekStartsOnOption;
+	}
 
 	function cycleWeekdayFormat() {
 		weekdayFormatOption.update((prev) => {
@@ -138,7 +150,7 @@
 				{@const { weeks } = month}
 				<table use:melt={$grid} class="w-full" data-testid="grid-{i}">
 					<thead aria-hidden="true">
-						<tr>
+						<tr data-testid="weekdays">
 							{#each $weekdays as day, idx}
 								<th class="text-sm font-semibold text-magnum-800">
 									<div
@@ -152,8 +164,8 @@
 						</tr>
 					</thead>
 					<tbody>
-						{#each weeks as days}
-							<tr>
+						{#each weeks as days, i}
+							<tr data-testid="week-{i + 1}">
 								{#each days as date}
 									<td role="gridcell">
 										<div
@@ -174,6 +186,24 @@
 		<button on:click={cycleWeekdayFormat} data-testid="cycle-weekday-format">
 			Cycle weekdayFormat
 		</button>
+		<button
+			data-testid="numberOfMonths"
+			on:click={() => {
+				if (!$numberOfMonthsOption) {
+					$numberOfMonthsOption = 1;
+				}
+				$numberOfMonthsOption++;
+			}}>numberOfMonths</button
+		>
+		<br />
+		<button data-testid="weekStartsOn" on:click={cycleWeekStart}>weekStartsOn</button>
+		<br />
+		<button
+			data-testid="fixedWeeks"
+			on:click={() => {
+				$fixedWeeksOption = !$fixedWeeksOption;
+			}}>fixedWeeksOption</button
+		>
 	</div>
 </main>
 

--- a/src/tests/date-picker/DatePickerTest.svelte
+++ b/src/tests/date-picker/DatePickerTest.svelte
@@ -84,7 +84,7 @@
 	);
 
 	function cycleWeekStart() {
-		$weekStartsOnOption = ((($weekStartsOnOption ?? 0) + 1) % 7) as typeof $weekStartsOnOption;
+		$weekStartsOnOption = (($weekStartsOnOption + 1) % 7) as typeof $weekStartsOnOption;
 	}
 
 	function cycleWeekdayFormat() {
@@ -189,9 +189,6 @@
 		<button
 			data-testid="numberOfMonths"
 			on:click={() => {
-				if (!$numberOfMonthsOption) {
-					$numberOfMonthsOption = 1;
-				}
 				$numberOfMonthsOption++;
 			}}>numberOfMonths</button
 		>

--- a/src/tests/range-calendar/RangeCalendar.spec.ts
+++ b/src/tests/range-calendar/RangeCalendar.spec.ts
@@ -542,7 +542,7 @@ describe('Range Calendar', () => {
 		}
 	});
 
-	test('dynamically change weekStartsOn option', async () => {
+	test('dynamically change fixedWeeks option', async () => {
 		const { getByTestId, queryByTestId, user } = setup();
 
 		const nextButton = getByTestId('next-button');


### PR DESCRIPTION
Closes #1074 

I initially added the code to sync the options in the range date picker to but i just now realized while writing the tests that the range date picker doesn't expose the calendar options like `numberOfMonths`, `fixedWeeks` or `weekStartsOn`. I have everything stashed locally so if you prefer that i expose those props in another PR and then sync them i can do it. In the meantime here it is.

EDIT: i've also fixed a couple of test names in my two old PRs