### PR TITLE
Fix(interact outside) touch devices leak click events to dom elements

### DIFF
--- a/.changeset/wise-schools-complain.md
+++ b/.changeset/wise-schools-complain.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+Fixed a bug on touch devices where an outside interaction leaked click events to other dom elements (closes #1115)


### PR DESCRIPTION
closes https://github.com/melt-ui/melt-ui/issues/1115

This closes an issue where clicking outside a dialog on a touch device would trigger a click event on the element underneath the dialog.

This only happens when using pointer events on touch devices. After `pointerup` is called on touch devices, we need to wait for a `click` event before triggering an outside interaction. There is a delay between `pointerup` and `click` during which we used to close the dialog and hence trigger a click event on the element under the dialog.

Technically this issue should also occur when using touch events, which we use when pointer events are not available, however this issue doesn't occur in our case when using touch events because we call `e.preventDefault()` which will prevent a click event occurring after a `touchend`

### Before


https://github.com/melt-ui/melt-ui/assets/53095479/0e1f2964-d5f2-4465-bda9-262f1435a683



https://github.com/melt-ui/melt-ui/assets/53095479/9697e482-26b7-4fc1-95ea-0dcad5f369ae



### After

https://github.com/melt-ui/melt-ui/assets/53095479/fc2187a4-9ecd-429e-bae7-a6c8877bb0ff



https://github.com/melt-ui/melt-ui/assets/53095479/0218571f-82e1-460b-a4ca-5fbc8c4a7fa0

