### PR TITLE
fix(combobox): menu close within composition session

### DIFF
--- a/.changeset/giant-queens-drive.md
+++ b/.changeset/giant-queens-drive.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+Combobox: menu no longer closes when composing (Closes: #1106)

--- a/src/lib/builders/listbox/create.ts
+++ b/src/lib/builders/listbox/create.ts
@@ -366,7 +366,10 @@ export function createListbox<
 						return;
 					}
 					// Pressing enter with a highlighted item should select it.
-					if (e.key === kbd.ENTER || (e.key === kbd.SPACE && isHTMLButtonElement(node))) {
+					if (
+						(e.key === kbd.ENTER && !e.isComposing) ||
+						(e.key === kbd.SPACE && isHTMLButtonElement(node))
+					) {
 						e.preventDefault();
 						const $highlightedItem = highlightedItem.get();
 						if ($highlightedItem) {


### PR DESCRIPTION
Fix menu close by Enter event within composition session.

### Before

https://github.com/melt-ui/melt-ui/assets/6259797/1a8c9142-948f-44d6-ae79-f1cda1443111

### After

https://github.com/melt-ui/melt-ui/assets/6259797/aabe1731-feb3-4e42-95c7-101b770f7a13

