### PR TITLE
fix not reusing portals

### DIFF
--- a/.changeset/tough-bees-hunt.md
+++ b/.changeset/tough-bees-hunt.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+Not reusing portals for multiple components by default.

--- a/src/lib/internal/helpers/attr.ts
+++ b/src/lib/internal/helpers/attr.ts
@@ -24,7 +24,7 @@ export const hiddenInputAttrs = {
  */
 export function portalAttr(portal: string | HTMLElement | null | undefined) {
 	if (portal !== null) {
-		return '';
+		return portal;
 	}
 	return undefined;
 }


### PR DESCRIPTION
We should not reuse portals by default.
For example, if we have a tooltip inside a popover, if we reuse portals and set `overflow: hidden` on the popover, the tooltip gets clipped.

Portals solve many issues but the benefits of them disappear if you reuse portals for multiple components.

Radix UI doesn't reuse portals. A tooltip inside a popover is rendered in a new portal.