### PR TITLE
chore: refactor popover tests

### DIFF
--- a/src/tests/popover/Popover.spec.ts
+++ b/src/tests/popover/Popover.spec.ts
@@ -19,6 +19,15 @@ function setup(props: CreatePopoverProps = {}) {
 	};
 }
 
+const open = async (props: CreatePopoverProps = {}) => {
+	const returned = setup(props);
+	const { user, trigger, content } = returned;
+	expect(content).not.toBeVisible();
+	await user.click(trigger);
+	expect(content).toBeVisible();
+	return returned;
+};
+
 describe('Popover (Default)', () => {
 	test('No accessibility violations', async () => {
 		const { container } = render(PopoverTest);
@@ -27,31 +36,19 @@ describe('Popover (Default)', () => {
 	});
 
 	test('Opens on click', async () => {
-		const { content, trigger, user } = setup();
-
-		expect(content).not.toBeVisible();
-		await user.click(trigger);
-		await waitFor(() => expect(content).toBeVisible());
+		await open();
 	});
 
 	test('Closes on escape', async () => {
-		const { content, trigger, user } = setup();
-
-		expect(content).not.toBeVisible();
-		await user.click(trigger);
-		await waitFor(() => expect(content).toBeVisible());
+		const { content, user } = await open();
 		await user.keyboard(kbd.ESCAPE);
-		await waitFor(() => expect(content).not.toBeVisible());
+		expect(content).not.toBeVisible();
 	});
 
 	test('Closes when click outside content', async () => {
-		const { content, trigger, user, getByTestId } = setup();
-
-		expect(content).not.toBeVisible();
-		await user.click(trigger);
-		await waitFor(() => expect(content).toBeVisible());
+		const { content, user, getByTestId } = await open();
 		await user.click(content);
-		await waitFor(() => expect(content).toBeVisible());
+		expect(content).toBeVisible();
 		const outside = getByTestId('outside');
 		await sleep(100);
 		expect(outside).toBeVisible();
@@ -61,15 +58,9 @@ describe('Popover (Default)', () => {
 	});
 
 	test('doesnt close when preventDefault called in `onOutsideClick`', async () => {
-		const { content, trigger, user, getByTestId } = setup({
-			onOutsideClick: (e) => {
-				e.preventDefault();
-			},
+		const { content, user, getByTestId } = await open({
+			onOutsideClick: (e) => e.preventDefault(),
 		});
-
-		expect(content).not.toBeVisible();
-		await user.click(trigger);
-		await waitFor(() => expect(content).toBeVisible());
 		await user.click(content);
 		await waitFor(() => expect(content).toBeVisible());
 		const outside = getByTestId('outside');
@@ -82,38 +73,24 @@ describe('Popover (Default)', () => {
 	});
 
 	test('Toggles open state on trigger click', async () => {
-		const { content, trigger, user } = setup();
-
-		expect(content).not.toBeVisible();
-		await user.click(trigger);
-		await waitFor(() => expect(content).toBeVisible());
+		const { content, trigger, user } = await open();
 		await user.click(trigger);
 		await waitFor(() => expect(content).not.toBeVisible());
 	});
 
 	test('Respects `openFocus` prop', async () => {
-		const { content, trigger, user, getByTestId } = setup({
-			openFocus: () => {
-				return document.getElementById('openFocus');
-			},
+		const { getByTestId } = await open({
+			openFocus: () => document.getElementById('openFocus'),
 		});
-
-		await user.click(trigger);
-		await waitFor(() => expect(content).toBeVisible());
 		const openFocus = getByTestId('openFocus');
 		await sleep(1);
 		expect(openFocus).toHaveFocus();
 	});
 
 	test('Respects `closeFocus` prop', async () => {
-		const { content, trigger, user, getByTestId } = setup({
-			closeFocus: () => {
-				return document.getElementById('closeFocus');
-			},
+		const { content, user, getByTestId } = await open({
+			closeFocus: () => document.getElementById('closeFocus'),
 		});
-
-		await user.click(trigger);
-		await waitFor(() => expect(content).toBeVisible());
 		await user.keyboard(kbd.ESCAPE);
 		await waitFor(() => expect(content).not.toBeVisible());
 		const closeFocus = getByTestId('closeFocus');
@@ -137,13 +114,7 @@ describe('Popover (Default)', () => {
 	});
 
 	it("Doesn't deactivate focus trap on escape provided `closeOnEscape` false", async () => {
-		const { getByTestId, user, trigger } = setup({
-			closeOnEscape: false,
-		});
-		const content = getByTestId('content');
-		expect(content).not.toBeVisible();
-		await user.click(trigger);
-		expect(content).toBeVisible();
+		const { getByTestId, user, content } = await open({ closeOnEscape: false });
 		await user.keyboard(kbd.ESCAPE);
 		expect(content).toBeVisible();
 		expect(getByTestId('content')).toHaveFocus();
@@ -152,13 +123,7 @@ describe('Popover (Default)', () => {
 	});
 
 	it("Doesn't deactivate focus trap on outside click provided `closeOnOutsideClick` false", async () => {
-		const { getByTestId, user, trigger } = setup({
-			closeOnOutsideClick: false,
-		});
-		const content = getByTestId('content');
-		expect(content).not.toBeVisible();
-		await user.click(trigger);
-		expect(content).toBeVisible();
+		const { getByTestId, user, content } = await open({ closeOnOutsideClick: false });
 		await user.click(getByTestId('outside'));
 		expect(content).toBeVisible();
 		await user.tab();
@@ -166,25 +131,15 @@ describe('Popover (Default)', () => {
 	});
 
 	it('Returns focus to trigger when manually setting `open` state to false', async () => {
-		const { getByTestId, user, trigger } = setup();
-		const content = getByTestId('content');
-
-		expect(trigger).not.toHaveFocus();
-		await user.click(trigger);
-		expect(content).toBeVisible();
+		const { getByTestId, user, trigger } = await open();
 		await user.click(getByTestId('toggle-open'));
 		expect(trigger).toHaveFocus();
 	});
 
 	it('Respects the `closeFocus` prop when manually setting `open` state to false', async () => {
-		const { getByTestId, user, trigger } = setup({
+		const { getByTestId, user } = await open({
 			closeFocus: () => document.getElementById('closeFocus'),
 		});
-		const content = getByTestId('content');
-
-		expect(trigger).not.toHaveFocus();
-		await user.click(trigger);
-		expect(content).toBeVisible();
 		await user.click(getByTestId('toggle-open'));
 		expect(getByTestId('closeFocus')).toHaveFocus();
 	});


### PR DESCRIPTION
Currently in our popover tests, every test repeats the assertions for opening a popover so I refactored it into an `open` function.