### PR TITLE
refactor(internal): add `runAfterTick` prop to `effect`

### DIFF
--- a/.changeset/cyan-toes-jam.md
+++ b/.changeset/cyan-toes-jam.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+Refactor effect internals to prevent potential memory leaks

--- a/src/lib/builders/context-menu/create.ts
+++ b/src/lib/builders/context-menu/create.ts
@@ -23,7 +23,6 @@ import {
 } from '$lib/internal/helpers/index.js';
 import type { MeltActionReturn } from '$lib/internal/types.js';
 import type { VirtualElement } from '@floating-ui/core';
-import { tick } from 'svelte';
 import { derived, writable, type Readable } from 'svelte/store';
 import {
 	applyAttrsIfDisabled,
@@ -156,29 +155,27 @@ export function createContextMenu(props?: CreateContextMenuProps) {
 				]) => {
 					unsubPopper();
 					if (!$isVisible || !$rootActiveTrigger) return;
-					tick().then(() => {
-						unsubPopper();
-						setMeltMenuAttribute(node, selector);
-						const $virtual = virtual.get();
-						unsubPopper = usePopper(node, {
-							anchorElement: $virtual ? $virtual : $rootActiveTrigger,
-							open: rootOpen,
-							options: {
-								floating: $positioning,
-								modal: {
-									closeOnInteractOutside: $closeOnOutsideClick,
-									onClose: () => {
-										rootOpen.set(false);
-									},
-									shouldCloseOnInteractOutside: handleClickOutside,
-									open: $isVisible,
+					setMeltMenuAttribute(node, selector);
+					const $virtual = virtual.get();
+					unsubPopper = usePopper(node, {
+						anchorElement: $virtual ? $virtual : $rootActiveTrigger,
+						open: rootOpen,
+						options: {
+							floating: $positioning,
+							modal: {
+								closeOnInteractOutside: $closeOnOutsideClick,
+								onClose: () => {
+									rootOpen.set(false);
 								},
-								portal: getPortalDestination(node, $portal),
-								escapeKeydown: $closeOnEscape ? undefined : null,
+								shouldCloseOnInteractOutside: handleClickOutside,
+								open: $isVisible,
 							},
-						}).destroy;
-					});
-				}
+							portal: getPortalDestination(node, $portal),
+							escapeKeydown: $closeOnEscape ? undefined : null,
+						},
+					}).destroy;
+				},
+				{ runAfterTick: true }
 			);
 
 			const unsubEvents = executeCallbacks(

--- a/src/lib/builders/link-preview/create.ts
+++ b/src/lib/builders/link-preview/create.ts
@@ -27,7 +27,6 @@ import { generateIds } from '../../internal/helpers/id.js';
 import { omit } from '../../internal/helpers/object.js';
 import type { LinkPreviewEvents } from './events.js';
 import type { CreateLinkPreviewProps } from './types.js';
-import { tick } from 'svelte';
 
 type LinkPreviewParts = 'trigger' | 'content' | 'arrow';
 const { name } = createElHelpers<LinkPreviewParts>('hover-card');
@@ -187,39 +186,33 @@ export function createLinkPreview(props: CreateLinkPreviewProps = {}) {
 				]) => {
 					unsubPopper();
 					if (!$isVisible || !$activeTrigger) return;
-
-					tick().then(() => {
-						unsubPopper();
-						unsubPopper = usePopper(node, {
-							anchorElement: $activeTrigger,
-							open: open,
-							options: {
-								floating: $positioning,
-								modal: {
-									closeOnInteractOutside: $closeOnOutsideClick,
-									onClose: () => {
-										open.set(false);
-										$activeTrigger.focus();
-									},
-									shouldCloseOnInteractOutside: (e) => {
-										onOutsideClick.get()?.(e);
-										if (e.defaultPrevented) return false;
-										if (
-											isHTMLElement($activeTrigger) &&
-											$activeTrigger.contains(e.target as Element)
-										)
-											return false;
-										return true;
-									},
-									open: $isVisible,
+					unsubPopper = usePopper(node, {
+						anchorElement: $activeTrigger,
+						open: open,
+						options: {
+							floating: $positioning,
+							modal: {
+								closeOnInteractOutside: $closeOnOutsideClick,
+								onClose: () => {
+									open.set(false);
+									$activeTrigger.focus();
 								},
-								portal: getPortalDestination(node, $portal),
-								focusTrap: null,
-								escapeKeydown: $closeOnEscape ? undefined : null,
+								shouldCloseOnInteractOutside: (e) => {
+									onOutsideClick.get()?.(e);
+									if (e.defaultPrevented) return false;
+									if (isHTMLElement($activeTrigger) && $activeTrigger.contains(e.target as Element))
+										return false;
+									return true;
+								},
+								open: $isVisible,
 							},
-						}).destroy;
-					});
-				}
+							portal: getPortalDestination(node, $portal),
+							focusTrap: null,
+							escapeKeydown: $closeOnEscape ? undefined : null,
+						},
+					}).destroy;
+				},
+				{ runAfterTick: true }
 			);
 
 			unsub = executeCallbacks(

--- a/src/lib/builders/listbox/create.ts
+++ b/src/lib/builders/listbox/create.ts
@@ -474,43 +474,38 @@ export function createListbox<
 					[isVisible, portal, closeOnOutsideClick, positioning, activeTrigger],
 					([$isVisible, $portal, $closeOnOutsideClick, $positioning, $activeTrigger]) => {
 						unsubPopper();
-
 						if (!$isVisible || !$activeTrigger) return;
-
-						tick().then(() => {
-							unsubPopper();
-							const ignoreHandler = createClickOutsideIgnore(ids.trigger.get());
-
-							unsubPopper = usePopper(node, {
-								anchorElement: $activeTrigger,
-								open,
-								options: {
-									floating: $positioning,
-									focusTrap: null,
-									modal: {
-										closeOnInteractOutside: $closeOnOutsideClick,
-										onClose: closeMenu,
-										open: $isVisible,
-										shouldCloseOnInteractOutside: (e) => {
-											onOutsideClick.get()?.(e);
-											if (e.defaultPrevented) return false;
-											const target = e.target;
-											if (!isElement(target)) return false;
-											if (target === $activeTrigger || $activeTrigger.contains(target)) {
-												return false;
-											}
-											// return opposite of the result of the ignoreHandler
-											if (ignoreHandler(e)) return false;
-											return true;
-										},
+						const ignoreHandler = createClickOutsideIgnore(ids.trigger.get());
+						unsubPopper = usePopper(node, {
+							anchorElement: $activeTrigger,
+							open,
+							options: {
+								floating: $positioning,
+								focusTrap: null,
+								modal: {
+									closeOnInteractOutside: $closeOnOutsideClick,
+									onClose: closeMenu,
+									open: $isVisible,
+									shouldCloseOnInteractOutside: (e) => {
+										onOutsideClick.get()?.(e);
+										if (e.defaultPrevented) return false;
+										const target = e.target;
+										if (!isElement(target)) return false;
+										if (target === $activeTrigger || $activeTrigger.contains(target)) {
+											return false;
+										}
+										// return opposite of the result of the ignoreHandler
+										if (ignoreHandler(e)) return false;
+										return true;
 									},
-
-									escapeKeydown: null,
-									portal: getPortalDestination(node, $portal),
 								},
-							}).destroy;
-						});
-					}
+
+								escapeKeydown: null,
+								portal: getPortalDestination(node, $portal),
+							},
+						}).destroy;
+					},
+					{ runAfterTick: true }
 				)
 			);
 			return {

--- a/src/lib/builders/menu/create.ts
+++ b/src/lib/builders/menu/create.ts
@@ -189,37 +189,35 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 				]) => {
 					unsubPopper();
 					if (!$isVisible || !$rootActiveTrigger) return;
-					tick().then(() => {
-						unsubPopper();
-						setMeltMenuAttribute(node, selector);
-						unsubPopper = usePopper(node, {
-							anchorElement: $rootActiveTrigger,
-							open: rootOpen,
-							options: {
-								floating: $positioning,
-								modal: {
-									closeOnInteractOutside: $closeOnOutsideClick,
-									shouldCloseOnInteractOutside: (e) => {
-										onOutsideClick.get()?.(e);
-										if (e.defaultPrevented) return false;
+					setMeltMenuAttribute(node, selector);
+					unsubPopper = usePopper(node, {
+						anchorElement: $rootActiveTrigger,
+						open: rootOpen,
+						options: {
+							floating: $positioning,
+							modal: {
+								closeOnInteractOutside: $closeOnOutsideClick,
+								shouldCloseOnInteractOutside: (e) => {
+									onOutsideClick.get()?.(e);
+									if (e.defaultPrevented) return false;
 
-										if (
-											isHTMLElement($rootActiveTrigger) &&
-											$rootActiveTrigger.contains(e.target as Element)
-										) {
-											return false;
-										}
-										return true;
-									},
-									onClose: () => rootOpen.set(false),
-									open: $isVisible,
+									if (
+										isHTMLElement($rootActiveTrigger) &&
+										$rootActiveTrigger.contains(e.target as Element)
+									) {
+										return false;
+									}
+									return true;
 								},
-								portal: getPortalDestination(node, $portal),
-								escapeKeydown: $closeOnEscape ? undefined : null,
+								onClose: () => rootOpen.set(false),
+								open: $isVisible,
 							},
-						}).destroy;
-					});
-				}
+							portal: getPortalDestination(node, $portal),
+							escapeKeydown: $closeOnEscape ? undefined : null,
+						},
+					}).destroy;
+				},
+				{ runAfterTick: true }
 			);
 
 			const unsubEvents = executeCallbacks(
@@ -783,23 +781,21 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 						if (!$subIsVisible) return;
 						const activeTrigger = subActiveTrigger.get();
 						if (!activeTrigger) return;
-						tick().then(() => {
-							unsubPopper();
-							const parentMenuEl = getParentMenu(activeTrigger);
+						const parentMenuEl = getParentMenu(activeTrigger);
 
-							unsubPopper = usePopper(node, {
-								anchorElement: activeTrigger,
-								open: subOpen,
-								options: {
-									floating: $positioning,
-									portal: isHTMLElement(parentMenuEl) ? parentMenuEl : undefined,
-									modal: null,
-									focusTrap: null,
-									escapeKeydown: null,
-								},
-							}).destroy;
-						});
-					}
+						unsubPopper = usePopper(node, {
+							anchorElement: activeTrigger,
+							open: subOpen,
+							options: {
+								floating: $positioning,
+								portal: isHTMLElement(parentMenuEl) ? parentMenuEl : undefined,
+								modal: null,
+								focusTrap: null,
+								escapeKeydown: null,
+							},
+						}).destroy;
+					},
+					{ runAfterTick: true }
 				);
 
 				const unsubEvents = executeCallbacks(

--- a/src/lib/builders/menubar/create.ts
+++ b/src/lib/builders/menubar/create.ts
@@ -29,7 +29,6 @@ import {
 } from '$lib/internal/helpers/index.js';
 import { safeOnDestroy, safeOnMount } from '$lib/internal/helpers/lifecycle.js';
 import type { MeltActionReturn } from '$lib/internal/types.js';
-import { tick } from 'svelte';
 import { writable } from 'svelte/store';
 import {
 	applyAttrsIfDisabled,
@@ -174,36 +173,33 @@ export function createMenubar(props?: CreateMenubarProps) {
 					[rootOpen, rootActiveTrigger, positioning, portal, closeOnOutsideClick],
 					([$rootOpen, $rootActiveTrigger, $positioning, $portal, $closeOnOutsideClick]) => {
 						unsubPopper();
-						if (!($rootOpen && $rootActiveTrigger)) return;
-
-						tick().then(() => {
-							unsubPopper();
-							unsubPopper = usePopper(node, {
-								anchorElement: $rootActiveTrigger,
-								open: rootOpen,
-								options: {
-									floating: $positioning,
-									portal: getPortalDestination(node, $portal),
-									modal: {
-										closeOnInteractOutside: $closeOnOutsideClick,
-										shouldCloseOnInteractOutside: (e) => {
-											onOutsideClick.get()?.(e);
-											if (e.defaultPrevented) return false;
-											const target = e.target;
-											const menubarEl = document.getElementById(ids.menubar.get());
-											if (!menubarEl || !isElement(target)) return true;
-											if (menubarEl.contains(target)) return false;
-											return true;
-										},
-										onClose: () => {
-											activeMenu.set('');
-										},
-										open: $rootOpen,
+						if (!$rootOpen || !$rootActiveTrigger) return;
+						unsubPopper = usePopper(node, {
+							anchorElement: $rootActiveTrigger,
+							open: rootOpen,
+							options: {
+								floating: $positioning,
+								portal: getPortalDestination(node, $portal),
+								modal: {
+									closeOnInteractOutside: $closeOnOutsideClick,
+									shouldCloseOnInteractOutside: (e) => {
+										onOutsideClick.get()?.(e);
+										if (e.defaultPrevented) return false;
+										const target = e.target;
+										const menubarEl = document.getElementById(ids.menubar.get());
+										if (!menubarEl || !isElement(target)) return true;
+										if (menubarEl.contains(target)) return false;
+										return true;
 									},
+									onClose: () => {
+										activeMenu.set('');
+									},
+									open: $rootOpen,
 								},
-							}).destroy;
-						});
-					}
+							},
+						}).destroy;
+					},
+					{ runAfterTick: true }
 				);
 
 				const unsubEvents = executeCallbacks(

--- a/src/lib/builders/popover/create.ts
+++ b/src/lib/builders/popover/create.ts
@@ -130,38 +130,35 @@ export function createPopover(args?: CreatePopoverProps) {
 				]) => {
 					unsubPopper();
 					if (!$isVisible || !$activeTrigger) return;
-
-					tick().then(() => {
-						unsubPopper();
-						unsubPopper = usePopper(node, {
-							anchorElement: $activeTrigger,
-							open,
-							options: {
-								floating: $positioning,
-								focusTrap: $disableFocusTrap
-									? null
-									: {
-											returnFocusOnDeactivate: false,
-											allowOutsideClick: true,
-									  },
-								modal: {
-									shouldCloseOnInteractOutside: shouldCloseOnInteractOutside,
-									onClose: handleClose,
-									open: $isVisible,
-									closeOnInteractOutside: $closeOnOutsideClick,
-								},
-								escapeKeydown: $closeOnEscape
-									? {
-											handler: () => {
-												handleClose();
-											},
-									  }
-									: null,
-								portal: getPortalDestination(node, $portal),
+					unsubPopper = usePopper(node, {
+						anchorElement: $activeTrigger,
+						open,
+						options: {
+							floating: $positioning,
+							focusTrap: $disableFocusTrap
+								? null
+								: {
+										returnFocusOnDeactivate: false,
+										allowOutsideClick: true,
+								  },
+							modal: {
+								shouldCloseOnInteractOutside: shouldCloseOnInteractOutside,
+								onClose: handleClose,
+								open: $isVisible,
+								closeOnInteractOutside: $closeOnOutsideClick,
 							},
-						}).destroy;
-					});
-				}
+							escapeKeydown: $closeOnEscape
+								? {
+										handler: () => {
+											handleClose();
+										},
+								  }
+								: null,
+							portal: getPortalDestination(node, $portal),
+						},
+					}).destroy;
+				},
+				{ runAfterTick: true }
 			);
 
 			return {

--- a/src/lib/builders/tooltip/create.ts
+++ b/src/lib/builders/tooltip/create.ts
@@ -27,7 +27,6 @@ import { derived, writable, type Writable } from 'svelte/store';
 import { generateIds } from '../../internal/helpers/id.js';
 import type { TooltipEvents } from './events.js';
 import type { CreateTooltipProps } from './types.js';
-import { tick } from 'svelte';
 
 const defaults = {
 	positioning: {
@@ -216,15 +215,11 @@ export function createTooltip(props?: CreateTooltipProps) {
 					unsubFloating();
 					const triggerEl = getEl('trigger');
 					if (!$isVisible || !triggerEl) return;
-
-					tick().then(() => {
-						unsubPortal();
-						unsubFloating();
-						const portalDest = getPortalDestination(node, $portal);
-						if (portalDest) unsubPortal = usePortal(node, portalDest).destroy;
-						unsubFloating = useFloating(triggerEl, node, $positioning).destroy;
-					});
-				}
+					const portalDest = getPortalDestination(node, $portal);
+					if (portalDest) unsubPortal = usePortal(node, portalDest).destroy;
+					unsubFloating = useFloating(triggerEl, node, $positioning).destroy;
+				},
+				{ runAfterTick: true }
 			);
 
 			/**


### PR DESCRIPTION
This PR adds a new prop `runAfterTick` to `effect`.

Previously we needed to run `tick()` in many builders to prevent https://github.com/melt-ui/melt-ui/issues/1048 where the DOM hasn't updated yet before our effect ran which caused issues, however after adding a tick to solve that issue, we then ran into a new issue https://github.com/melt-ui/melt-ui/pull/1087 where we were getting memory leaks due to not calling the cleanup functions both before and after the `tick`. So by adding the `runAfterTick` prop, our effect will run after the DOM has updated and it removes the need to make sure we call all the cleanup functions twice in so many builders.