### PR TITLE
fix(dialog,popover): restore focus when `open` set to `false`

### DIFF
--- a/.changeset/six-insects-joke.md
+++ b/.changeset/six-insects-joke.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+Fixed a bug where manually closing a dialog or popover would not restore focus to the trigger (closes #1109)

--- a/src/lib/builders/dialog/create.ts
+++ b/src/lib/builders/dialog/create.ts
@@ -95,10 +95,6 @@ export function createDialog(props?: CreateDialogProps) {
 
 	function handleClose() {
 		open.set(false);
-		handleFocus({
-			prop: closeFocus.get(),
-			defaultEl: activeTrigger.get(),
-		});
 	}
 
 	const trigger = makeElement(name('trigger'), {
@@ -326,6 +322,18 @@ export function createDialog(props?: CreateDialogProps) {
 			}
 		};
 	});
+
+	effect(
+		open,
+		($open) => {
+			if (!isBrowser || $open) return;
+			handleFocus({
+				prop: closeFocus.get(),
+				defaultEl: activeTrigger.get(),
+			});
+		},
+		true
+	);
 
 	return {
 		ids,

--- a/src/lib/builders/dialog/create.ts
+++ b/src/lib/builders/dialog/create.ts
@@ -332,7 +332,7 @@ export function createDialog(props?: CreateDialogProps) {
 				defaultEl: activeTrigger.get(),
 			});
 		},
-		true
+		{ skipFirstRun: true }
 	);
 
 	return {

--- a/src/lib/builders/menu/create.ts
+++ b/src/lib/builders/menu/create.ts
@@ -1182,7 +1182,7 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 			if (!isBrowser || $rootOpen) return;
 			handleFocus({ prop: closeFocus.get(), defaultEl: rootActiveTrigger.get() });
 		},
-		true
+		{ skipFirstRun: true }
 	);
 
 	effect([rootOpen, preventScroll], ([$rootOpen, $preventScroll]) => {

--- a/src/lib/builders/menu/create.ts
+++ b/src/lib/builders/menu/create.ts
@@ -206,10 +206,7 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 										}
 										return true;
 									},
-									onClose: () => {
-										rootOpen.set(false);
-										$rootActiveTrigger.focus();
-									},
+									onClose: () => rootOpen.set(false),
 									open: $isVisible,
 								},
 								portal: getPortalDestination(node, $portal),
@@ -351,11 +348,7 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 
 			if (closeOnEscape.get()) {
 				const escapeKeydown = useEscapeKeydown(node, {
-					handler: () => {
-						rootOpen.set(false);
-						const $rootActiveTrigger = rootActiveTrigger.get();
-						if ($rootActiveTrigger) $rootActiveTrigger.focus();
-					},
+					handler: () => rootOpen.set(false),
 				});
 				if (escapeKeydown && escapeKeydown.destroy) {
 					unsubEscapeKeydown = escapeKeydown.destroy;
@@ -1183,18 +1176,14 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 		}
 	});
 
