### PR TITLE
Fix(interact outside): enable interact outside interception

### DIFF
--- a/.changeset/young-peaches-retire.md
+++ b/.changeset/young-peaches-retire.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+Fixed bug where outside interactions could not be intercepted (closes #917)

--- a/src/docs/previews/dialog/main/tailwind/index.svelte
+++ b/src/docs/previews/dialog/main/tailwind/index.svelte
@@ -4,6 +4,7 @@
 	import { flyAndScale } from '$docs/utils/index.js';
 	import { X } from '$icons/index.js';
 	import { fade } from 'svelte/transition';
+	import { usePortal } from '$lib/internal/actions/portal.js';
 
 	const {
 		elements: {
@@ -102,3 +103,53 @@
 		</div>
 	{/if}
 </div>
+
+{#if $open}
+	<div
+		use:usePortal
+		class="fixed left-0 top-4 z-50 flex w-full flex-wrap items-center justify-center gap-4 px-4"
+	>
+		<button
+			on:click|stopPropagation
+			class="rounded-xl bg-white px-4 py-2 text-magnum-700"
+		>
+			click interceptor
+		</button>
+		<button
+			on:pointerdown|stopPropagation
+			class="rounded-xl bg-white px-4 py-2 text-magnum-700"
+		>
+			pointerdown interceptor
+		</button>
+		<button
+			on:pointerup|stopPropagation
+			class="rounded-xl bg-white px-4 py-2 text-magnum-700"
+		>
+			pointerup interceptor
+		</button>
+		<button
+			on:mousedown|stopPropagation
+			class="rounded-xl bg-white px-4 py-2 text-magnum-700"
+		>
+			mousedown interceptor
+		</button>
+		<button
+			on:mouseup|stopPropagation
+			class="rounded-xl bg-white px-4 py-2 text-magnum-700"
+		>
+			mouseup interceptor
+		</button>
+		<button
+			on:touchstart|stopPropagation
+			class="rounded-xl bg-white px-4 py-2 text-magnum-700"
+		>
+			touchstart interceptor
+		</button>
+		<button
+			on:touchend|stopPropagation
+			class="rounded-xl bg-white px-4 py-2 text-magnum-700"
+		>
+			touchend interceptor
+		</button>
+	</div>
+{/if}

--- a/src/docs/previews/dialog/main/tailwind/index.svelte
+++ b/src/docs/previews/dialog/main/tailwind/index.svelte
@@ -4,7 +4,6 @@
 	import { flyAndScale } from '$docs/utils/index.js';
 	import { X } from '$icons/index.js';
 	import { fade } from 'svelte/transition';
-	import { usePortal } from '$lib/internal/actions/portal.js';
 
 	const {
 		elements: {
@@ -101,55 +100,5 @@
 				<X class="size-4" />
 			</button>
 		</div>
-	</div>
-{/if}
-
-{#if $open}
-	<div
-		use:usePortal
-		class="fixed left-0 top-4 z-50 flex w-full flex-wrap items-center justify-center gap-2 px-1 md:gap-4 md:px-4"
-	>
-		<button
-			on:click|stopPropagation
-			class="rounded-xl bg-white px-2 py-1 text-magnum-700 sm:text-sm md:px-4 md:py-2"
-		>
-			click interceptor
-		</button>
-		<button
-			on:pointerdown|stopPropagation
-			class="rounded-xl bg-white px-2 py-1 text-magnum-700 sm:text-sm md:px-4 md:py-2"
-		>
-			pointerdown interceptor
-		</button>
-		<button
-			on:pointerup|stopPropagation
-			class="rounded-xl bg-white px-2 py-1 text-magnum-700 sm:text-sm md:px-4 md:py-2"
-		>
-			pointerup interceptor
-		</button>
-		<button
-			on:mousedown|stopPropagation
-			class="rounded-xl bg-white px-2 py-1 text-magnum-700 sm:text-sm md:px-4 md:py-2"
-		>
-			mousedown interceptor
-		</button>
-		<button
-			on:mouseup|stopPropagation
-			class="rounded-xl bg-white px-2 py-1 text-magnum-700 sm:text-sm md:px-4 md:py-2"
-		>
-			mouseup interceptor
-		</button>
-		<button
-			on:touchstart|stopPropagation
-			class="rounded-xl bg-white px-2 py-1 text-magnum-700 sm:text-sm md:px-4 md:py-2"
-		>
-			touchstart interceptor
-		</button>
-		<button
-			on:touchend|stopPropagation
-			class="rounded-xl bg-white px-2 py-1 text-magnum-700 sm:text-sm md:px-4 md:py-2"
-		>
-			touchend interceptor
-		</button>
 	</div>
 {/if}

--- a/src/docs/previews/dialog/main/tailwind/index.svelte
+++ b/src/docs/previews/dialog/main/tailwind/index.svelte
@@ -107,47 +107,47 @@
 {#if $open}
 	<div
 		use:usePortal
-		class="fixed left-0 top-4 z-50 flex w-full flex-wrap items-center justify-center gap-4 px-4"
+		class="fixed left-0 top-4 z-50 flex w-full flex-wrap items-center justify-center gap-2 px-1 md:gap-4 md:px-4"
 	>
 		<button
 			on:click|stopPropagation
-			class="rounded-xl bg-white px-4 py-2 text-magnum-700"
+			class="rounded-xl bg-white px-2 py-1 text-magnum-700 sm:text-sm md:px-4 md:py-2"
 		>
 			click interceptor
 		</button>
 		<button
 			on:pointerdown|stopPropagation
-			class="rounded-xl bg-white px-4 py-2 text-magnum-700"
+			class="rounded-xl bg-white px-2 py-1 text-magnum-700 sm:text-sm md:px-4 md:py-2"
 		>
 			pointerdown interceptor
 		</button>
 		<button
 			on:pointerup|stopPropagation
-			class="rounded-xl bg-white px-4 py-2 text-magnum-700"
+			class="rounded-xl bg-white px-2 py-1 text-magnum-700 sm:text-sm md:px-4 md:py-2"
 		>
 			pointerup interceptor
 		</button>
 		<button
 			on:mousedown|stopPropagation
-			class="rounded-xl bg-white px-4 py-2 text-magnum-700"
+			class="rounded-xl bg-white px-2 py-1 text-magnum-700 sm:text-sm md:px-4 md:py-2"
 		>
 			mousedown interceptor
 		</button>
 		<button
 			on:mouseup|stopPropagation
-			class="rounded-xl bg-white px-4 py-2 text-magnum-700"
+			class="rounded-xl bg-white px-2 py-1 text-magnum-700 sm:text-sm md:px-4 md:py-2"
 		>
 			mouseup interceptor
 		</button>
 		<button
 			on:touchstart|stopPropagation
-			class="rounded-xl bg-white px-4 py-2 text-magnum-700"
+			class="rounded-xl bg-white px-2 py-1 text-magnum-700 sm:text-sm md:px-4 md:py-2"
 		>
 			touchstart interceptor
 		</button>
 		<button
 			on:touchend|stopPropagation
-			class="rounded-xl bg-white px-4 py-2 text-magnum-700"
+			class="rounded-xl bg-white px-2 py-1 text-magnum-700 sm:text-sm md:px-4 md:py-2"
 		>
 			touchend interceptor
 		</button>

--- a/src/lib/internal/actions/interact-outside/action.ts
+++ b/src/lib/internal/actions/interact-outside/action.ts
@@ -152,7 +152,12 @@ export const useInteractOutside = ((node, config) => {
 			setupBubblePhaseHandlerAndMarkAsNotIntercepted('touchstart', onPointerDown, {
 				passive: false,
 			}),
-			/** Bubbling Events For Interaction End */
+			/**
+			 * Bubbling Events For Interaction End
+			 * We must listen to all interaction end events vs. only `click` events
+			 * because on a touch device, if you press on the screen, move your finger
+			 * and lift it, the `click` event won't trigger but we should still call `onPointerUp`.
+			 */
 			setupBubblePhaseHandlerAndMarkAsNotIntercepted('pointerup', onPointerUp),
 			setupBubblePhaseHandlerAndMarkAsNotIntercepted('mouseup', onPointerUp),
 			setupBubblePhaseHandlerAndMarkAsNotIntercepted('touchend', onPointerUp),

--- a/src/lib/internal/actions/interact-outside/action.ts
+++ b/src/lib/internal/actions/interact-outside/action.ts
@@ -149,9 +149,7 @@ export const useInteractOutside = ((node, config) => {
 			/** Bubbling Events For Interaction Start */
 			setupBubblePhaseHandlerAndMarkAsNotIntercepted('pointerdown', onPointerDown),
 			setupBubblePhaseHandlerAndMarkAsNotIntercepted('mousedown', onPointerDown),
-			setupBubblePhaseHandlerAndMarkAsNotIntercepted('touchstart', onPointerDown, {
-				passive: false,
-			}),
+			setupBubblePhaseHandlerAndMarkAsNotIntercepted('touchstart', onPointerDown),
 			/**
 			 * Bubbling Events For Interaction End
 			 * We must listen to all interaction end events vs. only `click` events

--- a/src/lib/internal/actions/interact-outside/action.ts
+++ b/src/lib/internal/actions/interact-outside/action.ts
@@ -141,6 +141,7 @@ export const useInteractOutside = ((node, config) => {
 			setupCapturePhaseHandlerAndMarkAsIntercepted('mouseup', resetInterceptedEventsDebounced),
 			setupCapturePhaseHandlerAndMarkAsIntercepted('touchend', resetInterceptedEventsDebounced),
 			setupCapturePhaseHandlerAndMarkAsIntercepted('click', resetInterceptedEventsDebounced),
+
 			/** Bubbling Events For Interaction Start */
 			setupBubblePhaseHandlerAndMarkAsNotIntercepted('pointerdown', onPointerDownDebounced),
 			setupBubblePhaseHandlerAndMarkAsNotIntercepted('mousedown', onPointerDownDebounced),

--- a/src/lib/internal/actions/interact-outside/action.ts
+++ b/src/lib/internal/actions/interact-outside/action.ts
@@ -75,18 +75,12 @@ export const useInteractOutside = ((node, config) => {
 		E extends InteractOutsideInterceptEventType
 	>(
 		eventType: E,
-		handler?: InteractOutsideInterceptHandler<E>,
-		options?: boolean | AddEventListenerOptions
+		handler?: InteractOutsideInterceptHandler<E>
 	) => {
-		return addEventListener(
-			documentObj,
-			eventType,
-			(e: HTMLElementEventMap[E]) => {
-				interceptedEvents[eventType] = false;
-				handler?.(e);
-			},
-			options
-		);
+		return addEventListener(documentObj, eventType, (e: HTMLElementEventMap[E]) => {
+			interceptedEvents[eventType] = false;
+			handler?.(e);
+		});
 	};
 
 	function update(config: InteractOutsideConfig) {

--- a/src/lib/internal/actions/interact-outside/action.ts
+++ b/src/lib/internal/actions/interact-outside/action.ts
@@ -159,7 +159,7 @@ export const useInteractOutside = ((node, config) => {
 			setupBubblePhaseHandlerAndMarkAsNotIntercepted('pointerup', onPointerUp),
 			setupBubblePhaseHandlerAndMarkAsNotIntercepted('mouseup', onPointerUp),
 			setupBubblePhaseHandlerAndMarkAsNotIntercepted('touchend', onPointerUp),
-			setupBubblePhaseHandlerAndMarkAsNotIntercepted('click')
+			setupBubblePhaseHandlerAndMarkAsNotIntercepted('click', onPointerUp)
 		);
 	}
 

--- a/src/lib/internal/actions/interact-outside/action.ts
+++ b/src/lib/internal/actions/interact-outside/action.ts
@@ -102,7 +102,7 @@ export const useInteractOutside = ((node, config) => {
 		const { onInteractOutside, onInteractOutsideStart, enabled } = config;
 		if (!enabled) return;
 
-		const resetInterceptedEventsDebounced = debounce(resetInterceptedEvents, 10);
+		const resetInterceptedEventsDebounced = debounce(resetInterceptedEvents, 20);
 		unsubResetInterceptedEvents = resetInterceptedEventsDebounced.destroy;
 
 		/**

--- a/src/lib/internal/actions/interact-outside/action.ts
+++ b/src/lib/internal/actions/interact-outside/action.ts
@@ -34,6 +34,12 @@ export const useInteractOutside = ((node, config) => {
 		click: false,
 	};
 
+	const resetInterceptedEvents = () => {
+		for (const eventType in interceptedEvents) {
+			interceptedEvents[eventType as InteractOutsideInterceptEventType] = false;
+		}
+	};
+
 	const isAnyEventIntercepted = () => {
 		for (const isIntercepted of Object.values(interceptedEvents)) {
 			if (isIntercepted) return true;
@@ -92,15 +98,12 @@ export const useInteractOutside = ((node, config) => {
 		unsubPointerDown();
 		unsubPointerUp();
 		unsubResetInterceptedEvents();
+		resetInterceptedEvents();
 		const { onInteractOutside, onInteractOutsideStart, enabled } = config;
 		if (!enabled) return;
 
-		const resetInterceptedEvents = debounce(() => {
-			for (const eventType in interceptedEvents) {
-				interceptedEvents[eventType as InteractOutsideInterceptEventType] = false;
-			}
-		}, 10);
-		unsubResetInterceptedEvents = resetInterceptedEvents.destroy;
+		const resetInterceptedEventsDebounced = debounce(resetInterceptedEvents, 10);
+		unsubResetInterceptedEvents = resetInterceptedEventsDebounced.destroy;
 
 		/**
 		 * We debounce onPointerDown to allow other events to be marked
@@ -139,10 +142,10 @@ export const useInteractOutside = ((node, config) => {
 			 * to allow the user to intercept the beginning of an interaction
 			 * while still intercepting the entire interaction.
 			 */
-			setupCapturePhaseHandlerAndMarkAsIntercepted('pointerup', resetInterceptedEvents),
-			setupCapturePhaseHandlerAndMarkAsIntercepted('mouseup', resetInterceptedEvents),
-			setupCapturePhaseHandlerAndMarkAsIntercepted('touchend', resetInterceptedEvents),
-			setupCapturePhaseHandlerAndMarkAsIntercepted('click', resetInterceptedEvents),
+			setupCapturePhaseHandlerAndMarkAsIntercepted('pointerup', resetInterceptedEventsDebounced),
+			setupCapturePhaseHandlerAndMarkAsIntercepted('mouseup', resetInterceptedEventsDebounced),
+			setupCapturePhaseHandlerAndMarkAsIntercepted('touchend', resetInterceptedEventsDebounced),
+			setupCapturePhaseHandlerAndMarkAsIntercepted('click', resetInterceptedEventsDebounced),
 			/** Bubbling Events For Interaction Start */
 			setupBubblePhaseHandlerAndMarkAsNotIntercepted('pointerdown', onPointerDown),
 			setupBubblePhaseHandlerAndMarkAsNotIntercepted('mousedown', onPointerDown),

--- a/src/lib/internal/actions/interact-outside/types.ts
+++ b/src/lib/internal/actions/interact-outside/types.ts
@@ -9,7 +9,7 @@ export type InteractOutsideInterceptEventType =
 	| 'touchend'
 	| 'click';
 
-export type InteractOutsideInterceptHandler<E extends keyof HTMLElementEventMap> = (
+export type InteractOutsideInterceptHandler<E extends InteractOutsideInterceptEventType> = (
 	ev: HTMLElementEventMap[E]
 ) => void;
 

--- a/src/lib/internal/actions/interact-outside/types.ts
+++ b/src/lib/internal/actions/interact-outside/types.ts
@@ -1,5 +1,18 @@
 export type InteractOutsideEvent = PointerEvent | MouseEvent | TouchEvent;
 
+export type InteractOutsideInterceptEventType =
+	| 'pointerdown'
+	| 'pointerup'
+	| 'mousedown'
+	| 'mouseup'
+	| 'touchstart'
+	| 'touchend'
+	| 'click';
+
+export type InteractOutsideInterceptHandler<E extends keyof HTMLElementEventMap> = (
+	ev: HTMLElementEventMap[E]
+) => void;
+
 export type InteractOutsideConfig = {
 	/**
 	 * Callback fired when an outside interaction event completes,

--- a/src/lib/internal/actions/modal/action.ts
+++ b/src/lib/internal/actions/modal/action.ts
@@ -40,15 +40,11 @@ export const useModal = ((node, config) => {
 			const target = e.target;
 			if (!isElement(target)) return;
 			if (target && isLastModal()) {
-				e.preventDefault();
-				e.stopPropagation();
 				e.stopImmediatePropagation();
 			}
 		}
 		function onInteractOutside(e: InteractOutsideEvent) {
 			if (shouldCloseOnInteractOutside?.(e) && isLastModal()) {
-				e.preventDefault();
-				e.stopPropagation();
 				e.stopImmediatePropagation();
 				closeModal();
 			}

--- a/src/lib/internal/helpers/debounce.ts
+++ b/src/lib/internal/helpers/debounce.ts
@@ -1,13 +1,13 @@
-export function debounce<T extends (...args: unknown[]) => unknown>(fn: T, wait = 500) {
-	let timeout: ReturnType<typeof setTimeout> | null = null;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function debounce<T extends (...args: any[]) => any>(fn: T, wait = 500) {
+	let timeout: NodeJS.Timeout;
 
-	return function (...args: Parameters<T>) {
-		const later = () => {
-			timeout = null;
-			fn(...args);
-		};
-
-		timeout && clearTimeout(timeout);
+	const debounced = (...args: Parameters<T>) => {
+		clearTimeout(timeout);
+		const later = () => fn(...args);
 		timeout = setTimeout(later, wait);
 	};
+
+	debounced.destroy = () => clearTimeout(timeout);
+	return debounced;
 }

--- a/src/tests/dialog/Dialog.spec.ts
+++ b/src/tests/dialog/Dialog.spec.ts
@@ -531,5 +531,29 @@ describe('Dialog', () => {
 			await sleep(20);
 			await waitFor(() => expect(content).not.toBeVisible());
 		});
+
+		it('Resets `interceptedEvents` when calling `preventDefault()` on touch event', async () => {
+			const { getByTestId, user, trigger } = setup();
+			const content = getByTestId('content');
+			const overlay = getByTestId('overlay');
+			const touchendPreventDefault = getByTestId('touchend-prevent-default-interceptor');
+
+			expect(content).not.toBeVisible();
+			await user.click(trigger);
+			expect(content).toBeVisible();
+			await sleep(100);
+			await fireEvent(touchendPreventDefault, new TouchEvent('touchstart', { bubbles: true }));
+			await fireEvent(touchendPreventDefault, new TouchEvent('touchend', { bubbles: true }));
+			await sleep(20);
+			expect(content).toBeVisible();
+
+			/**
+			 * Clicking the overlay and the dialog getting closed
+			 * will be possible only if we reset `interceptedEvents`
+			 * from the previous interaction.
+			 */
+			await user.click(overlay);
+			await waitFor(() => expect(content).not.toBeVisible());
+		});
 	});
 });

--- a/src/tests/dialog/Dialog.spec.ts
+++ b/src/tests/dialog/Dialog.spec.ts
@@ -1,4 +1,4 @@
-import { render, waitFor } from '@testing-library/svelte';
+import { fireEvent, render, waitFor } from '@testing-library/svelte';
 import { axe } from 'jest-axe';
 import { describe, it } from 'vitest';
 import DialogTest from './DialogTest.svelte';
@@ -417,7 +417,7 @@ describe('Dialog', () => {
 			await sleep(100);
 			await touch(clickInterceptor);
 			expect(content).toBeVisible();
-			await sleep(10);
+			await sleep(20);
 			await user.click(overlay);
 			await waitFor(() => expect(content).not.toBeVisible());
 		});
@@ -432,7 +432,7 @@ describe('Dialog', () => {
 			await sleep(100);
 			await touch(getByTestId('pointerdown-interceptor'));
 			expect(content).toBeVisible();
-			await sleep(10);
+			await sleep(20);
 			await user.click(overlay);
 			await waitFor(() => expect(content).not.toBeVisible());
 		});
@@ -447,7 +447,7 @@ describe('Dialog', () => {
 			await sleep(100);
 			await touch(getByTestId('pointerup-interceptor'));
 			expect(content).toBeVisible();
-			await sleep(10);
+			await sleep(20);
 			await user.click(overlay);
 			await waitFor(() => expect(content).not.toBeVisible());
 		});
@@ -462,7 +462,7 @@ describe('Dialog', () => {
 			await sleep(100);
 			await touch(getByTestId('mousedown-interceptor'));
 			expect(content).toBeVisible();
-			await sleep(10);
+			await sleep(20);
 			await user.click(overlay);
 			await waitFor(() => expect(content).not.toBeVisible());
 		});
@@ -477,7 +477,7 @@ describe('Dialog', () => {
 			await sleep(100);
 			await touch(getByTestId('mouseup-interceptor'));
 			expect(content).toBeVisible();
-			await sleep(10);
+			await sleep(20);
 			await user.click(overlay);
 			await waitFor(() => expect(content).not.toBeVisible());
 		});
@@ -493,7 +493,7 @@ describe('Dialog', () => {
 			await sleep(100);
 			await touch(touchstartInterceptor);
 			expect(content).toBeVisible();
-			await sleep(10);
+			await sleep(20);
 			await user.click(overlay);
 			await waitFor(() => expect(content).not.toBeVisible());
 		});
@@ -509,7 +509,7 @@ describe('Dialog', () => {
 			await sleep(100);
 			await touch(touchendInterceptor);
 			expect(content).toBeVisible();
-			await sleep(10);
+			await sleep(20);
 			await user.click(overlay);
 			await waitFor(() => expect(content).not.toBeVisible());
 		});

--- a/src/tests/dialog/Dialog.spec.ts
+++ b/src/tests/dialog/Dialog.spec.ts
@@ -74,7 +74,7 @@ describe('Dialog', () => {
 		await sleep(100);
 		expect(overlay).toBeVisible();
 		await user.click(overlay);
-		expect(content).not.toBeVisible();
+		await waitFor(() => expect(content).not.toBeVisible());
 	});
 
 	it('Prevents closing on outside click if `defaultPrevented` in `onOutsideClick` callback', async () => {
@@ -297,9 +297,9 @@ describe('Dialog', () => {
 		expect(content).toBeVisible();
 		await sleep(100);
 		expect(overlay).toBeVisible();
-		await user.pointer({ target: overlay, offset: 2, keys: '[MouseLeft>]' });
-		await user.pointer({ target: overlay, offset: 2, keys: '[/MouseLeft]' });
-		expect(content).not.toBeVisible();
+		await user.pointer({ target: overlay, keys: '[MouseLeft>]' });
+		await user.pointer({ target: overlay, keys: '[/MouseLeft]' });
+		await waitFor(() => expect(content).not.toBeVisible());
 	});
 
 	it("Doesn't deactivate focus trap on escape provided `closeOnEscape` false", async () => {

--- a/src/tests/dialog/Dialog.spec.ts
+++ b/src/tests/dialog/Dialog.spec.ts
@@ -307,4 +307,73 @@ describe('Dialog', () => {
 		await user.tab({ shift: true });
 		expect(getByTestId('floating-closer')).not.toHaveFocus();
 	});
+
+	it("Doesn't close when interacting outside with click interceptor", async () => {
+		const { getByTestId, user, trigger } = setup();
+		const content = getByTestId('content');
+		expect(content).not.toBeVisible();
+		await user.click(trigger);
+		expect(content).toBeVisible();
+		await user.click(getByTestId('click-interceptor'));
+		expect(content).toBeVisible();
+	});
+
+	it("Doesn't close when interacting outside with pointerdown interceptor", async () => {
+		const { getByTestId, user, trigger } = setup();
+		const content = getByTestId('content');
+		expect(content).not.toBeVisible();
+		await user.click(trigger);
+		expect(content).toBeVisible();
+		await user.click(getByTestId('pointerdown-interceptor'));
+		expect(content).toBeVisible();
+	});
+	it("Doesn't close when interacting outside with pointerup interceptor", async () => {
+		const { getByTestId, user, trigger } = setup();
+		const content = getByTestId('content');
+		expect(content).not.toBeVisible();
+		await user.click(trigger);
+		expect(content).toBeVisible();
+		await user.click(getByTestId('pointerup-interceptor'));
+		expect(content).toBeVisible();
+	});
+
+	it("Doesn't close when interacting outside with mousedown interceptor", async () => {
+		const { getByTestId, user, trigger } = setup();
+		const content = getByTestId('content');
+		expect(content).not.toBeVisible();
+		await user.click(trigger);
+		expect(content).toBeVisible();
+		await user.click(getByTestId('mousedown-interceptor'));
+		expect(content).toBeVisible();
+	});
+
+	it("Doesn't close when interacting outside with mouseup interceptor", async () => {
+		const { getByTestId, user, trigger } = setup();
+		const content = getByTestId('content');
+		expect(content).not.toBeVisible();
+		await user.click(trigger);
+		expect(content).toBeVisible();
+		await user.click(getByTestId('mouseup-interceptor'));
+		expect(content).toBeVisible();
+	});
+
+	it("Doesn't close when interacting outside with touchstart interceptor", async () => {
+		const { getByTestId, user, trigger } = setup();
+		const content = getByTestId('content');
+		expect(content).not.toBeVisible();
+		await user.click(trigger);
+		expect(content).toBeVisible();
+		await user.click(getByTestId('touchstart-interceptor'));
+		expect(content).toBeVisible();
+	});
+
+	it("Doesn't close when interacting outside with touchend interceptor", async () => {
+		const { getByTestId, user, trigger } = setup();
+		const content = getByTestId('content');
+		expect(content).not.toBeVisible();
+		await user.click(trigger);
+		expect(content).toBeVisible();
+		await user.click(getByTestId('touchend-interceptor'));
+		expect(content).toBeVisible();
+	});
 });

--- a/src/tests/dialog/Dialog.spec.ts
+++ b/src/tests/dialog/Dialog.spec.ts
@@ -69,7 +69,7 @@ describe('Dialog', () => {
 	});
 
 	it('Prevents closing on outside click if `defaultPrevented` in `onOutsideClick` callback', async () => {
-		const { getByTestId, user, overlay, content } = await open({
+		const { user, overlay, content } = await open({
 			onOutsideClick: (e) => {
 				e.preventDefault();
 			},
@@ -81,7 +81,7 @@ describe('Dialog', () => {
 	});
 
 	it('Portalled el attaches dialog to body', async () => {
-		const { getByTestId, portalled } = await open();
+		const { portalled } = await open();
 
 		expect(portalled.parentElement).toEqual(document.body);
 	});
@@ -258,14 +258,8 @@ describe('Dialog', () => {
 
 	describe('Mouse Device', () => {
 		it("Doesn't close when interacting outside with click interceptor", async () => {
-			const { getByTestId, user, trigger } = setup();
+			const { getByTestId, user, content, overlay } = await open();
 			const clickInterceptor = getByTestId('click-interceptor');
-			const content = getByTestId('content');
-			const overlay = getByTestId('overlay');
-			expect(content).not.toBeVisible();
-			await user.click(trigger);
-			expect(content).toBeVisible();
-			await sleep(100);
 			await user.click(clickInterceptor);
 			expect(content).toBeVisible();
 			await user.click(overlay);
@@ -273,13 +267,7 @@ describe('Dialog', () => {
 		});
 
 		it("Doesn't close when interacting outside with pointerdown interceptor", async () => {
-			const { getByTestId, user, trigger } = setup();
-			const content = getByTestId('content');
-			const overlay = getByTestId('overlay');
-			expect(content).not.toBeVisible();
-			await user.click(trigger);
-			await sleep(100);
-			expect(content).toBeVisible();
+			const { getByTestId, user, content, overlay } = await open();
 			await user.click(getByTestId('pointerdown-interceptor'));
 			expect(content).toBeVisible();
 			await user.click(overlay);
@@ -287,13 +275,7 @@ describe('Dialog', () => {
 		});
 
 		it("Doesn't close when interacting outside with pointerup interceptor", async () => {
-			const { getByTestId, user, trigger } = setup();
-			const content = getByTestId('content');
-			const overlay = getByTestId('overlay');
-			expect(content).not.toBeVisible();
-			await user.click(trigger);
-			await sleep(100);
-			expect(content).toBeVisible();
+			const { getByTestId, user, content, overlay } = await open();
 			await user.click(getByTestId('pointerup-interceptor'));
 			expect(content).toBeVisible();
 			await user.click(overlay);
@@ -301,13 +283,7 @@ describe('Dialog', () => {
 		});
 
 		it("Doesn't close when interacting outside with mousedown interceptor", async () => {
-			const { getByTestId, user, trigger } = setup();
-			const content = getByTestId('content');
-			const overlay = getByTestId('overlay');
-			expect(content).not.toBeVisible();
-			await user.click(trigger);
-			await sleep(100);
-			expect(content).toBeVisible();
+			const { getByTestId, user, content, overlay } = await open();
 			await user.click(getByTestId('mousedown-interceptor'));
 			expect(content).toBeVisible();
 			await user.click(overlay);
@@ -315,13 +291,7 @@ describe('Dialog', () => {
 		});
 
 		it("Doesn't close when interacting outside with mouseup interceptor", async () => {
-			const { getByTestId, user, trigger } = setup();
-			const content = getByTestId('content');
-			const overlay = getByTestId('overlay');
-			expect(content).not.toBeVisible();
-			await user.click(trigger);
-			await sleep(100);
-			expect(content).toBeVisible();
+			const { getByTestId, user, content, overlay } = await open();
 			await user.click(getByTestId('mouseup-interceptor'));
 			expect(content).toBeVisible();
 			await user.click(overlay);
@@ -331,14 +301,8 @@ describe('Dialog', () => {
 
 	describe('Touch Device', () => {
 		it("Doesn't close when interacting outside with click interceptor", async () => {
-			const { getByTestId, user, trigger } = setup();
+			const { getByTestId, user, content, overlay } = await open();
 			const clickInterceptor = getByTestId('click-interceptor');
-			const content = getByTestId('content');
-			const overlay = getByTestId('overlay');
-			expect(content).not.toBeVisible();
-			await touch(trigger);
-			expect(content).toBeVisible();
-			await sleep(100);
 			await touch(clickInterceptor);
 			expect(content).toBeVisible();
 			await sleep(20);
@@ -347,13 +311,7 @@ describe('Dialog', () => {
 		});
 
 		it("Doesn't close when interacting outside with pointerdown interceptor", async () => {
-			const { getByTestId, user, trigger } = setup();
-			const content = getByTestId('content');
-			const overlay = getByTestId('overlay');
-			expect(content).not.toBeVisible();
-			await touch(trigger);
-			expect(content).toBeVisible();
-			await sleep(100);
+			const { getByTestId, user, content, overlay } = await open();
 			await touch(getByTestId('pointerdown-interceptor'));
 			expect(content).toBeVisible();
 			await sleep(20);
@@ -362,13 +320,7 @@ describe('Dialog', () => {
 		});
 
 		it("Doesn't close when interacting outside with pointerup interceptor", async () => {
-			const { getByTestId, user, trigger } = setup();
-			const content = getByTestId('content');
-			const overlay = getByTestId('overlay');
-			expect(content).not.toBeVisible();
-			await touch(trigger);
-			expect(content).toBeVisible();
-			await sleep(100);
+			const { getByTestId, user, content, overlay } = await open();
 			await touch(getByTestId('pointerup-interceptor'));
 			expect(content).toBeVisible();
 			await sleep(20);
@@ -377,13 +329,7 @@ describe('Dialog', () => {
 		});
 
 		it("Doesn't close when interacting outside with mousedown interceptor", async () => {
-			const { getByTestId, user, trigger } = setup();
-			const content = getByTestId('content');
-			const overlay = getByTestId('overlay');
-			expect(content).not.toBeVisible();
-			await touch(trigger);
-			expect(content).toBeVisible();
-			await sleep(100);
+			const { getByTestId, user, content, overlay } = await open();
 			await touch(getByTestId('mousedown-interceptor'));
 			expect(content).toBeVisible();
 			await sleep(20);
@@ -392,13 +338,7 @@ describe('Dialog', () => {
 		});
 
 		it("Doesn't close when interacting outside with mouseup interceptor", async () => {
-			const { getByTestId, user, trigger } = setup();
-			const content = getByTestId('content');
-			const overlay = getByTestId('overlay');
-			expect(content).not.toBeVisible();
-			await touch(trigger);
-			expect(content).toBeVisible();
-			await sleep(100);
+			const { getByTestId, user, content, overlay } = await open();
 			await touch(getByTestId('mouseup-interceptor'));
 			expect(content).toBeVisible();
 			await sleep(20);
@@ -407,14 +347,8 @@ describe('Dialog', () => {
 		});
 
 		it("Doesn't close when interacting outside with touchstart interceptor", async () => {
-			const { getByTestId, user, trigger } = setup();
+			const { getByTestId, user, content, overlay } = await open();
 			const touchstartInterceptor = getByTestId('touchstart-interceptor');
-			const content = getByTestId('content');
-			const overlay = getByTestId('overlay');
-			expect(content).not.toBeVisible();
-			await touch(trigger);
-			expect(content).toBeVisible();
-			await sleep(100);
 			await touch(touchstartInterceptor);
 			expect(content).toBeVisible();
 			await sleep(20);
@@ -423,14 +357,8 @@ describe('Dialog', () => {
 		});
 
 		it("Doesn't close when interacting outside with touchend interceptor", async () => {
-			const { getByTestId, user, trigger } = setup();
+			const { getByTestId, user, overlay, content } = await open();
 			const touchendInterceptor = getByTestId('touchend-interceptor');
-			const content = getByTestId('content');
-			const overlay = getByTestId('overlay');
-			expect(content).not.toBeVisible();
-			await touch(trigger);
-			expect(content).toBeVisible();
-			await sleep(100);
 			await touch(touchendInterceptor);
 			expect(content).toBeVisible();
 			await sleep(20);
@@ -439,14 +367,7 @@ describe('Dialog', () => {
 		});
 
 		it('Closes on touchend if the previous touchstart occurred outside the dialog', async () => {
-			const { getByTestId, user, trigger } = setup();
-			const overlay = getByTestId('overlay');
-			const content = getByTestId('content');
-
-			expect(content).not.toBeVisible();
-			await user.click(trigger);
-			expect(content).toBeVisible();
-			await sleep(100);
+			const { content, overlay } = await open();
 			expect(overlay).toBeVisible();
 			await fireEvent(overlay, new TouchEvent('pointerdown', { bubbles: true }));
 			await fireEvent(overlay, new TouchEvent('touchstart', { bubbles: true }));
@@ -462,15 +383,8 @@ describe('Dialog', () => {
 		 * the screen may not trigger a `click` event.
 		 */
 		it('Resets `interceptedEvents` when calling `preventDefault()` on touch event', async () => {
-			const { getByTestId, user, trigger } = setup();
-			const content = getByTestId('content');
-			const overlay = getByTestId('overlay');
+			const { getByTestId, user, overlay, content } = await open();
 			const touchendPreventDefault = getByTestId('touchend-prevent-default-interceptor');
-
-			expect(content).not.toBeVisible();
-			await user.click(trigger);
-			expect(content).toBeVisible();
-			await sleep(100);
 			await fireEvent(touchendPreventDefault, new TouchEvent('touchstart', { bubbles: true }));
 			await fireEvent(touchendPreventDefault, new TouchEvent('touchend', { bubbles: true }));
 			await sleep(20);

--- a/src/tests/dialog/Dialog.spec.ts
+++ b/src/tests/dialog/Dialog.spec.ts
@@ -532,6 +532,11 @@ describe('Dialog', () => {
 			await waitFor(() => expect(content).not.toBeVisible());
 		});
 
+		/**
+		 * This makes sure we reset `interceptedEvents` not only after a click event.
+		 * On touch devices, actions like pressing, moving the finger, and lifting it off
+		 * the screen may not trigger a `click` event.
+		 */
 		it('Resets `interceptedEvents` when calling `preventDefault()` on touch event', async () => {
 			const { getByTestId, user, trigger } = setup();
 			const content = getByTestId('content');

--- a/src/tests/dialog/Dialog.spec.ts
+++ b/src/tests/dialog/Dialog.spec.ts
@@ -351,6 +351,7 @@ describe('Dialog', () => {
 		await user.click(getByTestId('pointerdown-interceptor'));
 		expect(content).toBeVisible();
 	});
+
 	it("Doesn't close when interacting outside with pointerup interceptor", async () => {
 		const { getByTestId, user, trigger } = setup();
 		const content = getByTestId('content');

--- a/src/tests/dialog/Dialog.spec.ts
+++ b/src/tests/dialog/Dialog.spec.ts
@@ -513,5 +513,23 @@ describe('Dialog', () => {
 			await user.click(overlay);
 			await waitFor(() => expect(content).not.toBeVisible());
 		});
+
+		it('Closes on touchend if the previous touchstart occurred outside the dialog', async () => {
+			const { getByTestId, user, trigger } = setup();
+			const overlay = getByTestId('overlay');
+			const content = getByTestId('content');
+
+			expect(content).not.toBeVisible();
+			await user.click(trigger);
+			expect(content).toBeVisible();
+			await sleep(100);
+			expect(overlay).toBeVisible();
+			await fireEvent(overlay, new TouchEvent('pointerdown', { bubbles: true }));
+			await fireEvent(overlay, new TouchEvent('touchstart', { bubbles: true }));
+			await fireEvent(overlay, new TouchEvent('pointerup', { bubbles: true }));
+			await fireEvent(overlay, new TouchEvent('touchend', { bubbles: true }));
+			await sleep(20);
+			await waitFor(() => expect(content).not.toBeVisible());
+		});
 	});
 });

--- a/src/tests/dialog/Dialog.spec.ts
+++ b/src/tests/dialog/Dialog.spec.ts
@@ -4,7 +4,7 @@ import { describe, it } from 'vitest';
 import DialogTest from './DialogTest.svelte';
 import { userEvent } from '@testing-library/user-event';
 import { sleep } from '$lib/internal/helpers/index.js';
-import { testKbd as kbd } from '../utils.js';
+import { testKbd as kbd, touch } from '../utils.js';
 import type { CreateDialogProps } from '$lib/index.js';
 
 function setup(props: CreateDialogProps = {}) {
@@ -332,73 +332,186 @@ describe('Dialog', () => {
 		expect(getByTestId('floating-closer')).not.toHaveFocus();
 	});
 
-	it("Doesn't close when interacting outside with click interceptor", async () => {
-		const { getByTestId, user, trigger } = setup();
-		const content = getByTestId('content');
-		expect(content).not.toBeVisible();
-		await user.click(trigger);
-		expect(content).toBeVisible();
-		await user.click(getByTestId('click-interceptor'));
-		expect(content).toBeVisible();
+	describe('Mouse Device', () => {
+		it("Doesn't close when interacting outside with click interceptor", async () => {
+			const { getByTestId, user, trigger } = setup();
+			const clickInterceptor = getByTestId('click-interceptor');
+			const content = getByTestId('content');
+			const overlay = getByTestId('overlay');
+			expect(content).not.toBeVisible();
+			await user.click(trigger);
+			expect(content).toBeVisible();
+			await sleep(100);
+			await user.click(clickInterceptor);
+			expect(content).toBeVisible();
+			await user.click(overlay);
+			await waitFor(() => expect(content).not.toBeVisible());
+		});
+
+		it("Doesn't close when interacting outside with pointerdown interceptor", async () => {
+			const { getByTestId, user, trigger } = setup();
+			const content = getByTestId('content');
+			const overlay = getByTestId('overlay');
+			expect(content).not.toBeVisible();
+			await user.click(trigger);
+			await sleep(100);
+			expect(content).toBeVisible();
+			await user.click(getByTestId('pointerdown-interceptor'));
+			expect(content).toBeVisible();
+			await user.click(overlay);
+			await waitFor(() => expect(content).not.toBeVisible());
+		});
+
+		it("Doesn't close when interacting outside with pointerup interceptor", async () => {
+			const { getByTestId, user, trigger } = setup();
+			const content = getByTestId('content');
+			const overlay = getByTestId('overlay');
+			expect(content).not.toBeVisible();
+			await user.click(trigger);
+			await sleep(100);
+			expect(content).toBeVisible();
+			await user.click(getByTestId('pointerup-interceptor'));
+			expect(content).toBeVisible();
+			await user.click(overlay);
+			await waitFor(() => expect(content).not.toBeVisible());
+		});
+
+		it("Doesn't close when interacting outside with mousedown interceptor", async () => {
+			const { getByTestId, user, trigger } = setup();
+			const content = getByTestId('content');
+			const overlay = getByTestId('overlay');
+			expect(content).not.toBeVisible();
+			await user.click(trigger);
+			await sleep(100);
+			expect(content).toBeVisible();
+			await user.click(getByTestId('mousedown-interceptor'));
+			expect(content).toBeVisible();
+			await user.click(overlay);
+			await waitFor(() => expect(content).not.toBeVisible());
+		});
+
+		it("Doesn't close when interacting outside with mouseup interceptor", async () => {
+			const { getByTestId, user, trigger } = setup();
+			const content = getByTestId('content');
+			const overlay = getByTestId('overlay');
+			expect(content).not.toBeVisible();
+			await user.click(trigger);
+			await sleep(100);
+			expect(content).toBeVisible();
+			await user.click(getByTestId('mouseup-interceptor'));
+			expect(content).toBeVisible();
+			await user.click(overlay);
+			await waitFor(() => expect(content).not.toBeVisible());
+		});
 	});
 
-	it("Doesn't close when interacting outside with pointerdown interceptor", async () => {
-		const { getByTestId, user, trigger } = setup();
-		const content = getByTestId('content');
-		expect(content).not.toBeVisible();
-		await user.click(trigger);
-		expect(content).toBeVisible();
-		await user.click(getByTestId('pointerdown-interceptor'));
-		expect(content).toBeVisible();
-	});
+	describe('Touch Device', () => {
+		it("Doesn't close when interacting outside with click interceptor", async () => {
+			const { getByTestId, user, trigger } = setup();
+			const clickInterceptor = getByTestId('click-interceptor');
+			const content = getByTestId('content');
+			const overlay = getByTestId('overlay');
+			expect(content).not.toBeVisible();
+			await touch(trigger);
+			expect(content).toBeVisible();
+			await sleep(100);
+			await touch(clickInterceptor);
+			expect(content).toBeVisible();
+			await sleep(10);
+			await user.click(overlay);
+			await waitFor(() => expect(content).not.toBeVisible());
+		});
 
-	it("Doesn't close when interacting outside with pointerup interceptor", async () => {
-		const { getByTestId, user, trigger } = setup();
-		const content = getByTestId('content');
-		expect(content).not.toBeVisible();
-		await user.click(trigger);
-		expect(content).toBeVisible();
-		await user.click(getByTestId('pointerup-interceptor'));
-		expect(content).toBeVisible();
-	});
+		it("Doesn't close when interacting outside with pointerdown interceptor", async () => {
+			const { getByTestId, user, trigger } = setup();
+			const content = getByTestId('content');
+			const overlay = getByTestId('overlay');
+			expect(content).not.toBeVisible();
+			await touch(trigger);
+			expect(content).toBeVisible();
+			await sleep(100);
+			await touch(getByTestId('pointerdown-interceptor'));
+			expect(content).toBeVisible();
+			await sleep(10);
+			await user.click(overlay);
+			await waitFor(() => expect(content).not.toBeVisible());
+		});
 
-	it("Doesn't close when interacting outside with mousedown interceptor", async () => {
-		const { getByTestId, user, trigger } = setup();
-		const content = getByTestId('content');
-		expect(content).not.toBeVisible();
-		await user.click(trigger);
-		expect(content).toBeVisible();
-		await user.click(getByTestId('mousedown-interceptor'));
-		expect(content).toBeVisible();
-	});
+		it("Doesn't close when interacting outside with pointerup interceptor", async () => {
+			const { getByTestId, user, trigger } = setup();
+			const content = getByTestId('content');
+			const overlay = getByTestId('overlay');
+			expect(content).not.toBeVisible();
+			await touch(trigger);
+			expect(content).toBeVisible();
+			await sleep(100);
+			await touch(getByTestId('pointerup-interceptor'));
+			expect(content).toBeVisible();
+			await sleep(10);
+			await user.click(overlay);
+			await waitFor(() => expect(content).not.toBeVisible());
+		});
 
-	it("Doesn't close when interacting outside with mouseup interceptor", async () => {
-		const { getByTestId, user, trigger } = setup();
-		const content = getByTestId('content');
-		expect(content).not.toBeVisible();
-		await user.click(trigger);
-		expect(content).toBeVisible();
-		await user.click(getByTestId('mouseup-interceptor'));
-		expect(content).toBeVisible();
-	});
+		it("Doesn't close when interacting outside with mousedown interceptor", async () => {
+			const { getByTestId, user, trigger } = setup();
+			const content = getByTestId('content');
+			const overlay = getByTestId('overlay');
+			expect(content).not.toBeVisible();
+			await touch(trigger);
+			expect(content).toBeVisible();
+			await sleep(100);
+			await touch(getByTestId('mousedown-interceptor'));
+			expect(content).toBeVisible();
+			await sleep(10);
+			await user.click(overlay);
+			await waitFor(() => expect(content).not.toBeVisible());
+		});
 
-	it("Doesn't close when interacting outside with touchstart interceptor", async () => {
-		const { getByTestId, user, trigger } = setup();
-		const content = getByTestId('content');
-		expect(content).not.toBeVisible();
-		await user.click(trigger);
-		expect(content).toBeVisible();
-		await user.click(getByTestId('touchstart-interceptor'));
-		expect(content).toBeVisible();
-	});
+		it("Doesn't close when interacting outside with mouseup interceptor", async () => {
+			const { getByTestId, user, trigger } = setup();
+			const content = getByTestId('content');
+			const overlay = getByTestId('overlay');
+			expect(content).not.toBeVisible();
+			await touch(trigger);
+			expect(content).toBeVisible();
+			await sleep(100);
+			await touch(getByTestId('mouseup-interceptor'));
+			expect(content).toBeVisible();
+			await sleep(10);
+			await user.click(overlay);
+			await waitFor(() => expect(content).not.toBeVisible());
+		});
 
-	it("Doesn't close when interacting outside with touchend interceptor", async () => {
-		const { getByTestId, user, trigger } = setup();
-		const content = getByTestId('content');
-		expect(content).not.toBeVisible();
-		await user.click(trigger);
-		expect(content).toBeVisible();
-		await user.click(getByTestId('touchend-interceptor'));
-		expect(content).toBeVisible();
+		it("Doesn't close when interacting outside with touchstart interceptor", async () => {
+			const { getByTestId, user, trigger } = setup();
+			const touchstartInterceptor = getByTestId('touchstart-interceptor');
+			const content = getByTestId('content');
+			const overlay = getByTestId('overlay');
+			expect(content).not.toBeVisible();
+			await touch(trigger);
+			expect(content).toBeVisible();
+			await sleep(100);
+			await touch(touchstartInterceptor);
+			expect(content).toBeVisible();
+			await sleep(10);
+			await user.click(overlay);
+			await waitFor(() => expect(content).not.toBeVisible());
+		});
+
+		it("Doesn't close when interacting outside with touchend interceptor", async () => {
+			const { getByTestId, user, trigger } = setup();
+			const touchendInterceptor = getByTestId('touchend-interceptor');
+			const content = getByTestId('content');
+			const overlay = getByTestId('overlay');
+			expect(content).not.toBeVisible();
+			await touch(trigger);
+			expect(content).toBeVisible();
+			await sleep(100);
+			await touch(touchendInterceptor);
+			expect(content).toBeVisible();
+			await sleep(10);
+			await user.click(overlay);
+			await waitFor(() => expect(content).not.toBeVisible());
+		});
 	});
 });

--- a/src/tests/dialog/DialogTest.svelte
+++ b/src/tests/dialog/DialogTest.svelte
@@ -51,6 +51,12 @@
 <button on:touchend|stopPropagation data-testid="touchend-interceptor">
 	touchend interceptor
 </button>
+<button
+	on:touchend|preventDefault|stopPropagation
+	data-testid="touchend-prevent-default-interceptor"
+>
+	touchend prevent default interceptor
+</button>
 
 {#if $open}
 	<!-- Floating close -->

--- a/src/tests/dialog/DialogTest.svelte
+++ b/src/tests/dialog/DialogTest.svelte
@@ -28,6 +28,24 @@
 </main>
 <div id="portal-target" data-testid="portal-target" />
 
+<button on:click|stopPropagation data-testid="click-interceptor">click interceptor</button>
+<button on:pointerdown|stopPropagation data-testid="pointerdown-interceptor">
+	pointerdown interceptor
+</button>
+<button on:pointerup|stopPropagation data-testid="pointerup-interceptor">
+	pointerup interceptor
+</button>
+<button on:mousedown|stopPropagation data-testid="mousedown-interceptor">
+	mousedown interceptor
+</button>
+<button on:mouseup|stopPropagation data-testid="mouseup-interceptor">mouseup interceptor</button>
+<button on:touchstart|stopPropagation data-testid="touchstart-interceptor">
+	touchstart interceptor
+</button>
+<button on:touchend|stopPropagation data-testid="touchend-interceptor">
+	touchend interceptor
+</button>
+
 {#if $open}
 	<!-- Floating close -->
 	<button use:melt={$close} data-testid="floating-closer">Close</button>

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -25,11 +25,11 @@ export function exists(get: (id: string) => HTMLElement, testId: string) {
  * same event sequence as in the browser.
  */
 export async function touch(node: HTMLElement) {
-	await fireEvent(node, new Event('pointerdown'));
-	await fireEvent(node, new TouchEvent('touchstart'));
-	await fireEvent(node, new Event('pointerup'));
-	await fireEvent(node, new TouchEvent('touchend'));
-	await fireEvent(node, new MouseEvent('mousedown'));
-	await fireEvent(node, new MouseEvent('mouseup'));
-	await fireEvent(node, new MouseEvent('click'));
+	await fireEvent(node, new Event('pointerdown', { bubbles: true }));
+	await fireEvent(node, new TouchEvent('touchstart', { bubbles: true }));
+	await fireEvent(node, new Event('pointerup', { bubbles: true }));
+	await fireEvent(node, new TouchEvent('touchend', { bubbles: true }));
+	await fireEvent(node, new MouseEvent('mousedown', { bubbles: true }));
+	await fireEvent(node, new MouseEvent('mouseup', { bubbles: true }));
+	await fireEvent(node, new MouseEvent('click', { bubbles: true }));
 }

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -1,4 +1,5 @@
 import { kbd, removeUndefined } from '$lib/internal/helpers/index.js';
+import { fireEvent } from '@testing-library/svelte';
 export { removeUndefined };
 type KbdKeys = keyof typeof kbd;
 /**
@@ -17,4 +18,18 @@ export function exists(get: (id: string) => HTMLElement, testId: string) {
 	} catch {
 		return false;
 	}
+}
+
+/**
+ * Simulates a touch interaction while triggering the
+ * same event sequence as in the browser.
+ */
+export async function touch(node: HTMLElement) {
+	await fireEvent(node, new Event('pointerdown'));
+	await fireEvent(node, new TouchEvent('touchstart'));
+	await fireEvent(node, new Event('pointerup'));
+	await fireEvent(node, new TouchEvent('touchend'));
+	await fireEvent(node, new MouseEvent('mousedown'));
+	await fireEvent(node, new MouseEvent('mouseup'));
+	await fireEvent(node, new MouseEvent('click'));
 }


### PR DESCRIPTION
Closes https://github.com/melt-ui/melt-ui/issues/917, https://github.com/melt-ui/melt-ui/issues/1128

This PR adds the ability for a DOM element to intercept an outside interaction by calling `e.stopPropagation()`.

Let's use an example that demonstrates how the DOM behaves and the challenges it imposes for this PR:

On a mouse device, clicking an element will trigger all of the following events:
1. pointerdown
2. pointerup
3. mousedown
4. mouseup
5. click

If the user intercepts the `pointerdown` event, `pointerup` and `click` will still trigger while the mouse events will not.
If the user intercepts `mousedown` or `mouseup`, all the other events will still be triggered.

Let's use another example: on a touch device, clicking an element will trigger all of the following events:
1. pointerdown
2. touchstart
3. pointerup
4. touchend
5. mousedown
6. mouseup
7. click

If the user intercepts `touchstart` or `touchend`, the mouse and click events will NOT be triggered but the pointer events WILL.

Ok, so ideally for our sake, the user should be able to intercept any of the events and prevent an outside interaction.

Currently, we default to only using pointer events and fallback to mouse and touch events when pointer events are not available.

But in the case of issue https://github.com/melt-ui/melt-ui/issues/917, clicking on the 1Password button inside an input that is inside a dialog closes the dialog. Despite 1Password intercepting the mouse events, our `pointerup` handler is still triggered, leading to the unintended closure of the dialog.

So we should listen to all the appropriate events and trigger an outside interaction only if none of the events were intercepted by the user.

Similar to PR https://github.com/melt-ui/melt-ui/pull/845 that enabled intercepting an escape key down by not using `capture` listeners, in order to allow intercepting outside interactions, we should not trigger an outside interaction using capture listeners.

However the challenge is--how do you determine if any of the events were intercepted when the browser will trigger a bunch of other events nonetheless.

To identify intercepted events during an interaction, we implement a two-step approach for the following events: `pointerdown`, `touchstart`, `pointerup`, `touchend`, `mousedown`, `mouseup`, and `click`. First, we attach an event listener in the capture phase (`capture: true`) to flag the event as intercepted. Subsequently, we add another event listener for the bubbling phase, designed to tag the event as NOT intercepted if it passes through. This setup relies on the principle that the bubbling phase listener is called only if the event was not intercepted by the user. Conversely, if an event is intercepted, only the capture phase listener will trigger, which marks the event as intercepted.

So now we can easily check if any events were intercepted and not trigger an outside interaction in that case.

Since we attach event listeners for multiple events, the browser may trigger multiple events at the same time (i.e. `pointerdown` + `touchstart`, `pointerup` + `touchend`, etc.). In order to make sure that we don't run into race conditions and prematurely check whether any events were intercepted before all other bubbling handlers have potentially marked the events as not intercepted, we debounce the event handlers, which also prevents them from being executed more than once.

After an interaction has finished, we also need to correctly reset the `interceptedEvents` object so that future interactions that are not intercepted will behave as expected. We should only reset `interceptedEvents` at the end of an interaction (`touchend`, `pointerup`, `mouseup`, `click`) in case the user intercepted the beginning of an interaction while still expecting the whole interaction to be intercepted. We debounce resetting `interceptedEvents` to avoid race conditions. We should also call `resetInterceptedEventsDebounced` in the capture phase handlers since the bubbling phase handlers may not be called due to user interception.

I modified the dialog example in the docs and added buttons that intercept different events for demonstration purposes. The modified docs should not be included in the final PR.

Also, I added a lot of tests that make sure all this works correctly so don't be intimidated by the number of lines added by this PR :)

Thanks for reading all this :)


### Before

https://github.com/melt-ui/melt-ui/assets/53095479/21002268-8cff-4ed8-a8af-1f21e4f43a95

### After

https://github.com/melt-ui/melt-ui/assets/53095479/51cb8552-c1e5-4041-addc-b33930d6bb69

### Mouse Device

https://github.com/melt-ui/melt-ui/assets/53095479/c95a68dc-772f-43c8-8167-700309dc4bb2

### Touch Device

https://github.com/melt-ui/melt-ui/assets/53095479/c724abf0-e84f-4ecf-aae6-ed6f4111c367

