### PR TITLE
fix(focus trap): focus trap deactivates on intercepted escape

### DIFF
--- a/.changeset/hungry-steaks-whisper.md
+++ b/.changeset/hungry-steaks-whisper.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+Fixed bug where focus trap would deactivate on escape that was intercepted (closes #1132)

--- a/src/lib/builders/dialog/create.ts
+++ b/src/lib/builders/dialog/create.ts
@@ -178,30 +178,26 @@ export function createDialog(props?: CreateDialogProps) {
 			let deactivate = noop;
 
 			const destroy = executeCallbacks(
-				effect(
-					[open, closeOnOutsideClick, closeOnEscape],
-					([$open, $closeOnOutsideClick, $closeOnEscape]) => {
-						if (!$open) return;
+				effect([open, closeOnOutsideClick], ([$open, $closeOnOutsideClick]) => {
+					if (!$open) return;
 
-						const focusTrap = createFocusTrap({
-							immediate: false,
-							escapeDeactivates: $closeOnEscape,
-							clickOutsideDeactivates: $closeOnOutsideClick,
-							allowOutsideClick: true,
-							returnFocusOnDeactivate: false,
-							fallbackFocus: node,
-						});
+					const focusTrap = createFocusTrap({
+						immediate: false,
+						clickOutsideDeactivates: $closeOnOutsideClick,
+						allowOutsideClick: true,
+						returnFocusOnDeactivate: false,
+						fallbackFocus: node,
+					});
 
-						activate = focusTrap.activate;
-						deactivate = focusTrap.deactivate;
-						const ac = focusTrap.useFocusTrap(node);
-						if (ac && ac.destroy) {
-							return ac.destroy;
-						} else {
-							return focusTrap.deactivate;
-						}
+					activate = focusTrap.activate;
+					deactivate = focusTrap.deactivate;
+					const ac = focusTrap.useFocusTrap(node);
+					if (ac && ac.destroy) {
+						return ac.destroy;
+					} else {
+						return focusTrap.deactivate;
 					}
-				),
+				}),
 				effect([closeOnOutsideClick, open], ([$closeOnOutsideClick, $open]) => {
 					return useModal(node, {
 						open: $open,

--- a/src/lib/builders/popover/create.ts
+++ b/src/lib/builders/popover/create.ts
@@ -144,7 +144,6 @@ export function createPopover(args?: CreatePopoverProps) {
 											returnFocusOnDeactivate: false,
 											clickOutsideDeactivates: $closeOnOutsideClick,
 											allowOutsideClick: true,
-											escapeDeactivates: $closeOnEscape,
 									  },
 								modal: {
 									shouldCloseOnInteractOutside: shouldCloseOnInteractOutside,

--- a/src/lib/internal/actions/focus-trap/action.ts
+++ b/src/lib/internal/actions/focus-trap/action.ts
@@ -35,6 +35,7 @@ export function createFocusTrap(config: FocusTrapConfig = {}) {
 
 	const useFocusTrap = (node: HTMLElement) => {
 		trap = _createFocusTrap(node, {
+			escapeDeactivates: false,
 			...focusTrapOptions,
 			onActivate() {
 				hasFocus.set(true);

--- a/src/lib/internal/actions/popper/action.ts
+++ b/src/lib/internal/actions/popper/action.ts
@@ -42,7 +42,6 @@ export const usePopper = ((popperElement, args) => {
 	if (opts.focusTrap !== null) {
 		const { useFocusTrap } = createFocusTrap({
 			immediate: true,
-			escapeDeactivates: false,
 			allowOutsideClick: true,
 			returnFocusOnDeactivate: false,
 			fallbackFocus: popperElement,

--- a/src/tests/dialog/Dialog.spec.ts
+++ b/src/tests/dialog/Dialog.spec.ts
@@ -4,7 +4,7 @@ import { describe, it } from 'vitest';
 import DialogTest from './DialogTest.svelte';
 import { userEvent } from '@testing-library/user-event';
 import { sleep } from '$lib/internal/helpers/index.js';
-import { testKbd as kbd, touch } from '../utils.js';
+import { assertActiveFocusTrap, testKbd as kbd, touch } from '../utils.js';
 import type { CreateDialogProps } from '$lib/index.js';
 
 function setup(props: CreateDialogProps = {}) {
@@ -231,12 +231,7 @@ describe('Dialog', () => {
 		const { user, content } = await open({ closeOnEscape: false });
 		await user.keyboard(kbd.ESCAPE);
 		expect(content).toBeVisible();
-		for (let i = 0; i < 10; i++) {
-			await user.tab();
-			if (content !== document.activeElement) {
-				expect(content).toContainElement(document.activeElement as HTMLElement);
-			}
-		}
+		await assertActiveFocusTrap(user, content);
 	});
 
 	it("Doesn't deactivate focus trap on outside click provided `closeOnOutsideClick` false", async () => {
@@ -271,12 +266,7 @@ describe('Dialog', () => {
 		getByTestId('escape-interceptor').focus();
 		await user.keyboard(kbd.ESCAPE);
 		expect(content).toBeVisible();
-		for (let i = 0; i < 10; i++) {
-			await user.tab();
-			if (content !== document.activeElement) {
-				expect(content).toContainElement(document.activeElement as HTMLElement);
-			}
-		}
+		await assertActiveFocusTrap(user, content);
 	});
 
 	describe('Mouse Device', () => {

--- a/src/tests/dialog/DialogTest.svelte
+++ b/src/tests/dialog/DialogTest.svelte
@@ -21,11 +21,12 @@
 			<h2 use:melt={$title} data-testid="title">Title</h2>
 			<p use:melt={$description} data-testid="description">Description</p>
 			<button on:click={() => open.update((p) => !p)} data-testid="toggle-open">toggle open</button>
-			<input
-				data-testid="input-keydown-interceptor"
-				type="text"
+			<div
+				data-testid="escape-interceptor"
 				on:keydown={(e) => e.key === kbd.ESCAPE && e.stopPropagation()}
-			/>
+			>
+				escape interceptor
+			</div>
 
 			<button use:melt={$close} data-testid="closer">Close</button>
 			<button use:melt={$close} data-testid="last">Close</button>

--- a/src/tests/dialog/DialogTest.svelte
+++ b/src/tests/dialog/DialogTest.svelte
@@ -21,12 +21,12 @@
 			<h2 use:melt={$title} data-testid="title">Title</h2>
 			<p use:melt={$description} data-testid="description">Description</p>
 			<button on:click={() => open.update((p) => !p)} data-testid="toggle-open">toggle open</button>
-			<div
+			<button
 				data-testid="escape-interceptor"
 				on:keydown={(e) => e.key === kbd.ESCAPE && e.stopPropagation()}
 			>
 				escape interceptor
-			</div>
+			</button>
 
 			<button use:melt={$close} data-testid="closer">Close</button>
 			<button use:melt={$close} data-testid="last">Close</button>

--- a/src/tests/popover/Popover.spec.ts
+++ b/src/tests/popover/Popover.spec.ts
@@ -3,7 +3,7 @@ import { axe } from 'jest-axe';
 import PopoverTest from './PopoverTest.svelte';
 import { userEvent } from '@testing-library/user-event';
 import type { CreatePopoverProps } from '$lib/index.js';
-import { testKbd as kbd } from '../utils.js';
+import { assertActiveFocusTrap, testKbd as kbd } from '../utils.js';
 import { sleep } from '$lib/internal/helpers/index.js';
 
 function setup(props: CreatePopoverProps = {}) {
@@ -198,11 +198,6 @@ describe('Popover (Default)', () => {
 		getByTestId('escape-interceptor').focus();
 		await user.keyboard(kbd.ESCAPE);
 		expect(content).toBeVisible();
-		for (let i = 0; i < 10; i++) {
-			await user.tab();
-			if (content !== document.activeElement) {
-				expect(content).toContainElement(document.activeElement as HTMLElement);
-			}
-		}
+		await assertActiveFocusTrap(user, content);
 	});
 });

--- a/src/tests/popover/Popover.spec.ts
+++ b/src/tests/popover/Popover.spec.ts
@@ -188,4 +188,21 @@ describe('Popover (Default)', () => {
 		await user.click(getByTestId('toggle-open'));
 		expect(getByTestId('closeFocus')).toHaveFocus();
 	});
+
+	it("Doesn't deactivate focus trap on escape that is intercepted", async () => {
+		const { getByTestId, user, trigger } = setup();
+		const content = getByTestId('content');
+		expect(trigger).not.toHaveFocus();
+		await user.click(trigger);
+		expect(content).toBeVisible();
+		getByTestId('escape-interceptor').focus();
+		await user.keyboard(kbd.ESCAPE);
+		expect(content).toBeVisible();
+		for (let i = 0; i < 10; i++) {
+			await user.tab();
+			if (content !== document.activeElement) {
+				expect(content).toContainElement(document.activeElement as HTMLElement);
+			}
+		}
+	});
 });

--- a/src/tests/popover/PopoverTest.svelte
+++ b/src/tests/popover/PopoverTest.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { createPopover, melt, type CreatePopoverProps } from '$lib/index.js';
 	import { Settings2, X } from '$icons/index.js';
+	import { kbd } from '$lib/internal/helpers/keyboard.js';
 
 	export let openFocus: CreatePopoverProps['openFocus'] = undefined;
 	export let closeFocus: CreatePopoverProps['closeFocus'] = undefined;
@@ -49,6 +50,12 @@
 			<label for="weight">Weight</label>
 			<input type="number" id="weight" class="input" placeholder="Weight" data-testid="input4" />
 		</fieldset>
+		<button
+			on:keydown={(e) => e.key === kbd.ESCAPE && e.stopPropagation()}
+			data-testid="escape-interceptor"
+		>
+			escape interceptor
+		</button>
 		<button on:click={() => open.update((p) => !p)} data-testid="toggle-open">toggle open</button>
 	</div>
 	<button class="close" use:melt={$close} data-testid="close">

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -1,5 +1,6 @@
 import { kbd, removeUndefined } from '$lib/internal/helpers/index.js';
 import { fireEvent } from '@testing-library/svelte';
+import type { UserEvent } from '@testing-library/user-event';
 export { removeUndefined };
 type KbdKeys = keyof typeof kbd;
 /**
@@ -33,3 +34,19 @@ export async function touch(node: HTMLElement) {
 	await fireEvent(node, new MouseEvent('mouseup', { bubbles: true }));
 	await fireEvent(node, new MouseEvent('click', { bubbles: true }));
 }
+
+/**
+ * Simulates a specified number of tab key presses to check if the focus remains
+ * within the given element, thus determining if a focus trap is active. The `tabsPresses` parameter
+ * allows customization of how many tab key presses to simulate, with a default value of 10.
+ */
+export const assertActiveFocusTrap = async (
+	user: UserEvent,
+	element: HTMLElement,
+	tabsPresses = 10
+) => {
+	for (let i = 0; i < tabsPresses; i++) {
+		await user.tab();
+		expect(element).toContainElement(document.activeElement as HTMLElement);
+	}
+};


### PR DESCRIPTION
closes https://github.com/melt-ui/melt-ui/issues/1132

We should not let the focus trap package deactivate the focus trap on an escape key press because they use capture events which will fire even if an element intercepted the event. Therefore we should never let the focus trap package deactivate based on an escape key press but rather when the dialog or popover unmount which is already implemented in the destroy method of the focus trap action.

### Before - I added an escape key interceptor on the dialog content

https://github.com/melt-ui/melt-ui/assets/53095479/5dccb797-25fb-420b-afd6-13ad5272fac2

### After

https://github.com/melt-ui/melt-ui/assets/53095479/9520d91e-7ff2-46b5-af8b-f5532460261e

