### PR TITLE
chore: refactor dialog tests

### DIFF
--- a/src/tests/dialog/Dialog.spec.ts
+++ b/src/tests/dialog/Dialog.spec.ts
@@ -11,11 +11,27 @@ function setup(props: CreateDialogProps = {}) {
 	const user = userEvent.setup();
 	const returned = render(DialogTest, props);
 	const trigger = returned.getByTestId('trigger');
+	const content = returned.getByTestId('content');
+	const overlay = returned.getByTestId('overlay');
+	const portalled = returned.getByTestId('portalled');
 	return {
 		trigger,
+		content,
+		overlay,
+		portalled,
 		user,
 		...returned,
 	};
+}
+
+async function open(props: CreateDialogProps = {}) {
+	const returned = setup(props);
+	const { user, trigger, content } = returned;
+	expect(content).not.toBeVisible();
+	await user.click(trigger);
+	await sleep(100);
+	expect(content).toBeVisible();
+	return returned;
 }
 
 describe('Dialog', () => {
@@ -26,128 +42,79 @@ describe('Dialog', () => {
 	});
 
 	it('Opens when trigger is clicked', async () => {
-		const { getByTestId, user, trigger } = setup();
-		const content = getByTestId('content');
-
-		expect(content).not.toBeVisible();
-		await user.click(trigger);
-		const now = performance.now();
-		expect(content).toBeVisible();
-		const elapsed = performance.now() - now;
-		expect(elapsed).toBeLessThan(10);
+		await open();
 	});
 
 	it('Closes when closer is clicked', async () => {
-		const { getByTestId, user, trigger } = setup();
+		const { getByTestId, user, content } = await open();
 		const closer = getByTestId('closer');
-		const content = getByTestId('content');
 
-		expect(trigger).toBeVisible();
-		expect(content).not.toBeVisible();
-		await user.click(trigger);
-		expect(content).toBeVisible();
 		await user.click(closer);
 		expect(content).not.toBeVisible();
 	});
 
 	it('Closes when Escape is hit', async () => {
-		const { getByTestId, user, trigger } = setup();
-		const content = getByTestId('content');
+		const { user, content } = await open();
 
-		expect(trigger).toBeVisible();
-		expect(content).not.toBeVisible();
-		await user.click(trigger);
-		expect(content).toBeVisible();
 		await user.keyboard(kbd.ESCAPE);
 		expect(content).not.toBeVisible();
 	});
 
 	it('Closes when overlay is clicked', async () => {
-		const { getByTestId, user, trigger } = setup();
-		const overlay = getByTestId('overlay');
-		const content = getByTestId('content');
+		const { user, overlay, content } = await open();
 
-		expect(trigger).toBeVisible();
-		expect(content).not.toBeVisible();
-		await user.click(trigger);
-		expect(content).toBeVisible();
-		await sleep(100);
 		expect(overlay).toBeVisible();
 		await user.click(overlay);
 		expect(content).not.toBeVisible();
 	});
 
 	it('Prevents closing on outside click if `defaultPrevented` in `onOutsideClick` callback', async () => {
-		const { getByTestId, user, trigger } = setup({
+		const { getByTestId, user, overlay, content } = await open({
 			onOutsideClick: (e) => {
 				e.preventDefault();
 			},
 		});
-		const overlay = getByTestId('overlay');
-		const content = getByTestId('content');
 
-		expect(trigger).toBeVisible();
-		expect(content).not.toBeVisible();
-		await user.click(trigger);
-		expect(content).toBeVisible();
-		await sleep(100);
 		expect(overlay).toBeVisible();
 		await user.click(overlay);
 		expect(content).toBeVisible();
 	});
 
 	it('Portalled el attaches dialog to body', async () => {
-		const { getByTestId, user, trigger } = setup();
-		await user.click(trigger);
-
-		const portalled = getByTestId('portalled');
+		const { getByTestId, portalled } = await open();
 
 		expect(portalled.parentElement).toEqual(document.body);
 	});
 
 	it('Attaches portal el to the portal target if prop provided', async () => {
-		const { getByTestId, user, trigger } = setup({
+		const { getByTestId, portalled } = await open({
 			portal: '#portal-target',
 		});
-		await user.click(trigger);
-		const portalled = getByTestId('portalled');
 		const portalTarget = getByTestId('portal-target');
 
 		expect(portalled.parentElement).toEqual(portalTarget);
 	});
 
 	it('Does not portal if `null` is passed as portal prop', async () => {
-		const { getByTestId, user, trigger } = setup({
+		const { getByTestId, portalled } = await open({
 			portal: null,
 		});
-		await user.click(trigger);
-		const portalled = getByTestId('portalled');
 		const main = getByTestId('main');
 
 		expect(portalled.parentElement).toEqual(main);
 	});
 
 	it('Focuses first focusable item upon opening', async () => {
-		const { getByTestId, user, trigger } = setup();
-		const content = getByTestId('content');
+		const { content } = await open();
 
-		expect(trigger).toBeVisible();
-		expect(content).not.toBeVisible();
-		await user.click(trigger);
-		expect(content).toBeVisible();
 		// Testing focus-trap is a bit flaky. So the focusable element is
 		// always content here.
 		expect(document.activeElement).toBe(content);
 	});
 
 	it('Tabbing on last item focuses first item', async () => {
-		const { getByTestId, user, trigger } = setup();
-		const content = getByTestId('content');
+		const { user, content } = await open();
 
-		expect(trigger).toBeVisible();
-		expect(content).not.toBeVisible();
-		await user.click(trigger);
-		expect(content).toBeVisible();
 		// Testing focus-trap is a bit flaky. So the focusable element is
 		// always content here.
 		expect(document.activeElement).toBe(content);
@@ -156,14 +123,9 @@ describe('Dialog', () => {
 	});
 
 	it("Doesn't close when clicking content", async () => {
-		const { getByTestId, user, trigger } = setup();
-		const content = getByTestId('content');
+		const { getByTestId, user, trigger, content } = await open();
 		const closer = getByTestId('closer');
 
-		expect(trigger).toBeVisible();
-		expect(content).not.toBeVisible();
-		await user.click(trigger);
-		expect(content).toBeVisible();
 		await user.click(content);
 		expect(content).toBeVisible();
 
@@ -179,75 +141,54 @@ describe('Dialog', () => {
 	});
 
 	it('Respects the `openFocus` prop', async () => {
-		const { getByTestId, user, trigger } = setup({
+		const { getByTestId } = await open({
 			openFocus: () => document.getElementById('openFocus'),
 		});
 
-		await user.click(trigger);
 		await waitFor(() => expect(getByTestId('openFocus')).toHaveFocus());
 	});
 
 	it('Respects the `closeFocus` prop', async () => {
-		const { getByTestId, user, trigger } = setup({
+		const { getByTestId, user } = await open({
 			closeFocus: () => document.getElementById('closeFocus'),
 		});
-		await user.click(trigger);
 		await user.keyboard(kbd.ESCAPE);
 		await waitFor(() => expect(getByTestId('closeFocus')).toHaveFocus());
 	});
 
 	it('Respects the `closeOnOutsideClick` prop', async () => {
-		const { getByTestId, user, trigger } = setup({
+		const { user, content, overlay } = await open({
 			closeOnOutsideClick: false,
 		});
-		const content = getByTestId('content');
-		const overlay = getByTestId('overlay');
 
-		expect(trigger).toBeVisible();
-		expect(content).not.toBeVisible();
-		await user.click(trigger);
-		expect(content).toBeVisible();
-		await sleep(100);
 		expect(overlay).toBeVisible();
 		await user.click(overlay);
 		expect(content).toBeVisible();
 	});
 
 	it('When closeOnOutsideClick is false, clicking floating closer closes dialog', async () => {
-		const { getByTestId, user, trigger } = setup({
+		const { getByTestId, user, content } = await open({
 			closeOnOutsideClick: false,
 		});
-		const content = getByTestId('content');
-
-		expect(trigger).toBeVisible();
-		expect(content).not.toBeVisible();
-		await user.click(trigger);
-		expect(content).toBeVisible();
-		await sleep(100);
 		const closer = getByTestId('floating-closer');
+
 		await waitFor(() => expect(closer).toBeVisible());
 		await user.click(closer);
 		await waitFor(() => expect(content).not.toBeVisible());
 	});
 
 	it('Respects the `closeOnEscape` prop', async () => {
-		const { getByTestId, user, trigger } = setup({
+		const { user, content } = await open({
 			closeOnEscape: false,
 		});
-		expect(trigger).toBeVisible();
-		const content = getByTestId('content');
-		expect(content).not.toBeVisible();
-		await user.click(trigger);
-		expect(content).toBeVisible();
+
 		await user.keyboard(kbd.ESCAPE);
 		expect(content).toBeVisible();
 	});
 
 	it("Doesn't close on escape if child intercepts event", async () => {
-		const { getByTestId, user, trigger } = setup();
-		await user.click(trigger);
-		const content = getByTestId('content');
-		expect(content).toBeVisible();
+		const { getByTestId, user, content } = await open();
+
 		const input = getByTestId('input-keydown-interceptor');
 		input.focus();
 		await user.keyboard(kbd.ESCAPE);
@@ -260,11 +201,10 @@ describe('Dialog', () => {
 			title: 'id-title',
 			description: 'id-description',
 		};
-		const { getByTestId } = setup({
+		const { getByTestId, content } = setup({
 			ids,
 		});
 
-		const content = getByTestId('content');
 		const title = getByTestId('title');
 		const description = getByTestId('description');
 		expect(content.id).toBe(ids.content);
@@ -273,14 +213,8 @@ describe('Dialog', () => {
 	});
 
 	it("Doesn't close on pointerup if the previous pointerdown didn't occur inside the dialog", async () => {
-		const { getByTestId, user, trigger } = setup();
-		const overlay = getByTestId('overlay');
-		const content = getByTestId('content');
+		const { user, overlay, content } = await open();
 
-		expect(content).not.toBeVisible();
-		await user.click(trigger);
-		expect(content).toBeVisible();
-		await sleep(100);
 		expect(overlay).toBeVisible();
 		await user.pointer({ target: content, offset: 2, keys: '[MouseLeft>]' });
 		await user.pointer({ target: overlay, offset: 2, keys: '[/MouseLeft]' });
@@ -288,14 +222,8 @@ describe('Dialog', () => {
 	});
 
 	it('Closes on pointerup if the previous pointerdown occurred outside the dialog', async () => {
-		const { getByTestId, user, trigger } = setup();
-		const overlay = getByTestId('overlay');
-		const content = getByTestId('content');
+		const { user, overlay, content } = await open();
 
-		expect(content).not.toBeVisible();
-		await user.click(trigger);
-		expect(content).toBeVisible();
-		await sleep(100);
 		expect(overlay).toBeVisible();
 		await user.pointer({ target: overlay, offset: 2, keys: '[MouseLeft>]' });
 		await user.pointer({ target: overlay, offset: 2, keys: '[/MouseLeft]' });
@@ -303,32 +231,28 @@ describe('Dialog', () => {
 	});
 
 	it("Doesn't deactivate focus trap on escape provided `closeOnEscape` false", async () => {
-		const { getByTestId, user, trigger } = setup({
+		const { getByTestId, user, content } = await open({
 			closeOnEscape: false,
 		});
-		const content = getByTestId('content');
-		expect(content).not.toBeVisible();
-		await user.click(trigger);
-		expect(content).toBeVisible();
+		const closer = getByTestId('floating-closer');
+
 		await user.keyboard(kbd.ESCAPE);
 		expect(content).toBeVisible();
-		expect(getByTestId('content')).toHaveFocus();
+		expect(content).toHaveFocus();
 		await user.tab({ shift: true });
-		expect(getByTestId('floating-closer')).not.toHaveFocus();
+		expect(closer).not.toHaveFocus();
 	});
 
 	it("Doesn't deactivate focus trap on outside click provided `closeOnOutsideClick` false", async () => {
-		const { getByTestId, user, trigger } = setup({
+		const { getByTestId, user, overlay, content } = await open({
 			closeOnOutsideClick: false,
 		});
-		const content = getByTestId('content');
-		expect(content).not.toBeVisible();
-		await user.click(trigger);
+		const closer = getByTestId('floating-closer');
+
+		await user.click(overlay);
 		expect(content).toBeVisible();
-		await user.click(getByTestId('overlay'));
-		expect(content).toBeVisible();
-		expect(getByTestId('content')).toHaveFocus();
+		expect(content).toHaveFocus();
 		await user.tab({ shift: true });
-		expect(getByTestId('floating-closer')).not.toHaveFocus();
+		expect(closer).not.toHaveFocus();
 	});
 });


### PR DESCRIPTION
Currently in our dialog tests, every test repeats the assertions for opening a dialog so I refactored it into an `open` function.
Also most tests need `getByTestId('content')` and `getByTestId('overlay')`, so I added them to the object returned from `setup`