### PR TITLE
chore: fix dialog test name

### DIFF
--- a/src/tests/dialog/Dialog.spec.ts
+++ b/src/tests/dialog/Dialog.spec.ts
@@ -272,7 +272,7 @@ describe('Dialog', () => {
 		expect(description.id).toBe(ids.description);
 	});
 
-	it("Doesn't close on pointerup if the previous pointerdown didn't occur inside the dialog", async () => {
+	it("Doesn't close on pointerup if the previous pointerdown occurred inside the dialog", async () => {
 		const { getByTestId, user, trigger } = setup();
 		const overlay = getByTestId('overlay');
 		const content = getByTestId('content');


### PR DESCRIPTION
This PR improves the changes introduced by https://github.com/melt-ui/melt-ui/pull/1118
Currently in touch devices, we wait for a `click` event after a `pointerdown` and a `pointerup` to prevent the events leaking to elements underneath the dialog.

So now, instead of listening to `pointerup`, `touchend`, `mouseup`, we can just listen to the `click` event.