### PR TITLE
docs: fix should not keep dialog always mounted

### DIFF
--- a/src/docs/components/nav/mobile-nav.svelte
+++ b/src/docs/components/nav/mobile-nav.svelte
@@ -25,8 +25,8 @@
 	<Menu class="size-6" />
 	<span class="sr-only">Toggle Menu</span>
 </button>
-<div use:melt={$portalled} class="md:hidden">
-	{#if $open}
+{#if $open}
+	<div use:melt={$portalled} class="md:hidden">
 		<div
 			use:melt={$overlay}
 			class="fixed inset-0 z-50 bg-black/80 backdrop-blur-sm"
@@ -86,8 +86,8 @@
 				</div>
 			</div>
 		</div>
-	{/if}
-</div>
+	</div>
+{/if}
 
 <style lang="postcss">
 	.menu,

--- a/src/docs/content/builders/dialog.md
+++ b/src/docs/content/builders/dialog.md
@@ -28,16 +28,16 @@ At a high level, the anatomy of a dialog looks like this:
 
 <button use:melt={$trigger}> Open Dialog </button>
 
-<div use:melt={$portalled}>
-	{#if $open}
+{#if $open}
+	<div use:melt={$portalled}>
 		<div use:melt={$overlay} />
 		<div use:melt={$content}>
 			<h2 use:melt={$title}>Dialog Title</h2>
 			<p use:melt={$description}>Dialog description</p>
 			<button use:melt={$close}> Close Dialog </button>
 		</div>
-	{/if}
-</div>
+	</div>
+{/if}
 ```
 
 - **Trigger**: The button(s) that open the dialog

--- a/src/docs/previews/dialog/alert/css/index.svelte
+++ b/src/docs/previews/dialog/alert/css/index.svelte
@@ -22,8 +22,8 @@
 </script>
 
 <button use:melt={$trigger} class="trigger"> Delete Item </button>
-<div use:melt={$portalled}>
-	{#if $open}
+{#if $open}
+	<div use:melt={$portalled}>
 		<div use:melt={$overlay} class="overlay" />
 		<div
 			class="content"
@@ -51,8 +51,8 @@
 				<X class="size-4" />
 			</button>
 		</div>
-	{/if}
-</div>
+	</div>
+{/if}
 
 <style>
 	.trigger {

--- a/src/docs/previews/dialog/alert/tailwind/index.svelte
+++ b/src/docs/previews/dialog/alert/tailwind/index.svelte
@@ -29,8 +29,8 @@
 	Delete Item
 </button>
 
-<div class="force-dark" use:melt={$portalled}>
-	{#if $open}
+{#if $open}
+	<div class="force-dark" use:melt={$portalled}>
 		<div use:melt={$overlay} class="fixed inset-0 z-50 bg-black/50" />
 		<div
 			class="fixed left-[50%] top-[50%] z-50 max-h-[85vh] w-[90vw]
@@ -78,5 +78,5 @@
 				<X class="size-4" />
 			</button>
 		</div>
-	{/if}
-</div>
+	</div>
+{/if}

--- a/src/docs/previews/dialog/controlled/css/index.svelte
+++ b/src/docs/previews/dialog/controlled/css/index.svelte
@@ -25,8 +25,8 @@
 </script>
 
 <button use:melt={$trigger} class="trigger"> Open Dialog </button>
-<div use:melt={$portalled}>
-	{#if $open}
+{#if $open}
+	<div use:melt={$portalled}>
 		<div use:melt={$overlay} class="overlay" />
 		<div
 			class="content"
@@ -59,8 +59,8 @@
 				<X class="size-4" />
 			</button>
 		</div>
-	{/if}
-</div>
+	</div>
+{/if}
 
 <style lang="postcss">
 	.trigger {

--- a/src/docs/previews/dialog/controlled/tailwind/index.svelte
+++ b/src/docs/previews/dialog/controlled/tailwind/index.svelte
@@ -31,8 +31,8 @@
 >
 	Open Dialog
 </button>
-<div class="force-dark" use:melt={$portalled}>
-	{#if $open}
+{#if $open}
+	<div class="force-dark" use:melt={$portalled}>
 		<div use:melt={$overlay} class="fixed inset-0 z-50 bg-black/50" />
 		<div
 			class="fixed left-[50%] top-[50%] z-50 max-h-[85vh] w-[90vw]
@@ -101,5 +101,5 @@
 				<X class="size-4" />
 			</button>
 		</div>
-	{/if}
-</div>
+	</div>
+{/if}

--- a/src/docs/previews/dialog/drawer/css/index.svelte
+++ b/src/docs/previews/dialog/drawer/css/index.svelte
@@ -21,8 +21,8 @@
 </script>
 
 <button use:melt={$trigger} class="trigger"> View Notifications </button>
-<div use:melt={$portalled}>
-	{#if $open}
+{#if $open}
+	<div use:melt={$portalled}>
 		<div
 			use:melt={$overlay}
 			class="overlay"
@@ -57,8 +57,8 @@
 				</div>
 			</section>
 		</div>
-	{/if}
-</div>
+	</div>
+{/if}
 
 <style>
 	.trigger {

--- a/src/docs/previews/dialog/drawer/tailwind/index.svelte
+++ b/src/docs/previews/dialog/drawer/tailwind/index.svelte
@@ -28,8 +28,8 @@
 >
 	View Notifications
 </button>
-<div class="force-dark" use:melt={$portalled}>
-	{#if $open}
+{#if $open}
+	<div class="force-dark" use:melt={$portalled}>
 		<div
 			use:melt={$overlay}
 			class="fixed inset-0 z-50 bg-black/50"
@@ -88,5 +88,5 @@
 				</div>
 			</section>
 		</div>
-	{/if}
-</div>
+	</div>
+{/if}

--- a/src/docs/previews/dialog/main/css/index.svelte
+++ b/src/docs/previews/dialog/main/css/index.svelte
@@ -19,8 +19,8 @@
 </script>
 
 <button use:melt={$trigger} class="trigger"> Open Dialog </button>
-<div use:melt={$portalled}>
-	{#if $open}
+{#if $open}
+	<div use:melt={$portalled}>
 		<div use:melt={$overlay} class="overlay" />
 		<div
 			class="content"
@@ -53,8 +53,8 @@
 				<X class="size-4" />
 			</button>
 		</div>
-	{/if}
-</div>
+	</div>
+{/if}
 
 <style lang="postcss">
 	.trigger {

--- a/src/docs/previews/dialog/main/tailwind/index.svelte
+++ b/src/docs/previews/dialog/main/tailwind/index.svelte
@@ -29,8 +29,8 @@
 	Open Dialog
 </button>
 
-<div class="force-dark" use:melt={$portalled}>
-	{#if $open}
+{#if $open}
+	<div class="force-dark" use:melt={$portalled}>
 		<div
 			use:melt={$overlay}
 			class="fixed inset-0 z-50 bg-black/50"
@@ -100,5 +100,5 @@
 				<X class="size-4" />
 			</button>
 		</div>
-	{/if}
-</div>
+	</div>
+{/if}

--- a/src/docs/previews/dialog/nested/css/index.svelte
+++ b/src/docs/previews/dialog/nested/css/index.svelte
@@ -36,8 +36,8 @@
 </script>
 
 <button use:melt={$trigger} class="trigger"> Open Dialog </button>
-<div use:melt={$portalled}>
-	{#if $open}
+{#if $open}
+	<div use:melt={$portalled}>
 		<div use:melt={$overlay} class="overlay" />
 		<div
 			class="content"
@@ -62,11 +62,11 @@
 				<X />
 			</button>
 		</div>
-	{/if}
-</div>
+	</div>
+{/if}
 
-<div use:melt={$portalledNested}>
-	{#if $openNested}
+{#if $openNested}
+	<div use:melt={$portalledNested}>
 		<div use:melt={$overlayNested} class="overlay overlay-nested" />
 		<div
 			class="content content-nested"
@@ -90,8 +90,8 @@
 				<X />
 			</button>
 		</div>
-	{/if}
-</div>
+	</div>
+{/if}
 
 <style>
 	.trigger {

--- a/src/docs/previews/dialog/nested/tailwind/index.svelte
+++ b/src/docs/previews/dialog/nested/tailwind/index.svelte
@@ -38,8 +38,8 @@
 >
 	Open Dialog
 </button>
-<div class="force-dark" use:melt={$portalled}>
-	{#if $open}
+{#if $open}
+	<div class="force-dark" use:melt={$portalled}>
 		<div use:melt={$overlay} class="fixed inset-0 z-50 bg-black/50" />
 		<div
 			class="fixed left-[50%] top-[50%] z-50 max-h-[85vh] w-[90vw]
@@ -75,8 +75,8 @@
 					Open second
 				</button>
 			</div>
-			<div class="force-dark" use:melt={$portalledNested}>
-				{#if $openNested}
+			{#if $openNested}
+				<div class="force-dark" use:melt={$portalledNested}>
 					<div
 						use:melt={$overlayNested}
 						class="fixed inset-0 z-50 bg-black/75"
@@ -124,8 +124,8 @@
 							<X class="size-4" />
 						</button>
 					</div>
-				{/if}
-			</div>
+				</div>
+			{/if}
 		</div>
 		<button
 			use:melt={$close}
@@ -135,5 +135,5 @@
 		>
 			<X />
 		</button>
-	{/if}
-</div>
+	</div>
+{/if}

--- a/src/tests/dialog/DialogNestedTest.svelte
+++ b/src/tests/dialog/DialogNestedTest.svelte
@@ -22,8 +22,8 @@
 
 <main>
 	<button use:melt={$trigger} data-testid="trigger">Open</button>
-	<div use:melt={$portalled} data-testid="portalled">
-		{#if $open}
+	{#if $open}
+		<div use:melt={$portalled} data-testid="portalled">
 			<div use:melt={$overlay} data-testid="overlay" transition:fade />
 			<div use:melt={$content} data-testid="content">
 				<h2 use:melt={$title}>Title</h2>
@@ -31,8 +31,8 @@
 
 				<button use:melt={$close} data-testid="closer">Close</button>
 				<button use:melt={$triggerA} data-testid="triggerA">Close2</button>
-				<div use:melt={$portalledA} data-testid="portalledA">
-					{#if $openA}
+				{#if $openA}
+					<div use:melt={$portalledA} data-testid="portalledA">
 						<div use:melt={$overlayA} data-testid="overlayA" />
 						<div use:melt={$contentA} data-testid="contentA" transition:fade>
 							<h2 use:melt={$titleA}>Title</h2>
@@ -41,11 +41,11 @@
 							<button use:melt={$closeA} data-testid="closerA">Close</button>
 							<button use:melt={$closeA} data-testid="lastA">Close2</button>
 						</div>
-					{/if}
-				</div>
+					</div>
+				{/if}
 			</div>
-		{/if}
-	</div>
+		</div>
+	{/if}
 </main>
 
 <style>


### PR DESCRIPTION
We should not keep the dialog portalled always mounted. This is fixed in this PR https://github.com/melt-ui/melt-ui/pull/1080, however when using `forceVisible: true`, we should keep the portalled element inside the if block, not outside.

This especially creates issues when using sibling portals. For example, if we use 2 dialogs that should be nested inside each other while using sibling portals and we have the nested dialog in our svelte file above the top dialog. When opening the nested dialog, the nested dialog is going to be "behind" the main dialog. This is because the portal of the nested dialog was mounted first and so the main dialog's portal appears after in the DOM which takes precedent z-index wise even if you give both dialogs the same z-index.