### PR TITLE
docs: fix tooltip always mounted

### DIFF
--- a/src/docs/components/tooltip.svelte
+++ b/src/docs/components/tooltip.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { browser } from '$app/environment';
 	import { createTooltip, melt } from '$lib/index.js';
+	import { fade } from 'svelte/transition';
 
 	const {
 		elements: { trigger, content, arrow },
@@ -20,30 +20,20 @@
 	<slot />
 </div>
 
-<div
-	use:melt={$content}
-	class="z-50 rounded-md bg-neutral-700 px-2 py-1 text-sm text-neutral-50 shadow-sm"
-	data-open={$open ? '' : undefined}
-	class:hidden={!browser}
->
-	<div use:melt={$arrow} />
-	{text}
-</div>
+{#if $open}
+	<div
+		use:melt={$content}
+		in:fade={{ duration: 150 }}
+		class="z-50 rounded-md bg-neutral-700 px-2 py-1 text-sm text-neutral-50 shadow-sm"
+	>
+		<div use:melt={$arrow} />
+		{text}
+	</div>
+{/if}
 
 <style lang="postcss">
 	[data-melt-tooltip-trigger] {
 		display: grid;
 		place-items: center;
-	}
-
-	[data-melt-tooltip-content] {
-		opacity: 0;
-		visibility: hidden;
-		transition: opacity 150ms ease;
-
-		&[data-open] {
-			opacity: 1;
-			visibility: visible;
-		}
 	}
 </style>


### PR DESCRIPTION
We should not keep the tooltip always mounted. 
After this PR https://github.com/melt-ui/melt-ui/pull/1080, this will cause the tooltip to always stay in the stack and so escape key presses will behave unexpectedly. 

So for example, in the docs we have 2 tooltips using this component--the theme switcher and search. Since the tooltips are always mounted, the first tooltip when open will not react to an escape key press since it's not in the top of the stack.