### PR TITLE
Feat: add `autoSort` option for sliders

### DIFF
--- a/.changeset/new-hairs-vanish.md
+++ b/.changeset/new-hairs-vanish.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+slider: add disable swapping option to avoid sorting of values array

--- a/src/docs/content/builders/slider.md
+++ b/src/docs/content/builders/slider.md
@@ -61,10 +61,10 @@ You can add slider ticks using the `ticks` state and the `tick` element returned
     <svelte:component this={previews.ticks} />
 </Preview>
 
-### Disable Index Swapping
+### Auto Sorting
 
 By default, the `value` array is always automatically sorted. You can disable this behavior by
-setting `disableSwap` to `true`, which will keep values in their original spot when thumbs are moved
+setting `autoSort` to `false`, which will keep values in their original spot when thumbs are moved
 past each other.
 
 <Preview code={snippets.multiple}>

--- a/src/docs/content/builders/slider.md
+++ b/src/docs/content/builders/slider.md
@@ -63,7 +63,9 @@ You can add slider ticks using the `ticks` state and the `tick` element returned
 
 ### Disable Index Swapping
 
-By default, the `value` array is always automatically sorted. You can disable this behavior by setting `disableSwap` to `true`, which will keep values in their original spot when thumbs are moved past each other.
+By default, the `value` array is always automatically sorted. You can disable this behavior by
+setting `disableSwap` to `true`, which will keep values in their original spot when thumbs are moved
+past each other.
 
 <Preview code={snippets.multiple}>
     <svelte:component this={previews.multiple} />

--- a/src/docs/content/builders/slider.md
+++ b/src/docs/content/builders/slider.md
@@ -61,9 +61,9 @@ You can add slider ticks using the `ticks` state and the `tick` element returned
     <svelte:component this={previews.ticks} />
 </Preview>
 
-### Enable Index Swapping
+### Disable Index Swapping
 
-You can enable index swapping, so that the `value` array is always automatically sorted. By default `enableSwap` is `false`, so values will not get swapped when thumbs are moved past each other.
+By default, the `value` array is always automatically sorted. You can disable this behavior by setting `disableSwap` to `true`, which will keep values in their original spot when thumbs are moved past each other.
 
 <Preview code={snippets.multiple}>
     <svelte:component this={previews.multiple} />

--- a/src/docs/content/builders/slider.md
+++ b/src/docs/content/builders/slider.md
@@ -61,6 +61,14 @@ You can add slider ticks using the `ticks` state and the `tick` element returned
     <svelte:component this={previews.ticks} />
 </Preview>
 
+### Enable Index Swapping
+
+You can enable index swapping, so that the `value` array is always automatically sorted. By default `enableSwap` is `false`, so values will not get swapped when thumbs are moved past each other.
+
+<Preview code={snippets.multiple}>
+    <svelte:component this={previews.multiple} />
+</Preview>
+
 ## API Reference
 
 <APIReference {schemas} />

--- a/src/docs/data/builders/slider.ts
+++ b/src/docs/data/builders/slider.ts
@@ -43,8 +43,7 @@ const OPTION_PROPS = [
 		name: 'autoSort',
 		type: 'boolean',
 		default: 'true',
-		description:
-			'Whether to automatically sort the values array when using multiple thumbs.',
+		description: 'Whether to automatically sort the values array when using multiple thumbs.',
 	},
 	PROPS.DISABLED,
 ];

--- a/src/docs/data/builders/slider.ts
+++ b/src/docs/data/builders/slider.ts
@@ -40,10 +40,10 @@ const OPTION_PROPS = [
 		description: 'The direction of the slider.',
 	},
 	{
-		name: 'enableSwap',
+		name: 'disableSwap',
 		type: 'boolean',
 		default: "false",
-		description: 'Whether to automatically sort the value array when using multiple thumbs.'
+		description: 'Whether to disable automatically sorting the values array when using multiple thumbs.'
 	},
 	PROPS.DISABLED,
 ];

