### PR TITLE
performance improvement: avoid effect multiple runs

### DIFF
--- a/.changeset/silly-eels-search.md
+++ b/.changeset/silly-eels-search.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+performance: avoid effect multiple runs

--- a/src/lib/builders/listbox/create.ts
+++ b/src/lib/builders/listbox/create.ts
@@ -212,7 +212,7 @@ export function createListbox<
 		if (!triggerEl) return;
 
 		// The active trigger is used to anchor the menu to the input element.
-		if (triggerEl !== get(activeTrigger)) activeTrigger.set(triggerEl);
+		if (triggerEl !== activeTrigger.get()) activeTrigger.set(triggerEl);
 
 		// Wait a tick for the menu to open then highlight the selected item.
 		await tick();

--- a/src/lib/builders/listbox/create.ts
+++ b/src/lib/builders/listbox/create.ts
@@ -212,7 +212,7 @@ export function createListbox<
 		if (!triggerEl) return;
 
 		// The active trigger is used to anchor the menu to the input element.
-		activeTrigger.set(triggerEl);
+		if (triggerEl !== get(activeTrigger)) activeTrigger.set(triggerEl);
 
 		// Wait a tick for the menu to open then highlight the selected item.
 		await tick();

--- a/src/lib/builders/popover/create.ts
+++ b/src/lib/builders/popover/create.ts
@@ -30,7 +30,7 @@ import {
 import { safeOnMount } from '$lib/internal/helpers/lifecycle.js';
 import type { Defaults, MeltActionReturn } from '$lib/internal/types.js';
 import { tick } from 'svelte';
-import { writable } from 'svelte/store';
+import { get, writable } from 'svelte/store';
 import type { PopoverEvents } from './events.js';
 import type { CreatePopoverProps } from './types.js';
 
@@ -184,7 +184,7 @@ export function createPopover(args?: CreatePopoverProps) {
 		open.update((prev) => {
 			return !prev;
 		});
-		if (triggerEl) {
+		if (triggerEl && triggerEl !== get(activeTrigger)) {
 			activeTrigger.set(triggerEl);
 		}
 	}

--- a/src/lib/builders/popover/create.ts
+++ b/src/lib/builders/popover/create.ts
@@ -19,6 +19,7 @@ import {
 	toWritableStores,
 	portalAttr,
 	generateIds,
+	withGet,
 } from '$lib/internal/helpers/index.js';
 
 import {
@@ -30,7 +31,7 @@ import {
 import { safeOnMount } from '$lib/internal/helpers/lifecycle.js';
 import type { Defaults, MeltActionReturn } from '$lib/internal/types.js';
 import { tick } from 'svelte';
-import { get, writable } from 'svelte/store';
+import { writable } from 'svelte/store';
 import type { PopoverEvents } from './events.js';
 import type { CreatePopoverProps } from './types.js';
 
@@ -79,7 +80,7 @@ export function createPopover(args?: CreatePopoverProps) {
 	const openWritable = withDefaults.open ?? writable(withDefaults.defaultOpen);
 	const open = overridable(openWritable, withDefaults?.onOpenChange);
 
-	const activeTrigger = writable<HTMLElement | null>(null);
+	const activeTrigger = withGet.writable<HTMLElement | null>(null);
 
 	const ids = toWritableStores({ ...generateIds(popoverIdParts), ...withDefaults.ids });
 
@@ -184,7 +185,7 @@ export function createPopover(args?: CreatePopoverProps) {
 		open.update((prev) => {
 			return !prev;
 		});
-		if (triggerEl && triggerEl !== get(activeTrigger)) {
+		if (triggerEl && triggerEl !== activeTrigger.get()) {
 			activeTrigger.set(triggerEl);
 		}
 	}


### PR DESCRIPTION
issue https://github.com/melt-ui/melt-ui/issues/1086 describes the effect running twice since we update both the open and activeTrigger stores. The issue was already fixed in PR https://github.com/melt-ui/melt-ui/pull/1087, but we can avoid running the effect twice by not updating the active trigger store if it's the same as the previous. Just a slight performance improvement.