### PR TITLE
fix: overlay portal cleanup - prevent memory leak

### DIFF
--- a/.changeset/witty-pandas-argue.md
+++ b/.changeset/witty-pandas-argue.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+Fix(popover) overlay memory leak

--- a/.changeset/witty-pandas-argue.md
+++ b/.changeset/witty-pandas-argue.md
@@ -2,4 +2,4 @@
 '@melt-ui/svelte': patch
 ---
 
-Fix(popover) overlay memory leak
+Popover: fixed a bug that has the potential to introduce a memory leak via the overlay

--- a/src/lib/builders/popover/create.ts
+++ b/src/lib/builders/popover/create.ts
@@ -244,6 +244,7 @@ export function createPopover(args?: CreatePopoverProps) {
 		},
 		action: (node: HTMLElement) => {
 			let unsubEscapeKeydown = noop;
+			let unsubPortal = noop;
 
 			if (closeOnEscape.get()) {
 				const escapeKeydown = useEscapeKeydown(node, {
@@ -256,11 +257,12 @@ export function createPopover(args?: CreatePopoverProps) {
 				}
 			}
 
-			const unsubPortal = effect([portal], ([$portal]) => {
-				if ($portal === null) return noop;
+			effect([portal], ([$portal]) => {
+				unsubPortal();
+				if ($portal === null) return;
 				const portalDestination = getPortalDestination(node, $portal);
-				if (portalDestination === null) return noop;
-				return usePortal(node, portalDestination).destroy;
+				if (portalDestination === null) return;
+				unsubPortal = usePortal(node, portalDestination).destroy;
 			});
 
 			return {

--- a/src/lib/builders/popover/create.ts
+++ b/src/lib/builders/popover/create.ts
@@ -244,6 +244,7 @@ export function createPopover(args?: CreatePopoverProps) {
 		},
 		action: (node: HTMLElement) => {
 			let unsubEscapeKeydown = noop;
+			let unsubDerived = noop;
 			let unsubPortal = noop;
 
 			if (closeOnEscape.get()) {
@@ -257,7 +258,7 @@ export function createPopover(args?: CreatePopoverProps) {
 				}
 			}
 
-			effect([portal], ([$portal]) => {
+			unsubDerived = effect([portal], ([$portal]) => {
 				unsubPortal();
 				if ($portal === null) return;
 				const portalDestination = getPortalDestination(node, $portal);
@@ -268,6 +269,7 @@ export function createPopover(args?: CreatePopoverProps) {
 			return {
 				destroy() {
 					unsubEscapeKeydown();
+					unsubDerived();
 					unsubPortal();
 				},
 			};


### PR DESCRIPTION
Prevent potential memory leak on popover overlay portal. Should cleanup portal action in the case that the `portal` store updates.