--- a/src/docs/data/builders/slider.ts
+++ b/src/docs/data/builders/slider.ts
@@ -39,6 +39,12 @@ const OPTION_PROPS = [
 		default: "'ltr'",
 		description: 'The direction of the slider.',
 	},
+	{
+		name: 'enableSwap',
+		type: 'boolean',
+		default: "false",
+		description: 'Whether to automatically sort the value array when using multiple thumbs.'
+	},
 	PROPS.DISABLED,
 ];
 const BUILDER_NAME = 'slider';

--- a/src/docs/data/builders/slider.ts
+++ b/src/docs/data/builders/slider.ts
@@ -42,8 +42,9 @@ const OPTION_PROPS = [
 	{
 		name: 'disableSwap',
 		type: 'boolean',
-		default: "false",
-		description: 'Whether to disable automatically sorting the values array when using multiple thumbs.'
+		default: 'false',
+		description:
+			'Whether to disable automatically sorting the values array when using multiple thumbs.',
 	},
 	PROPS.DISABLED,
 ];

--- a/src/docs/data/builders/slider.ts
+++ b/src/docs/data/builders/slider.ts
@@ -40,11 +40,11 @@ const OPTION_PROPS = [
 		description: 'The direction of the slider.',
 	},
 	{
-		name: 'disableSwap',
+		name: 'autoSort',
 		type: 'boolean',
-		default: 'false',
+		default: 'true',
 		description:
-			'Whether to disable automatically sorting the values array when using multiple thumbs.',
+			'Whether to automatically sort the values array when using multiple thumbs.',
 	},
 	PROPS.DISABLED,
 ];

--- a/src/docs/previews/slider/multiple/tailwind/index.svelte
+++ b/src/docs/previews/slider/multiple/tailwind/index.svelte
@@ -8,11 +8,11 @@
 
 <div class="flex flex-col gap-8">
 	<div class="flex flex-col gap-4 text-center">
-		<code>disableSwap: true; value: {$value1}</code>
-		<Slider value={value1} disableSwap={true} />
+		<code>autoSort: false; value: [{$value1}]</code>
+		<Slider value={value1} autoSort={false} />
 	</div>
 	<div class="flex flex-col gap-4 text-center">
-		<code>disableSwap: false; value: {$value2}</code>
+		<code>autoSort: true; value: [{$value2}]</code>
 		<Slider value={value2} />
 	</div>
 </div>

--- a/src/docs/previews/slider/multiple/tailwind/index.svelte
+++ b/src/docs/previews/slider/multiple/tailwind/index.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import Slider from './slider.svelte';
+</script>
+
+<div class="flex flex-col gap-8">
+	<div class="flex flex-col gap-4 text-center">
+		<code>enableSwap: false</code>
+		<Slider />
+	</div>
+	<div class="flex flex-col gap-4 text-center">
+		<code>enableSwap: true</code>
+		<Slider enableSwap={true} />
+	</div>
+</div>

--- a/src/docs/previews/slider/multiple/tailwind/index.svelte
+++ b/src/docs/previews/slider/multiple/tailwind/index.svelte
@@ -8,11 +8,11 @@
 
 <div class="flex flex-col gap-8">
 	<div class="flex flex-col gap-4 text-center">
-		<code>enableSwap: false; value: {$value1}</code>
-		<Slider value={value1} />
+		<code>disableSwap: true; value: {$value1}</code>
+		<Slider value={value1} disableSwap={true} />
 	</div>
 	<div class="flex flex-col gap-4 text-center">
-		<code>enableSwap: true; value: {$value2}</code>
-		<Slider value={value2} enableSwap={true} />
+		<code>disableSwap: false; value: {$value2}</code>
+		<Slider value={value2} />
 	</div>
 </div>

--- a/src/docs/previews/slider/multiple/tailwind/index.svelte
+++ b/src/docs/previews/slider/multiple/tailwind/index.svelte
@@ -1,14 +1,18 @@
 <script lang="ts">
+	import { writable } from 'svelte/store';
 	import Slider from './slider.svelte';
