### PR TITLE
Fix(focus trap): trap deactivation intercepted interact outside

### DIFF
--- a/.changeset/good-pants-crash.md
+++ b/.changeset/good-pants-crash.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+Fixed bug where focus trap would deactivate on an intercepted outside interaction (closes #1134)

--- a/src/lib/builders/dialog/create.ts
+++ b/src/lib/builders/dialog/create.ts
@@ -178,30 +178,26 @@ export function createDialog(props?: CreateDialogProps) {
 			let deactivate = noop;
 
 			const destroy = executeCallbacks(
-				effect(
-					[open, closeOnOutsideClick, closeOnEscape],
-					([$open, $closeOnOutsideClick, $closeOnEscape]) => {
-						if (!$open) return;
+				effect([open, closeOnEscape], ([$open, $closeOnEscape]) => {
+					if (!$open) return;
 
-						const focusTrap = createFocusTrap({
-							immediate: false,
-							escapeDeactivates: $closeOnEscape,
-							clickOutsideDeactivates: $closeOnOutsideClick,
-							allowOutsideClick: true,
-							returnFocusOnDeactivate: false,
-							fallbackFocus: node,
-						});
+					const focusTrap = createFocusTrap({
+						immediate: false,
+						escapeDeactivates: $closeOnEscape,
+						allowOutsideClick: true,
+						returnFocusOnDeactivate: false,
+						fallbackFocus: node,
+					});
 
-						activate = focusTrap.activate;
-						deactivate = focusTrap.deactivate;
-						const ac = focusTrap.useFocusTrap(node);
-						if (ac && ac.destroy) {
-							return ac.destroy;
-						} else {
-							return focusTrap.deactivate;
-						}
+					activate = focusTrap.activate;
+					deactivate = focusTrap.deactivate;
+					const ac = focusTrap.useFocusTrap(node);
+					if (ac && ac.destroy) {
+						return ac.destroy;
+					} else {
+						return focusTrap.deactivate;
 					}
-				),
+				}),
 				effect([closeOnOutsideClick, open], ([$closeOnOutsideClick, $open]) => {
 					return useModal(node, {
 						open: $open,

--- a/src/lib/builders/popover/create.ts
+++ b/src/lib/builders/popover/create.ts
@@ -142,7 +142,6 @@ export function createPopover(args?: CreatePopoverProps) {
 									? null
 									: {
 											returnFocusOnDeactivate: false,
-											clickOutsideDeactivates: $closeOnOutsideClick,
 											allowOutsideClick: true,
 											escapeDeactivates: $closeOnEscape,
 									  },

--- a/src/lib/internal/actions/focus-trap/action.ts
+++ b/src/lib/internal/actions/focus-trap/action.ts
@@ -35,6 +35,7 @@ export function createFocusTrap(config: FocusTrapConfig = {}) {
 
 	const useFocusTrap = (node: HTMLElement) => {
 		trap = _createFocusTrap(node, {
+			clickOutsideDeactivates: false,
 			...focusTrapOptions,
 			onActivate() {
 				hasFocus.set(true);

--- a/src/tests/dialog/Dialog.spec.ts
+++ b/src/tests/dialog/Dialog.spec.ts
@@ -269,6 +269,13 @@ describe('Dialog', () => {
 		expect(getByTestId('closeFocus')).toHaveFocus();
 	});
 
+	it("Doesn't deactivate focus trap on outside click that is intercepted", async () => {
+		const { getByTestId, user, trigger } = await open();
+		await user.click(getByTestId('click-interceptor'));
+		await user.tab({ shift: true });
+		expect(trigger).not.toHaveFocus();
+	});
+
 	describe('Mouse Device', () => {
 		it("Doesn't close when interacting outside with click interceptor", async () => {
 			const { getByTestId, user, content, overlay } = await open();

--- a/src/tests/popover/Popover.spec.ts
+++ b/src/tests/popover/Popover.spec.ts
@@ -188,4 +188,15 @@ describe('Popover (Default)', () => {
 		await user.click(getByTestId('toggle-open'));
 		expect(getByTestId('closeFocus')).toHaveFocus();
 	});
+
+	it("Doesn't deactivate focus trap on outside click that is intercepted", async () => {
+		const { getByTestId, user, trigger } = setup();
+		const content = getByTestId('content');
+		await user.click(trigger);
+		expect(content).toBeVisible();
+		await user.click(getByTestId('click-interceptor'));
+		await user.tab({ shift: true });
+		expect(content).toBeVisible();
+		expect(trigger).not.toHaveFocus();
+	});
 });

--- a/src/tests/popover/PopoverTest.svelte
+++ b/src/tests/popover/PopoverTest.svelte
@@ -57,6 +57,7 @@
 	<button data-testid="openFocus" id="openFocus"> focus me on open </button>
 </div>
 <div data-testid="outside" />
+<button on:click|stopPropagation data-testid="click-interceptor">click interceptor</button>
 
 <style lang="postcss">
 	fieldset {


### PR DESCRIPTION
closes https://github.com/melt-ui/melt-ui/issues/1134

We should not let the focus trap package deactivate the focus trap on an outside interaction because they use capture events which will fire even if an element intercepted the event. Therefore we should never let the focus trap package deactivate based on an outside interaction but rather when the dialog or popover unmount which is already implemented in the destroy method of the focus trap action.

### Before

https://github.com/melt-ui/melt-ui/assets/53095479/3445b6eb-df44-4569-9ccc-a08d733b3fb6


### After


https://github.com/melt-ui/melt-ui/assets/53095479/6cb1fe7d-019c-4fde-b7c8-d71befb704ac

