### PR TITLE
fix(dialog,popover):focus trap `closeOnOutsideClick: false` bug

### DIFF
--- a/.changeset/fifty-pigs-promise.md
+++ b/.changeset/fifty-pigs-promise.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+Fixed bug where focus trap deactivates in dialog and popover when clicking outside provided `closeOnOutsideClick: false` (closes #1084)

--- a/src/lib/builders/dialog/create.ts
+++ b/src/lib/builders/dialog/create.ts
@@ -186,13 +186,14 @@ export function createDialog(props?: CreateDialogProps) {
 			let deactivate = noop;
 
 			const destroy = executeCallbacks(
-				effect([open], ([$open]) => {
+				effect([open, closeOnOutsideClick], ([$open, $closeOnOutsideClick]) => {
 					if (!$open) return;
 
 					const focusTrap = createFocusTrap({
 						immediate: false,
 						escapeDeactivates: true,
-						clickOutsideDeactivates: true,
+						clickOutsideDeactivates: $closeOnOutsideClick,
+						allowOutsideClick: true,
 						returnFocusOnDeactivate: false,
 						fallbackFocus: node,
 					});

--- a/src/lib/builders/popover/create.ts
+++ b/src/lib/builders/popover/create.ts
@@ -144,7 +144,8 @@ export function createPopover(args?: CreatePopoverProps) {
 									? null
 									: {
 											returnFocusOnDeactivate: false,
-											clickOutsideDeactivates: true,
+											clickOutsideDeactivates: $closeOnOutsideClick,
+											allowOutsideClick: true,
 											escapeDeactivates: true,
 									  },
 								modal: {

--- a/src/tests/dialog/Dialog.spec.ts
+++ b/src/tests/dialog/Dialog.spec.ts
@@ -277,4 +277,19 @@ describe('Dialog', () => {
 		await user.pointer({ target: overlay, offset: 2, keys: '[/MouseLeft]' });
 		expect(content).not.toBeVisible();
 	});
+
+	it("Doesn't deactivate focus trap on outside click provided `closeOnOutsideClick` false", async () => {
+		const { getByTestId, user, trigger } = setup({
+			closeOnOutsideClick: false,
+		});
+		const content = getByTestId('content');
+		expect(content).not.toBeVisible();
+		await user.click(trigger);
+		expect(content).toBeVisible();
+		await user.click(getByTestId('overlay'));
+		expect(content).toBeVisible();
+		expect(getByTestId('content')).toHaveFocus();
+		await user.tab({ shift: true });
+		expect(getByTestId('floating-closer')).not.toHaveFocus();
+	});
 });

--- a/src/tests/popover/Popover.spec.ts
+++ b/src/tests/popover/Popover.spec.ts
@@ -135,4 +135,18 @@ describe('Popover (Default)', () => {
 		expect(trigger.id).toBe(ids.trigger);
 		expect(content.id).toBe(ids.content);
 	});
+
+	it("Doesn't deactivate focus trap on outside click provided `closeOnOutsideClick` false", async () => {
+		const { getByTestId, user, trigger } = setup({
+			closeOnOutsideClick: false,
+		});
+		const content = getByTestId('content');
+		expect(content).not.toBeVisible();
+		await user.click(trigger);
+		expect(content).toBeVisible();
+		await user.click(getByTestId('outside'));
+		expect(content).toBeVisible();
+		await user.tab();
+		expect(getByTestId('closeFocus')).not.toHaveFocus();
+	});
 });


### PR DESCRIPTION
closes https://github.com/melt-ui/melt-ui/issues/1084

Focus trap should not deactivate on click outside if the prop `closeOnOutsideClick: false` is passed. To make sure that this issue https://github.com/melt-ui/melt-ui/issues/452 doesn't occur, we need to allow outside clicks in the focus trap--this doesn't affect the content getting closes.

### Popover Before with `closeOnOutsideClick: false`

https://github.com/melt-ui/melt-ui/assets/53095479/f4e9d207-dc24-455a-93ed-1c0cee4baa9f



### Popover After

https://github.com/melt-ui/melt-ui/assets/53095479/3bc5c44d-9810-484b-8456-792eb9754fa5


### Dialog Before with `closeOnOutsideClick: false`

https://github.com/melt-ui/melt-ui/assets/53095479/55c63c71-d823-4d4f-bc7f-6ea719cf412b


### Dialog After

https://github.com/melt-ui/melt-ui/assets/53095479/d85f6682-aa51-4efb-a1c6-40b831e96471

