### PR TITLE
refactor: focus-trap

### DIFF
--- a/.changeset/tough-squids-rescue.md
+++ b/.changeset/tough-squids-rescue.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+Refactor focus trap internals

--- a/src/lib/builders/context-menu/create.ts
+++ b/src/lib/builders/context-menu/create.ts
@@ -171,7 +171,6 @@ export function createContextMenu(props?: CreateContextMenuProps) {
 										rootOpen.set(false);
 									},
 									shouldCloseOnInteractOutside: handleClickOutside,
-									open: $isVisible,
 								},
 								portal: getPortalDestination(node, $portal),
 								escapeKeydown: $closeOnEscape ? undefined : null,

--- a/src/lib/builders/date-range-field/create.ts
+++ b/src/lib/builders/date-range-field/create.ts
@@ -5,7 +5,6 @@ import {
 	getAnnouncer,
 	getDefaultDate,
 	getFirstSegment,
-	isBefore,
 	isBeforeOrSame,
 } from '$lib/internal/helpers/date/index.js';
 import {

--- a/src/lib/builders/dialog/create.ts
+++ b/src/lib/builders/dialog/create.ts
@@ -178,30 +178,23 @@ export function createDialog(props?: CreateDialogProps) {
 			let deactivate = noop;
 
 			const destroy = executeCallbacks(
-				effect(
-					[open, closeOnOutsideClick, closeOnEscape],
-					([$open, $closeOnOutsideClick, $closeOnEscape]) => {
-						if (!$open) return;
+				effect([open], ([$open]) => {
+					if (!$open) return;
 
-						const focusTrap = createFocusTrap({
-							immediate: false,
-							escapeDeactivates: $closeOnEscape,
-							clickOutsideDeactivates: $closeOnOutsideClick,
-							allowOutsideClick: true,
-							returnFocusOnDeactivate: false,
-							fallbackFocus: node,
-						});
+					const focusTrap = createFocusTrap({
+						immediate: false,
+						fallbackFocus: node,
+					});
 
-						activate = focusTrap.activate;
-						deactivate = focusTrap.deactivate;
-						const ac = focusTrap.useFocusTrap(node);
-						if (ac && ac.destroy) {
-							return ac.destroy;
-						} else {
-							return focusTrap.deactivate;
-						}
+					activate = focusTrap.activate;
+					deactivate = focusTrap.deactivate;
+					const ac = focusTrap.useFocusTrap(node);
+					if (ac && ac.destroy) {
+						return ac.destroy;
+					} else {
+						return focusTrap.deactivate;
 					}
-				),
+				}),
 				effect([closeOnOutsideClick, open], ([$closeOnOutsideClick, $open]) => {
 					return useModal(node, {
 						open: $open,

--- a/src/lib/builders/dialog/create.ts
+++ b/src/lib/builders/dialog/create.ts
@@ -188,12 +188,7 @@ export function createDialog(props?: CreateDialogProps) {
 
 					activate = focusTrap.activate;
 					deactivate = focusTrap.deactivate;
-					const ac = focusTrap.useFocusTrap(node);
-					if (ac && ac.destroy) {
-						return ac.destroy;
-					} else {
-						return focusTrap.deactivate;
-					}
+					return focusTrap.useFocusTrap(node).destroy;
 				}),
 				effect([closeOnOutsideClick, open], ([$closeOnOutsideClick, $open]) => {
 					return useModal(node, {

--- a/src/lib/builders/link-preview/create.ts
+++ b/src/lib/builders/link-preview/create.ts
@@ -211,7 +211,6 @@ export function createLinkPreview(props: CreateLinkPreviewProps = {}) {
 											return false;
 										return true;
 									},
-									open: $isVisible,
 								},
 								portal: getPortalDestination(node, $portal),
 								focusTrap: null,

--- a/src/lib/builders/listbox/create.ts
+++ b/src/lib/builders/listbox/create.ts
@@ -490,7 +490,6 @@ export function createListbox<
 									modal: {
 										closeOnInteractOutside: $closeOnOutsideClick,
 										onClose: closeMenu,
-										open: $isVisible,
 										shouldCloseOnInteractOutside: (e) => {
 											onOutsideClick.get()?.(e);
 											if (e.defaultPrevented) return false;

--- a/src/lib/builders/menu/create.ts
+++ b/src/lib/builders/menu/create.ts
@@ -212,7 +212,6 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 										return true;
 									},
 									onClose: () => rootOpen.set(false),
-									open: $isVisible,
 								},
 								portal: getPortalDestination(node, $portal),
 								escapeKeydown: $closeOnEscape ? undefined : null,

--- a/src/lib/builders/menubar/create.ts
+++ b/src/lib/builders/menubar/create.ts
@@ -198,7 +198,6 @@ export function createMenubar(props?: CreateMenubarProps) {
 										onClose: () => {
 											activeMenu.set('');
 										},
-										open: $rootOpen,
 									},
 								},
 							}).destroy;

--- a/src/lib/builders/popover/create.ts
+++ b/src/lib/builders/popover/create.ts
@@ -138,14 +138,7 @@ export function createPopover(args?: CreatePopoverProps) {
 							open,
 							options: {
 								floating: $positioning,
-								focusTrap: $disableFocusTrap
-									? null
-									: {
-											returnFocusOnDeactivate: false,
-											clickOutsideDeactivates: $closeOnOutsideClick,
-											allowOutsideClick: true,
-											escapeDeactivates: $closeOnEscape,
-									  },
+								focusTrap: $disableFocusTrap ? null : undefined,
 								modal: {
 									shouldCloseOnInteractOutside: shouldCloseOnInteractOutside,
 									onClose: handleClose,

--- a/src/lib/builders/popover/create.ts
+++ b/src/lib/builders/popover/create.ts
@@ -142,7 +142,6 @@ export function createPopover(args?: CreatePopoverProps) {
 								modal: {
 									shouldCloseOnInteractOutside: shouldCloseOnInteractOutside,
 									onClose: handleClose,
-									open: $isVisible,
 									closeOnInteractOutside: $closeOnOutsideClick,
 								},
 								escapeKeydown: $closeOnEscape

--- a/src/lib/internal/actions/focus-trap/action.ts
+++ b/src/lib/internal/actions/focus-trap/action.ts
@@ -10,7 +10,7 @@ import { createFocusTrap as _createFocusTrap } from 'focus-trap';
 export function createFocusTrap(config: FocusTrapConfig = {}) {
 	let trap: undefined | FocusTrap;
 
-	const { immediate, ...focusTrapOptions } = config;
+	const { immediate, ...focusTrapOptions } = { immediate: true, ...config };
 	const hasFocus = writable(false);
 	const isPaused = writable(false);
 
@@ -35,6 +35,10 @@ export function createFocusTrap(config: FocusTrapConfig = {}) {
 
 	const useFocusTrap = (node: HTMLElement) => {
 		trap = _createFocusTrap(node, {
+			returnFocusOnDeactivate: false,
+			allowOutsideClick: true,
+			escapeDeactivates: false,
+			clickOutsideDeactivates: false,
 			...focusTrapOptions,
 			onActivate() {
 				hasFocus.set(true);

--- a/src/lib/internal/actions/focus-trap/types.ts
+++ b/src/lib/internal/actions/focus-trap/types.ts
@@ -1,62 +1,30 @@
-// Modified from Grail UI v0.9.6 (2023-06-10)
-// Source: https://github.com/grail-ui/grail-ui
-// https://github.com/grail-ui/grail-ui/tree/master/packages/grail-ui/src/focusTrap/focusTrap.types.ts
-
-import type { ActivateOptions, DeactivateOptions, Options as FocusTrapOptions } from 'focus-trap';
-import type { Action } from 'svelte/action';
-import type { Readable } from 'svelte/store';
+import type {
+	Options as FocusTrapOptions,
+	KeyboardEventToBoolean,
+	MouseEventToBoolean,
+} from 'focus-trap';
 
 export type FocusTrapConfig = FocusTrapOptions & {
 	/**
-	 * Immediately activate the trap
-	 * @default true
+	 * Default: `false`. If `false`, when the trap is deactivated,
+	 * focus will *not* return to the element that had focus before activation.
 	 */
-	immediate?: boolean;
-};
-
-export type FocusTrapReturn = {
+	returnFocusOnDeactivate?: boolean;
 	/**
-	 * Indicates if the focus trap is currently active.
+	 * Default: `false`. If `false` or returns `false`, the `Escape` key will not trigger
+	 * deactivation of the focus trap. This can be useful if you want
+	 * to force the user to make a decision instead of allowing an easy
+	 * way out. Note that if a function is given, it's only called if the ESC key
+	 * was pressed.
 	 */
-	hasFocus: Readable<boolean>;
-
+	escapeDeactivates?: boolean | KeyboardEventToBoolean;
 	/**
-	 * Indicates if the focus trap is currently paused.
+	 * If set and is or returns `true`, a click outside the focus trap will not
+	 * be prevented, even when `clickOutsideDeactivates` is `false`. When
+	 * `clickOutsideDeactivates` is `true`, this option is **ignored** (i.e.
+	 * if it's a function, it will not be called). Use this option to control
+	 * if (and even which) clicks are allowed outside the trap in conjunction
+	 * with `clickOutsideDeactivates: false`. Default: `true`.
 	 */
-	isPaused: Readable<boolean>;
-
-	/**
-	 * Activate the focus trap.
-	 *
-	 * @see https://github.com/focus-trap/focus-trap#trapactivateactivateoptions
-	 */
-	activate: (opts?: ActivateOptions) => void;
-
-	/**
-	 * Deactivate the focus trap.
-	 *
-	 * @see https://github.com/focus-trap/focus-trap#trapdeactivatedeactivateoptions
-	 */
-	deactivate: (opts?: DeactivateOptions) => void;
-
-	/**
-	 * Pause the focus trap.
-	 *
-	 * @see https://github.com/focus-trap/focus-trap#trappause
-	 */
-	pause: () => void;
-
-	/**
-	 * Unpauses the focus trap.
-	 *
-	 * @see https://github.com/focus-trap/focus-trap#trapunpause
-	 */
-	unpause: () => void;
-
-	/**
-	 * Action to attach to the element that you want to act as a focus trap.
-	 */
-
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	useFocusTrap: Action<HTMLElement, any>;
+	allowOutsideClick?: boolean | MouseEventToBoolean;
 };

--- a/src/lib/internal/actions/focus-trap/types.ts
+++ b/src/lib/internal/actions/focus-trap/types.ts
@@ -9,6 +9,7 @@ import type { Readable } from 'svelte/store';
 export type FocusTrapConfig = FocusTrapOptions & {
 	/**
 	 * Immediately activate the trap
+	 * @default true
 	 */
 	immediate?: boolean;
 };

--- a/src/lib/internal/actions/interact-outside/action.ts
+++ b/src/lib/internal/actions/interact-outside/action.ts
@@ -89,7 +89,7 @@ export const useInteractOutside = ((node, config) => {
 		unsubPointerUp();
 		unsubResetInterceptedEvents();
 		resetInterceptedEvents();
-		const { onInteractOutside, onInteractOutsideStart, enabled } = config;
+		const { onInteractOutside, onInteractOutsideStart, enabled } = { enabled: true, ...config };
 		if (!enabled) return;
 
 		/**

--- a/src/lib/internal/actions/interact-outside/types.ts
+++ b/src/lib/internal/actions/interact-outside/types.ts
@@ -34,6 +34,7 @@ export type InteractOutsideConfig = {
 
 	/**
 	 * Whether or not outside interactions should be handled.
+	 * @default true
 	 */
 	enabled?: boolean;
 };

--- a/src/lib/internal/actions/modal/action.ts
+++ b/src/lib/internal/actions/modal/action.ts
@@ -1,4 +1,4 @@
-import { isElement, last, noop, sleep } from '$lib/internal/helpers/index.js';
+import { isElement, last, noop } from '$lib/internal/helpers/index.js';
 import type { InteractOutsideEvent } from '../interact-outside/types.js';
 import { useInteractOutside } from '../index.js';
 import type { ModalConfig } from './types.js';
@@ -7,6 +7,7 @@ import type { Action } from 'svelte/action';
 const visibleModals: Element[] = [];
 export const useModal = ((node, config) => {
 	let unsubInteractOutside = noop;
+	visibleModals.push(node);
 
 	function removeNodeFromVisibleModals() {
 		const index = visibleModals.indexOf(node);
@@ -15,20 +16,14 @@ export const useModal = ((node, config) => {
 		}
 	}
 
+	function isLastModal() {
+		return last(visibleModals) === node;
+	}
+
 	function update(config: ModalConfig) {
 		unsubInteractOutside();
-		const { open, onClose, shouldCloseOnInteractOutside, closeOnInteractOutside } = config;
+		const { onClose, shouldCloseOnInteractOutside, closeOnInteractOutside } = config;
 
-		sleep(100).then(() => {
-			if (open) {
-				visibleModals.push(node);
-			} else {
-				removeNodeFromVisibleModals();
-			}
-		});
-		function isLastModal() {
-			return last(visibleModals) === node;
-		}
 		function closeModal() {
 			// we only want to call onClose if this is the topmost modal
 			if (isLastModal() && onClose) {
@@ -49,10 +44,10 @@ export const useModal = ((node, config) => {
 				closeModal();
 			}
 		}
+
 		unsubInteractOutside = useInteractOutside(node, {
 			onInteractOutsideStart,
 			onInteractOutside: closeOnInteractOutside ? onInteractOutside : undefined,
-			enabled: open,
 		}).destroy;
 	}
 

--- a/src/lib/internal/actions/modal/types.ts
+++ b/src/lib/internal/actions/modal/types.ts
@@ -2,11 +2,6 @@ import type { InteractOutsideEvent } from '$lib/internal/actions/index.js';
 
 export type ModalConfig = {
 	/**
-	 * Whether the modal is currently open.
-	 */
-	open?: boolean;
-
-	/**
 	 * Handler called when the overlay closes.
 	 */
 	onClose?: () => void;

--- a/src/lib/internal/actions/popper/action.ts
+++ b/src/lib/internal/actions/popper/action.ts
@@ -41,12 +41,7 @@ export const usePopper = ((popperElement, args) => {
 
 	if (opts.focusTrap !== null) {
 		const { useFocusTrap } = createFocusTrap({
-			immediate: true,
-			escapeDeactivates: false,
-			allowOutsideClick: true,
-			returnFocusOnDeactivate: false,
 			fallbackFocus: popperElement,
-
 			...opts.focusTrap,
 		});
 

--- a/src/lib/internal/actions/popper/action.ts
+++ b/src/lib/internal/actions/popper/action.ts
@@ -1,5 +1,5 @@
 import {
-	createFocusTrap,
+	useFocusTrap,
 	useEscapeKeydown,
 	useFloating,
 	usePortal,
@@ -40,12 +40,12 @@ export const usePopper = ((popperElement, args) => {
 	callbacks.push(useFloating(anchorElement, popperElement, opts.floating).destroy);
 
 	if (opts.focusTrap !== null) {
-		const { useFocusTrap } = createFocusTrap({
-			fallbackFocus: popperElement,
-			...opts.focusTrap,
-		});
-
-		callbacks.push(useFocusTrap(popperElement).destroy);
+		callbacks.push(
+			useFocusTrap(popperElement, {
+				fallbackFocus: popperElement,
+				...opts.focusTrap,
+			}).destroy
+		);
 	}
 
 	if (opts.modal !== null) {

--- a/src/tests/combobox/Combobox.spec.ts
+++ b/src/tests/combobox/Combobox.spec.ts
@@ -5,7 +5,6 @@ import { describe } from 'vitest';
 import { testKbd as kbd } from '../utils.js';
 import ComboboxTest from './ComboboxTest.svelte';
 import type { ComboboxOptionProps } from '$lib/index.js';
-import { sleep } from '$lib/internal/helpers/sleep.js';
 import ComboboxForceVisibleTest from './ComboboxForceVisibleTest.svelte';
 
 const options: ComboboxOptionProps[] = [
@@ -207,7 +206,6 @@ describe('Combobox', () => {
 
 		expect(menu).not.toBeVisible();
 		await user.click(toggleBtn);
-		await sleep(100);
 		expect(menu).toBeVisible();
 	});
 
@@ -375,7 +373,6 @@ describe('Combobox (forceVisible)', () => {
 
 		const outsideClick = getByTestId('outside-click');
 		await user.click(outsideClick);
-		await sleep(100);
 		expect(getMenu()).not.toBeNull();
 	});
 
@@ -435,7 +432,6 @@ describe('Combobox (forceVisible)', () => {
 
 		expect(getMenu()).toBeNull();
 		await user.click(toggleBtn);
-		await sleep(100);
 		expect(getMenu()).not.toBeNull();
 	});
 

--- a/src/tests/context-menu/ContextMenu.spec.ts
+++ b/src/tests/context-menu/ContextMenu.spec.ts
@@ -5,7 +5,6 @@ import { userEvent } from '@testing-library/user-event';
 import { testKbd as kbd } from '../utils.js';
 import ContextMenuTest from './ContextMenuTest.svelte';
 import type { CreateContextMenuProps } from '$lib/index.js';
-import { sleep } from '$lib/internal/helpers/sleep.js';
 
 function setup(props: CreateContextMenuProps = {}) {
 	const user = userEvent.setup();
@@ -148,7 +147,6 @@ describe('Context Menu', () => {
 	test('Should close on outside click by default', async () => {
 		const { user, getByTestId, queryByTestId } = await open();
 		const outsideClick = getByTestId('outside-click');
-		await sleep(100);
 		expect(outsideClick).toBeVisible();
 		await user.click(outsideClick);
 		await waitFor(() => expect(queryByTestId('menu')).toBeNull());

--- a/src/tests/dialog/Dialog.spec.ts
+++ b/src/tests/dialog/Dialog.spec.ts
@@ -29,7 +29,6 @@ async function open(props: CreateDialogProps = {}) {
 	const { user, trigger, content } = returned;
 	expect(content).not.toBeVisible();
 	await user.click(trigger);
-	await sleep(100);
 	expect(content).toBeVisible();
 	return returned;
 }

--- a/src/tests/dialog/DialogNested.spec.ts
+++ b/src/tests/dialog/DialogNested.spec.ts
@@ -1,4 +1,3 @@
-import { sleep } from '$lib/internal/helpers/index.js';
 import { render, waitFor } from '@testing-library/svelte';
 import { userEvent } from '@testing-library/user-event';
 import DialogNestedTest from './DialogNestedTest.svelte';
@@ -79,7 +78,6 @@ describe('Nested Dialogs', () => {
 		await user.click(trigger);
 		await waitFor(() => expect(getByTestId('content')).not.toBeNull());
 		await waitFor(() => expect(getByTestId('overlay')).not.toBeNull());
-		await sleep(100);
 		await user.click(getByTestId('overlay'));
 		await waitFor(() => expect(queryByTestId('content')).toBeNull());
 		expect(queryByTestId('content')).toBeNull();

--- a/src/tests/dialog/DialogTransitions.spec.ts
+++ b/src/tests/dialog/DialogTransitions.spec.ts
@@ -2,7 +2,6 @@ import { render, waitFor } from '@testing-library/svelte';
 import { userEvent } from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { describe, vi, it, beforeEach, afterEach } from 'vitest';
-import { sleep } from '$lib/internal/helpers/index.js';
 import { testKbd as kbd } from '../utils.js';
 import DialogTransitionTest from './DialogTransitionTest.svelte';
 import type { CreateDialogProps } from '$lib/index.js';
@@ -66,7 +65,6 @@ describe('Dialog with Transitions', () => {
 
 	it('Closes when overlay is clicked', async () => {
 		const { user, queryByTestId, getByTestId } = await open();
-		await sleep(100);
 		await waitFor(() => expect(queryByTestId('content')).not.toBeNull());
 		await waitFor(() => expect(queryByTestId('overlay')).not.toBeNull());
 		await user.click(getByTestId('overlay'));

--- a/src/tests/popover/Popover.spec.ts
+++ b/src/tests/popover/Popover.spec.ts
@@ -53,10 +53,8 @@ describe('Popover (Default)', () => {
 		await user.click(content);
 		await waitFor(() => expect(content).toBeVisible());
 		const outside = getByTestId('outside');
-		await sleep(100);
 		expect(outside).toBeVisible();
 		await user.click(outside);
-		await sleep(100);
 		await waitFor(() => expect(content).not.toBeVisible());
 	});
 
@@ -74,10 +72,8 @@ describe('Popover (Default)', () => {
 		await waitFor(() => expect(content).toBeVisible());
 		const outside = getByTestId('outside');
 		await user.click(outside);
-		await sleep(100);
 		expect(outside).toBeVisible();
 		await user.click(outside);
-		await sleep(100);
 		await waitFor(() => expect(content).toBeVisible());
 	});
 

--- a/src/tests/portal/Portal.spec.ts
+++ b/src/tests/portal/Portal.spec.ts
@@ -2,7 +2,6 @@ import { describe, it } from 'vitest';
 import { render, waitFor } from '@testing-library/svelte';
 import { userEvent } from '@testing-library/user-event';
 import PopoverTooltip from './PopoverTooltip.svelte';
-import { sleep } from '$lib/internal/helpers/sleep.js';
 
 function setupPopoverTooltip() {
 	const user = userEvent.setup();
@@ -60,7 +59,6 @@ describe('Portal Behaviors - Popover & Tooltip', () => {
 		await user.click(elements.tooltipContent);
 		expect(elements.tooltipContent).toBeVisible();
 		expect(elements.popoverContent).toBeVisible();
-		await sleep(100);
 		expect(elements.outside).toBeVisible();
 		await user.click(elements.outside);
 		await waitFor(() => expect(elements.tooltipContent).not.toBeVisible());

--- a/src/tests/tooltip/Tooltip.spec.ts
+++ b/src/tests/tooltip/Tooltip.spec.ts
@@ -100,7 +100,6 @@ describe('Tooltip', () => {
 		await waitFor(() => expect(content).toBeVisible());
 
 		await user.click(content);
-		await sleep(100);
 		expect(content).toBeVisible();
 	});
 


### PR DESCRIPTION
This PR should be merged after https://github.com/melt-ui/melt-ui/pull/1135 and https://github.com/melt-ui/melt-ui/pull/1133

We currently set the same options for the focus trap action in multiple places (popover, dialog, popper). This PR moves all the same options that we use to be the default ones used in `createFocusTrap()` to avoid redundancy. Also as new issues come up with the focus trap (like the ones that are solved in the prerequisite PRs), there is the possibility of missing all the different places that use the focus trap that should behave the same way.

I also cleaned up `createFocusTrap()` and made it more similar to how our other actions behave.

And I cleaned up the dialog content builder.