### PR TITLE
fix(dialog, popover): focus trap deactivates on escape provided `closeOnEscape: false`

### DIFF
--- a/.changeset/many-rockets-cough.md
+++ b/.changeset/many-rockets-cough.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+Fixed bug where focus trap deactivates in dialog and popover when pressing escape provided `closeOnEscape: false` (closes #1091)

--- a/src/lib/builders/dialog/create.ts
+++ b/src/lib/builders/dialog/create.ts
@@ -186,12 +186,12 @@ export function createDialog(props?: CreateDialogProps) {
 			let deactivate = noop;
 
 			const destroy = executeCallbacks(
-				effect([open], ([$open]) => {
+				effect([open, closeOnEscape], ([$open, $closeOnEscape]) => {
 					if (!$open) return;
 
 					const focusTrap = createFocusTrap({
 						immediate: false,
-						escapeDeactivates: true,
+						escapeDeactivates: $closeOnEscape,
 						clickOutsideDeactivates: true,
 						returnFocusOnDeactivate: false,
 						fallbackFocus: node,

--- a/src/lib/builders/popover/create.ts
+++ b/src/lib/builders/popover/create.ts
@@ -145,7 +145,7 @@ export function createPopover(args?: CreatePopoverProps) {
 									: {
 											returnFocusOnDeactivate: false,
 											clickOutsideDeactivates: true,
-											escapeDeactivates: true,
+											escapeDeactivates: $closeOnEscape,
 									  },
 								modal: {
 									shouldCloseOnInteractOutside: shouldCloseOnInteractOutside,


### PR DESCRIPTION
closes https://github.com/melt-ui/melt-ui/issues/1091

Focus trap should not deactivate when escape is pressed if the prop `closeOnEscape: false` is provided. 

### Popover Before with `closeOnEscape: false`

https://github.com/melt-ui/melt-ui/assets/53095479/5ffbea4c-f9e1-46b7-b0b8-fbe4c9bba2c3



### Popover After

https://github.com/melt-ui/melt-ui/assets/53095479/57633812-b6aa-40a7-b068-8459fc1a01d5


### Dialog Before with `closeOnEscape: false`

https://github.com/melt-ui/melt-ui/assets/53095479/167c7346-a1ac-4263-b60d-a444fa95d4eb


### Dialog After

https://github.com/melt-ui/melt-ui/assets/53095479/73d05257-ddc9-4eb3-96fb-2b8de71675dd

