### PR TITLE
fix(menu): overlay portal cleanup - prevent memory leak #1112

### DIFF
--- a/.changeset/shy-pens-sleep.md
+++ b/.changeset/shy-pens-sleep.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+Menu: fixed a bug that has the potential to introduce a memory leak via the overlay

--- a/src/lib/builders/menu/create.ts
+++ b/src/lib/builders/menu/create.ts
@@ -350,6 +350,7 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 			} as const;
 		},
 		action: (node: HTMLElement) => {
+			let unsubPortal = noop;
 			let unsubEscapeKeydown = noop;
 
 			if (closeOnEscape.get()) {
@@ -361,17 +362,19 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 				}
 			}
 
-			const unsubPortal = effect([portal], ([$portal]) => {
-				if ($portal === null) return noop;
+			const unsubDerived = effect([portal], ([$portal]) => {
+				unsubPortal();
+				if ($portal === null) return;
 				const portalDestination = getPortalDestination(node, $portal);
-				if (portalDestination === null) return noop;
-				return usePortal(node, portalDestination).destroy;
+				if (portalDestination === null) return;
+				unsubPortal = usePortal(node, portalDestination).destroy;
 			});
 
 			return {
 				destroy() {
-					unsubEscapeKeydown();
+					unsubDerived();
 					unsubPortal();
+					unsubEscapeKeydown();
 				},
 			};
 		},


### PR DESCRIPTION
Prevent potential memory leak on menu overlay portal. Should cleanup portal action in the case that the `portal` store updates.