### PR TITLE
fix action cleanup function not running due to race condition and promises

### DIFF
--- a/.changeset/sharp-files-deliver.md
+++ b/.changeset/sharp-files-deliver.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+Fix bug where action doesn't get cleaned up due to race conditions with promises (closes #1086)

--- a/.changeset/sharp-files-deliver.md
+++ b/.changeset/sharp-files-deliver.md
@@ -2,4 +2,4 @@
 '@melt-ui/svelte': patch
 ---
 
-Fix bug where action doesn't get cleaned up due to race conditions with promises (closes #1086)
+Fixed memory leak caused by race conditions for various components (closes #1086)

--- a/src/lib/builders/context-menu/create.ts
+++ b/src/lib/builders/context-menu/create.ts
@@ -159,6 +159,7 @@ export function createContextMenu(props?: CreateContextMenuProps) {
 					unsubPopper();
 					if (!$isVisible || !$rootActiveTrigger) return;
 					tick().then(() => {
+						unsubPopper();
 						setMeltMenuAttribute(node, selector);
 						const $virtual = virtual.get();
 						const popper = usePopper(node, {

--- a/src/lib/builders/link-preview/create.ts
+++ b/src/lib/builders/link-preview/create.ts
@@ -191,6 +191,7 @@ export function createLinkPreview(props: CreateLinkPreviewProps = {}) {
 					if (!$isVisible || !$activeTrigger) return;
 
 					tick().then(() => {
+						unsubPopper();
 						const popper = usePopper(node, {
 							anchorElement: $activeTrigger,
 							open: open,

--- a/src/lib/builders/listbox/create.ts
+++ b/src/lib/builders/listbox/create.ts
@@ -480,6 +480,7 @@ export function createListbox<
 						if (!$isVisible || !$activeTrigger) return;
 
 						tick().then(() => {
+							unsubPopper();
 							const ignoreHandler = createClickOutsideIgnore(ids.trigger.get());
 
 							const popper = usePopper(node, {

--- a/src/lib/builders/menu/create.ts
+++ b/src/lib/builders/menu/create.ts
@@ -185,6 +185,7 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 					unsubPopper();
 					if (!$isVisible || !$rootActiveTrigger) return;
 					tick().then(() => {
+						unsubPopper();
 						setMeltMenuAttribute(node, selector);
 						const popper = usePopper(node, {
 							anchorElement: $rootActiveTrigger,
@@ -792,6 +793,7 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 						const activeTrigger = subActiveTrigger.get();
 						if (!activeTrigger) return;
 						tick().then(() => {
+							unsubPopper();
 							const parentMenuEl = getParentMenu(activeTrigger);
 
 							const popper = usePopper(node, {

--- a/src/lib/builders/menubar/create.ts
+++ b/src/lib/builders/menubar/create.ts
@@ -163,6 +163,7 @@ export function createMenubar(props?: CreateMenubarProps) {
 						if (!($rootOpen && $rootActiveTrigger)) return;
 
 						tick().then(() => {
+							unsubPopper();
 							const popper = usePopper(node, {
 								anchorElement: $rootActiveTrigger,
 								open: rootOpen,

--- a/src/lib/builders/popover/create.ts
+++ b/src/lib/builders/popover/create.ts
@@ -135,6 +135,7 @@ export function createPopover(args?: CreatePopoverProps) {
 					if (!$isVisible || !$activeTrigger) return;
 
 					tick().then(() => {
+						unsubPopper();
 						const popper = usePopper(node, {
 							anchorElement: $activeTrigger,
 							open,

--- a/src/lib/builders/tooltip/create.ts
+++ b/src/lib/builders/tooltip/create.ts
@@ -213,23 +213,19 @@ export function createTooltip(props?: CreateTooltipProps) {
 			const unsubDerived = effect(
 				[isVisible, positioning, portal],
 				([$isVisible, $positioning, $portal]) => {
+					unsubPortal();
+					unsubFloating();
 					const triggerEl = getEl('trigger');
-					if (!$isVisible || !triggerEl) {
-						unsubPortal();
-						unsubFloating();
-						return;
-					}
+					if (!$isVisible || !triggerEl) return;
 
 					tick().then(() => {
-						if ($portal === null) {
-							unsubPortal();
-						} else {
-							const portalDest = getPortalDestination(node, $portal);
-							if (portalDest) {
-								const portalReturn = usePortal(node, portalDest);
-								if (portalReturn && portalReturn.destroy) {
-									unsubPortal = portalReturn.destroy;
-								}
+						unsubPortal();
+						unsubFloating();
+						const portalDest = getPortalDestination(node, $portal);
+						if (portalDest) {
+							const portalReturn = usePortal(node, portalDest);
+							if (portalReturn && portalReturn.destroy) {
+								unsubPortal = portalReturn.destroy;
 							}
 						}
 


### PR DESCRIPTION
closes https://github.com/melt-ui/melt-ui/issues/1086

See the above issue for the full details. 
The action cleanup functions don't run in the following condition:
- When setting the cleanup function after a promise (i.e. tick())
- When the effect runs twice "concurrently", which can happen when updating more than 1 store that the effect depends on

Let's assess what happens with the following popover code assuming forceVisible is `false` and so `isVisible` matches the open state. Also, for context, the popover `handleOpen` sets the open state to true and sets the active trigger as well, which causes the following action to run twice "concurrently".

```typescript
const content = makeElement(name('content'), {
  action: (node: HTMLElement) => {
    let unsubPopper = noop;

    const unsubDerived = effect([isVisible, activeTrigger], ([$isVisible, $activeTrigger]) => {
      unsubPopper();
      if (!$isVisible || !$activeTrigger) return;

      tick().then(() => {
        unsubPopper = usePopper(node).destroy;
      });
    });

    return {
      destroy() {
        unsubDerived();
        unsubPopper();
      },
    };
  },
});
```

In the first run, we call `unsubPopper` which is `noop`. Then we create a promise in `tick()`. Before the promise gets resolved, the action gets rerun a second time. We call `unsubPopper` which is still `noop`. The second rerun creates a promise as well. Now the first promise gets resolved and creates a popper action. And then the second rerun promise gets resolved and creates another popper action. And this is how we ended up not running the previous cleanup.

This is solved by running the cleanup after the promise in `tick()` is resolved.

Before & After
I added the following lines of code to `usePopper` to log when the pointer enters the popper element
```typescript
const onPointerEnter = () => console.log('pointer entered');
popperElement.addEventListener('pointerenter', onPointerEnter);
callbacks.push(() => popperElement.removeEventListener('pointerenter', onPointerEnter));
```

https://github.com/melt-ui/melt-ui/assets/53095479/bb2160e0-ecf6-4726-a298-9bdf01494205