-	effect([rootOpen], ([$rootOpen]) => {
-		if (!isBrowser) return;
-		if (!$rootOpen) {
-			const $rootActiveTrigger = rootActiveTrigger.get();
-			if (!$rootActiveTrigger) return;
-			const $closeFocus = closeFocus.get();
-
-			if (!$rootOpen && $rootActiveTrigger) {
-				handleFocus({ prop: $closeFocus, defaultEl: $rootActiveTrigger });
-			}
-		}
-	});
+	effect(
+		[rootOpen],
+		([$rootOpen]) => {
+			if (!isBrowser || $rootOpen) return;
+			handleFocus({ prop: closeFocus.get(), defaultEl: rootActiveTrigger.get() });
+		},
+		true
+	);
 
 	effect([rootOpen, preventScroll], ([$rootOpen, $preventScroll]) => {
 		if (!isBrowser) return;

--- a/src/lib/builders/popover/create.ts
+++ b/src/lib/builders/popover/create.ts
@@ -341,7 +341,7 @@ export function createPopover(args?: CreatePopoverProps) {
 			const triggerEl = document.getElementById(ids.trigger.get());
 			handleFocus({ prop: closeFocus.get(), defaultEl: triggerEl });
 		},
-		true
+		{ skipFirstRun: true }
 	);
 
 	return {

--- a/src/lib/builders/popover/create.ts
+++ b/src/lib/builders/popover/create.ts
@@ -90,8 +90,6 @@ export function createPopover(args?: CreatePopoverProps) {
 
 	function handleClose() {
 		open.set(false);
-		const triggerEl = document.getElementById(ids.trigger.get());
-		handleFocus({ prop: closeFocus.get(), defaultEl: triggerEl });
 	}
 
 	const isVisible = derivedVisible({ open, activeTrigger, forceVisible });
@@ -335,6 +333,16 @@ export function createPopover(args?: CreatePopoverProps) {
 			unsubs.forEach((unsub) => unsub());
 		};
 	});
+
+	effect(
+		open,
+		($open) => {
+			if (!isBrowser || $open) return;
+			const triggerEl = document.getElementById(ids.trigger.get());
+			handleFocus({ prop: closeFocus.get(), defaultEl: triggerEl });
+		},
+		true
+	);
 
 	return {
 		ids,

--- a/src/lib/internal/helpers/store/effect.ts
+++ b/src/lib/internal/helpers/store/effect.ts
@@ -10,18 +10,25 @@ import { safeOnDestroy } from '../lifecycle.js';
  * @template S - The type of the stores object
  * @param stores - The stores object to derive from
  * @param fn - The function to run when the stores change
+ * @param skipFirstRun - Whether to skip the first run
  * @returns A function that can be used to unsubscribe the effect
  */
 export function effect<S extends Stores>(
 	stores: S,
-	fn: (values: StoresValues<S>) => (() => void) | void
+	fn: (values: StoresValues<S>) => (() => void) | void,
+	skipFirstRun?: boolean
 ): () => void {
 	let cb: (() => void) | void = undefined;
+	let isFirstRun = true;
 
 	// Create a derived store that contains the stores object and an onUnsubscribe function
 	const destroy = derived(stores, (stores) => {
 		cb?.();
-		cb = fn(stores);
+		if (isFirstRun && skipFirstRun) {
+			isFirstRun = false;
+		} else {
+			cb = fn(stores);
+		}
 	}).subscribe(noop);
 
 	const unsub = () => {

--- a/src/lib/internal/helpers/store/effect.ts
+++ b/src/lib/internal/helpers/store/effect.ts
@@ -3,6 +3,14 @@ import { derived } from 'svelte/store';
 import { noop } from '../index.js';
 import { safeOnDestroy } from '../lifecycle.js';
 
+type EffectOptions = {
+	/**
+	 * Whether to skip the first run
+	 * @default undefined
+	 */
+	skipFirstRun?: boolean;
+};
+
 /**
  * A utility function that creates an effect from a set of stores and a function.
  * The effect is automatically cleaned up when the component is destroyed.
@@ -10,16 +18,17 @@ import { safeOnDestroy } from '../lifecycle.js';
  * @template S - The type of the stores object
  * @param stores - The stores object to derive from
  * @param fn - The function to run when the stores change
- * @param skipFirstRun - Whether to skip the first run
+ * @param opts {@link EffectOptions}
  * @returns A function that can be used to unsubscribe the effect
  */
 export function effect<S extends Stores>(
 	stores: S,
 	fn: (values: StoresValues<S>) => (() => void) | void,
-	skipFirstRun?: boolean
+	opts: EffectOptions = {}
 ): () => void {
-	let cb: (() => void) | void = undefined;
+	const { skipFirstRun } = opts;
 	let isFirstRun = true;
+	let cb: (() => void) | void = undefined;
 
 	// Create a derived store that contains the stores object and an onUnsubscribe function
 	const destroy = derived(stores, (stores) => {

--- a/src/lib/internal/helpers/tests/effect.spec.ts
+++ b/src/lib/internal/helpers/tests/effect.spec.ts
@@ -51,4 +51,21 @@ describe('effect', () => {
 		unsub();
 		expect(calls).toBe(1);
 	});
+
+	it('Respect `skipFirstRun` prop', async () => {
+		const w = writable(1);
+		let calls = 0;
+		const unsub = effect(
+			w,
+			() => {
+				calls++;
+			},
+			{ skipFirstRun: true }
+		);
+		expect(calls).toBe(0);
+
+		w.set(2);
+		expect(calls).toBe(1);
+		unsub();
+	});
 });

--- a/src/tests/dialog/Dialog.spec.ts
+++ b/src/tests/dialog/Dialog.spec.ts
@@ -256,25 +256,15 @@ describe('Dialog', () => {
 	});
 
 	it('Returns focus to trigger when manually setting `open` state to false', async () => {
-		const { getByTestId, user, trigger } = setup();
-		const content = getByTestId('content');
-
-		expect(trigger).not.toHaveFocus();
-		await user.click(trigger);
-		expect(content).toBeVisible();
+		const { getByTestId, user, trigger } = await open();
 		await user.click(getByTestId('toggle-open'));
 		expect(trigger).toHaveFocus();
 	});
 
 	it('Respects the `closeFocus` prop when manually setting `open` state to false', async () => {
-		const { getByTestId, user, trigger } = setup({
+		const { getByTestId, user } = await open({
 			closeFocus: () => document.getElementById('closeFocus'),
 		});
-		const content = getByTestId('content');
-
-		expect(trigger).not.toHaveFocus();
-		await user.click(trigger);
-		expect(content).toBeVisible();
 		await user.click(getByTestId('toggle-open'));
 		expect(getByTestId('closeFocus')).toHaveFocus();
 	});

--- a/src/tests/dialog/Dialog.spec.ts
+++ b/src/tests/dialog/Dialog.spec.ts
@@ -307,4 +307,28 @@ describe('Dialog', () => {
 		await user.tab({ shift: true });
 		expect(getByTestId('floating-closer')).not.toHaveFocus();
 	});
+
+	it('Returns focus to trigger when manually setting `open` state to false', async () => {
+		const { getByTestId, user, trigger } = setup();
+		const content = getByTestId('content');
+
+		expect(trigger).not.toHaveFocus();
+		await user.click(trigger);
+		expect(content).toBeVisible();
+		await user.click(getByTestId('toggle-open'));
+		expect(trigger).toHaveFocus();
+	});
+
+	it('Respects the `closeFocus` prop when manually setting `open` state to false', async () => {
+		const { getByTestId, user, trigger } = setup({
+			closeFocus: () => document.getElementById('closeFocus'),
+		});
+		const content = getByTestId('content');
+
+		expect(trigger).not.toHaveFocus();
+		await user.click(trigger);
+		expect(content).toBeVisible();
+		await user.click(getByTestId('toggle-open'));
+		expect(getByTestId('closeFocus')).toHaveFocus();
+	});
 });

--- a/src/tests/dialog/DialogTest.svelte
+++ b/src/tests/dialog/DialogTest.svelte
@@ -19,6 +19,7 @@
 		<div use:melt={$content} data-testid="content">
 			<h2 use:melt={$title} data-testid="title">Title</h2>
 			<p use:melt={$description} data-testid="description">Description</p>
+			<button on:click={() => open.update((p) => !p)} data-testid="toggle-open">toggle open</button>
 
 			<button use:melt={$close} data-testid="closer">Close</button>
 			<button use:melt={$close} data-testid="last">Close</button>

--- a/src/tests/popover/Popover.spec.ts
+++ b/src/tests/popover/Popover.spec.ts
@@ -164,4 +164,28 @@ describe('Popover (Default)', () => {
 		await user.tab();
 		expect(getByTestId('closeFocus')).not.toHaveFocus();
 	});
+
+	it('Returns focus to trigger when manually setting `open` state to false', async () => {
+		const { getByTestId, user, trigger } = setup();
+		const content = getByTestId('content');
+
+		expect(trigger).not.toHaveFocus();
+		await user.click(trigger);
+		expect(content).toBeVisible();
+		await user.click(getByTestId('toggle-open'));
+		expect(trigger).toHaveFocus();
+	});
+
+	it('Respects the `closeFocus` prop when manually setting `open` state to false', async () => {
+		const { getByTestId, user, trigger } = setup({
+			closeFocus: () => document.getElementById('closeFocus'),
+		});
+		const content = getByTestId('content');
+
+		expect(trigger).not.toHaveFocus();
+		await user.click(trigger);
+		expect(content).toBeVisible();
+		await user.click(getByTestId('toggle-open'));
+		expect(getByTestId('closeFocus')).toHaveFocus();
+	});
 });

--- a/src/tests/popover/PopoverTest.svelte
+++ b/src/tests/popover/PopoverTest.svelte
@@ -8,6 +8,7 @@
 
 	const {
 		elements: { trigger, content, arrow, close },
+		states: { open },
 	} = createPopover({
 		openFocus,
 		closeFocus,
@@ -48,6 +49,7 @@
 			<label for="weight">Weight</label>
 			<input type="number" id="weight" class="input" placeholder="Weight" data-testid="input4" />
 		</fieldset>
+		<button on:click={() => open.update((p) => !p)} data-testid="toggle-open">toggle open</button>
 	</div>
 	<button class="close" use:melt={$close} data-testid="close">
 		<X class="h-4 w-4 " />


### PR DESCRIPTION
closes https://github.com/melt-ui/melt-ui/issues/1109

We now restore focus to the trigger (or using the `closeFocus` prop) in an `effect` that runs when `open` is `false`. In order to not focus the trigger on initial mount when `open` is `false`, I added a parameter `skipFirstRun` to the `effect` function that optionally skips the first run of the effect.

I also added regression tests for the dialog and popover. 

Also, in the menu builder, we are already doing what I implemented with the dialog and popover, which removes the need in the menu builder to manually focus the trigger in multiple places. And I cleaned up the effect in the menu component. 

### Dialog Before
https://github.com/melt-ui/melt-ui/assets/53095479/584dd6ad-bd39-4901-9ff1-2a0e987f1a2e


### Dialog After 
https://github.com/melt-ui/melt-ui/assets/53095479/ac7ac1d1-f02e-4b2a-8f48-040438149a43

### Popover Before


https://github.com/melt-ui/melt-ui/assets/53095479/89b2dc56-e1a8-47e3-9ce3-d4c42fbe41c3

### Popover After

https://github.com/melt-ui/melt-ui/assets/53095479/fa3943a1-35d1-417b-afe9-cb4f5650b69d