+
+	const value1 = writable([30, 40, 50, 60, 70]);
+	const value2 = writable([30, 40, 50, 60, 70]);
 </script>
 
 <div class="flex flex-col gap-8">
 	<div class="flex flex-col gap-4 text-center">
-		<code>enableSwap: false</code>
-		<Slider />
+		<code>enableSwap: false; value: {$value1}</code>
+		<Slider value={value1} />
 	</div>
 	<div class="flex flex-col gap-4 text-center">
-		<code>enableSwap: true</code>
-		<Slider enableSwap={true} />
+		<code>enableSwap: true; value: {$value2}</code>
+		<Slider value={value2} enableSwap={true} />
 	</div>
 </div>

--- a/src/docs/previews/slider/multiple/tailwind/slider.svelte
+++ b/src/docs/previews/slider/multiple/tailwind/slider.svelte
@@ -1,18 +1,20 @@
 <script lang="ts">
 	import { createSlider, melt } from '$lib/index.js';
+	import type { Writable } from 'svelte/store';
 
+	export let value: Writable<number[]>;
 	export let enableSwap = false;
 
 	const {
 		elements: { root, range, thumbs },
 	} = createSlider({
-		defaultValue: [20, 30, 40, 80],
+		value,
 		max: 100,
 		enableSwap,
 	});
 </script>
 
-<span use:melt={$root} class="relative flex h-[20px] w-[200px] items-center">
+<span use:melt={$root} class="relative flex h-[20px] items-center">
 	<span class="h-[3px] w-full bg-white">
 		<span use:melt={$range} class="h-[3px] bg-white" />
 	</span>

