### PR TITLE
fix(link-preview): reset activeTrigger on trigger unmount

### DIFF
--- a/.changeset/old-taxis-yell.md
+++ b/.changeset/old-taxis-yell.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+Fix link preview: reset activeTrigger on trigger unmount

--- a/src/lib/builders/link-preview/create.ts
+++ b/src/lib/builders/link-preview/create.ts
@@ -142,7 +142,10 @@ export function createLinkPreview(props: CreateLinkPreviewProps = {}) {
 			);
 
 			return {
-				destroy: unsub,
+				destroy() {
+					unsub();
+					activeTrigger.set(null);
+				},
 			};
 		},
 	});


### PR DESCRIPTION
reset activeTrigger on trigger unmount. Currently, if you unmount the trigger, the content stays open because we never reset the `activeTrigger`. So on trigger destroy, we set `activeTrigger` to `null`

### Before
https://github.com/melt-ui/melt-ui/assets/53095479/edacd63f-160a-4241-9ef5-c0a1b48507b2

### After

https://github.com/melt-ui/melt-ui/assets/53095479/767ac36f-988b-4483-9041-7f4348b7f689