--- a/src/docs/previews/slider/multiple/tailwind/slider.svelte
+++ b/src/docs/previews/slider/multiple/tailwind/slider.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import { createSlider, melt } from '$lib/index.js';
+
+	export let enableSwap = false;
+
+	const {
+		elements: { root, range, thumbs },
+	} = createSlider({
+		defaultValue: [20, 30, 40, 80],
+		max: 100,
+		enableSwap,
+	});
+</script>
+
+<span use:melt={$root} class="relative flex h-[20px] w-[200px] items-center">
+	<span class="h-[3px] w-full bg-white">
+		<span use:melt={$range} class="h-[3px] bg-white" />
+	</span>
+
+	{#each $thumbs as thumb, i}
+		<span
+			use:melt={thumb}
+			class="inline-flex h-5 w-5 cursor-grab items-center justify-center rounded-full bg-white font-semibold text-black focus:ring-4 focus:!ring-black/40"
+		>
+			{i}
+		</span>
+	{/each}
+</span>

--- a/src/docs/previews/slider/multiple/tailwind/slider.svelte
+++ b/src/docs/previews/slider/multiple/tailwind/slider.svelte
@@ -3,14 +3,14 @@
 	import type { Writable } from 'svelte/store';
 
 	export let value: Writable<number[]>;
-	export let enableSwap = false;
+	export let disableSwap = false;
 
 	const {
 		elements: { root, range, thumbs },
 	} = createSlider({
 		value,
 		max: 100,
-		enableSwap,
+		disableSwap,
 	});
 </script>
 

--- a/src/docs/previews/slider/multiple/tailwind/slider.svelte
+++ b/src/docs/previews/slider/multiple/tailwind/slider.svelte
@@ -3,14 +3,14 @@
 	import type { Writable } from 'svelte/store';
 
 	export let value: Writable<number[]>;
-	export let disableSwap = false;
+	export let autoSort = true;
 
 	const {
 		elements: { root, range, thumbs },
 	} = createSlider({
 		value,
 		max: 100,
-		disableSwap,
+		autoSort,
 	});
 </script>
 

--- a/src/lib/builders/slider/create.ts
+++ b/src/lib/builders/slider/create.ts
@@ -34,7 +34,7 @@ const defaults = {
 	orientation: 'horizontal',
 	dir: 'ltr',
 	disabled: false,
-	enableSwap: false
+	disableSwap: false
 } satisfies CreateSliderProps;
 
 const { name } = createElHelpers('slider');
@@ -43,7 +43,7 @@ export const createSlider = (props?: CreateSliderProps) => {
 	const withDefaults = { ...defaults, ...props } satisfies CreateSliderProps;
 
 	const options = toWritableStores(omit(withDefaults, 'value', 'onValueChange', 'defaultValue'));
-	const { min, max, step, orientation, dir, disabled, enableSwap } = options;
+	const { min, max, step, orientation, dir, disabled, disableSwap } = options;
 
 	const valueWritable = withDefaults.value ?? writable(withDefaults.defaultValue);
 	const value = overridable(valueWritable, withDefaults?.onValueChange);
@@ -73,7 +73,7 @@ export const createSlider = (props?: CreateSliderProps) => {
 				}
 			}
 
-			if (enableSwap.get() && 
+			if (!disableSwap.get() && 
 				((direction === -1 && val < newValue[index - 1]) || 
 				 (direction === 1 && val > newValue[index + 1]))) {
 				swap();

--- a/src/lib/builders/slider/create.ts
+++ b/src/lib/builders/slider/create.ts
@@ -34,7 +34,7 @@ const defaults = {
 	orientation: 'horizontal',
 	dir: 'ltr',
 	disabled: false,
-	disableSwap: false,
+	autoSort: true,
 } satisfies CreateSliderProps;
 
 const { name } = createElHelpers('slider');
@@ -43,7 +43,7 @@ export const createSlider = (props?: CreateSliderProps) => {
 	const withDefaults = { ...defaults, ...props } satisfies CreateSliderProps;
 
 	const options = toWritableStores(omit(withDefaults, 'value', 'onValueChange', 'defaultValue'));
-	const { min, max, step, orientation, dir, disabled, disableSwap } = options;
+	const { min, max, step, orientation, dir, disabled, autoSort } = options;
 
 	const valueWritable = withDefaults.value ?? writable(withDefaults.defaultValue);
 	const value = overridable(valueWritable, withDefaults?.onValueChange);
@@ -74,7 +74,7 @@ export const createSlider = (props?: CreateSliderProps) => {
 			}
 
 			if (
-				!disableSwap.get() &&
+				autoSort.get() &&
 				((direction === -1 && val < newValue[index - 1]) ||
 					(direction === 1 && val > newValue[index + 1]))
 			) {

--- a/src/lib/builders/slider/create.ts
+++ b/src/lib/builders/slider/create.ts
@@ -34,7 +34,7 @@ const defaults = {
 	orientation: 'horizontal',
 	dir: 'ltr',
 	disabled: false,
-	disableSwap: false
+	disableSwap: false,
 } satisfies CreateSliderProps;
 
 const { name } = createElHelpers('slider');
@@ -73,13 +73,15 @@ export const createSlider = (props?: CreateSliderProps) => {
 				}
 			}
 
-			if (!disableSwap.get() && 
-				((direction === -1 && val < newValue[index - 1]) || 
-				 (direction === 1 && val > newValue[index + 1]))) {
+			if (
+				!disableSwap.get() &&
+				((direction === -1 && val < newValue[index - 1]) ||
+					(direction === 1 && val > newValue[index + 1]))
+			) {
 				swap();
 				return newValue;
 			}
-			
+
 			const $min = min.get();
 			const $max = max.get();
 			const $step = step.get();

--- a/src/lib/builders/slider/create.ts
+++ b/src/lib/builders/slider/create.ts
@@ -34,6 +34,7 @@ const defaults = {
 	orientation: 'horizontal',
 	dir: 'ltr',
 	disabled: false,
+	enableSwap: false
 } satisfies CreateSliderProps;
 
 const { name } = createElHelpers('slider');
@@ -42,7 +43,7 @@ export const createSlider = (props?: CreateSliderProps) => {
 	const withDefaults = { ...defaults, ...props } satisfies CreateSliderProps;
 
 	const options = toWritableStores(omit(withDefaults, 'value', 'onValueChange', 'defaultValue'));
-	const { min, max, step, orientation, dir, disabled } = options;
+	const { min, max, step, orientation, dir, disabled, enableSwap } = options;
 
 	const valueWritable = withDefaults.value ?? writable(withDefaults.defaultValue);
 	const value = overridable(valueWritable, withDefaults?.onValueChange);
@@ -61,6 +62,7 @@ export const createSlider = (props?: CreateSliderProps) => {
 			const newValue = [...prev];
 
 			const direction = newValue[index] > val ? -1 : +1;
+
 			function swap() {
 				newValue[index] = newValue[index + direction];
 				newValue[index + direction] = val;
@@ -70,13 +72,14 @@ export const createSlider = (props?: CreateSliderProps) => {
 					activeThumb.set({ thumb: thumbs[index + direction], index: index + direction });
 				}
 			}
-			if (direction === -1 && val < newValue[index - 1]) {
-				swap();
-				return newValue;
-			} else if (direction === 1 && val > newValue[index + 1]) {
+
+			if (enableSwap.get() && 
+				((direction === -1 && val < newValue[index - 1]) || 
+				 (direction === 1 && val > newValue[index + 1]))) {
 				swap();
 				return newValue;
 			}
+			
 			const $min = min.get();
 			const $max = max.get();
 			const $step = step.get();

--- a/src/lib/builders/slider/types.ts
+++ b/src/lib/builders/slider/types.ts
@@ -73,11 +73,11 @@ export type CreateSliderProps = {
 	disabled?: boolean;
 
 	/**
-	 * When `true`, automatically sorts the value array when moving thumbs past each other.
+	 * When `true`, disables automatically sorting the value array when moving thumbs past each other.
 	 * 
 	 * @default false
 	 */
-	enableSwap?: boolean;
+	disableSwap?: boolean;
 };
 
 export type Slider = BuilderReturn<typeof createSlider>;

--- a/src/lib/builders/slider/types.ts
+++ b/src/lib/builders/slider/types.ts
@@ -71,6 +71,13 @@ export type CreateSliderProps = {
 	 * @default false
 	 */
 	disabled?: boolean;
+
+	/**
+	 * When `true`, automatically sorts the value array when moving thumbs past each other.
+	 * 
+	 * @default false
+	 */
+	enableSwap?: boolean;
 };
 
 export type Slider = BuilderReturn<typeof createSlider>;

--- a/src/lib/builders/slider/types.ts
+++ b/src/lib/builders/slider/types.ts
@@ -74,7 +74,7 @@ export type CreateSliderProps = {
 
 	/**
 	 * When `true`, disables automatically sorting the value array when moving thumbs past each other.
-	 * 
+	 *
 	 * @default false
 	 */
 	disableSwap?: boolean;

--- a/src/lib/builders/slider/types.ts
+++ b/src/lib/builders/slider/types.ts
@@ -73,11 +73,11 @@ export type CreateSliderProps = {
 	disabled?: boolean;
 
 	/**
-	 * When `true`, disables automatically sorting the value array when moving thumbs past each other.
+	 * When `false`, disables automatically sorting the value array when moving thumbs past each other.
 	 *
-	 * @default false
+	 * @default true
 	 */
-	disableSwap?: boolean;
+	autoSort?: boolean;
 };
 
 export type Slider = BuilderReturn<typeof createSlider>;


### PR DESCRIPTION
Closes #1122.

I added a `disableSwap` option to sliders which disables the automatic ordering of the value array. Therefore it's now possible to have arrays like these: `[25, 20, 30]`, whereas before the value arrays were always automatically sorted. This is important because in some instances users might want indexes to hold specific meaning, so if the values get swapped around there's no way of keeping track of the individual values.

I also added an example for it, which demonstrates the different behaviors:
![image](https://github.com/melt-ui/melt-ui/assets/20195536/2e662905-e4cc-4380-89a1-b29d8fac05c9)

