### PR TITLE
fix: mount portal only when isVisible is true

### DIFF
--- a/.changeset/breezy-buses-promise.md
+++ b/.changeset/breezy-buses-promise.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+Only mount the portal for dialog, menu overlay, and popover overlay when the component is set to open. This applies when `forceVisible: false` is used.

--- a/src/lib/builders/dialog/create.ts
+++ b/src/lib/builders/dialog/create.ts
@@ -217,10 +217,12 @@ export function createDialog(props?: CreateDialogProps) {
 	});
 
 	const portalled = makeElement(name('portalled'), {
-		stores: portal,
-		returned: ($portal) =>
+		stores: [portal, isVisible],
+		returned: ([$portal, $isVisible]) =>
 			({
+				hidden: $isVisible ? undefined : true,
 				'data-portal': portalAttr($portal),
+				style: $isVisible ? undefined : styleToString({ display: 'none' }),
 			} as const),
 		action: (node: HTMLElement) => {
 			let unsubPortal = noop;

--- a/src/lib/builders/dialog/create.ts
+++ b/src/lib/builders/dialog/create.ts
@@ -225,20 +225,16 @@ export function createDialog(props?: CreateDialogProps) {
 				style: $isVisible ? undefined : styleToString({ display: 'none' }),
 			} as const),
 		action: (node: HTMLElement) => {
-			let unsubPortal = noop;
-			const unsubDerived = effect([portal, isVisible], ([$portal, $isVisible]) => {
+			const unsubPortal = effect([portal, isVisible], ([$portal, $isVisible]) => {
 				unsubPortal();
 				if (!$isVisible || $portal === null) return;
 				const portalDestination = getPortalDestination(node, $portal);
 				if (portalDestination === null) return;
-				unsubPortal = usePortal(node, portalDestination).destroy;
+				return usePortal(node, portalDestination).destroy;
 			});
 
 			return {
-				destroy() {
-					unsubDerived();
-					unsubPortal();
-				},
+				destroy: unsubPortal,
 			};
 		},
 	});

--- a/src/lib/builders/dialog/create.ts
+++ b/src/lib/builders/dialog/create.ts
@@ -226,7 +226,6 @@ export function createDialog(props?: CreateDialogProps) {
 			} as const),
 		action: (node: HTMLElement) => {
 			const unsubPortal = effect([portal, isVisible], ([$portal, $isVisible]) => {
-				unsubPortal();
 				if (!$isVisible || $portal === null) return;
 				const portalDestination = getPortalDestination(node, $portal);
 				if (portalDestination === null) return;

--- a/src/lib/builders/menu/create.ts
+++ b/src/lib/builders/menu/create.ts
@@ -341,9 +341,7 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 			return {
 				hidden: $isVisible ? undefined : true,
 				tabindex: -1,
-				style: styleToString({
-					display: $isVisible ? undefined : 'none',
-				}),
+				style: $isVisible ? undefined : styleToString({ display: 'none' }),
 				'aria-hidden': 'true',
 				'data-state': stateAttr($isVisible),
 			} as const;

--- a/src/lib/builders/menu/create.ts
+++ b/src/lib/builders/menu/create.ts
@@ -350,6 +350,7 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 		},
 		action: (node: HTMLElement) => {
 			let unsubEscapeKeydown = noop;
+			let unsubPortal = noop;
 
 			if (closeOnEscape.get()) {
 				const escapeKeydown = useEscapeKeydown(node, {
@@ -360,15 +361,17 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 				}
 			}
 
-			const unsubPortal = effect([portal], ([$portal]) => {
-				if ($portal === null) return noop;
+			const unsubDerived = effect([portal, isVisible], ([$portal, $isVisible]) => {
+				unsubPortal();
+				if (!$isVisible || $portal === null) return;
 				const portalDestination = getPortalDestination(node, $portal);
-				if (portalDestination === null) return noop;
-				return usePortal(node, portalDestination).destroy;
+				if (portalDestination === null) return;
+				unsubPortal = usePortal(node, portalDestination).destroy;
 			});
 
 			return {
 				destroy() {
+					unsubDerived();
 					unsubEscapeKeydown();
 					unsubPortal();
 				},

--- a/src/lib/builders/menu/create.ts
+++ b/src/lib/builders/menu/create.ts
@@ -348,7 +348,6 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 		},
 		action: (node: HTMLElement) => {
 			let unsubEscapeKeydown = noop;
-			let unsubPortal = noop;
 
 			if (closeOnEscape.get()) {
 				const escapeKeydown = useEscapeKeydown(node, {
@@ -359,17 +358,15 @@ export function createMenuBuilder(opts: _MenuBuilderOptions) {
 				}
 			}
 
-			const unsubDerived = effect([portal, isVisible], ([$portal, $isVisible]) => {
-				unsubPortal();
+			const unsubPortal = effect([portal, isVisible], ([$portal, $isVisible]) => {
 				if (!$isVisible || $portal === null) return;
 				const portalDestination = getPortalDestination(node, $portal);
 				if (portalDestination === null) return;
-				unsubPortal = usePortal(node, portalDestination).destroy;
+				return usePortal(node, portalDestination).destroy;
 			});
 
 			return {
 				destroy() {
-					unsubDerived();
 					unsubEscapeKeydown();
 					unsubPortal();
 				},

--- a/src/lib/builders/popover/create.ts
+++ b/src/lib/builders/popover/create.ts
@@ -224,7 +224,6 @@ export function createPopover(args?: CreatePopoverProps) {
 		},
 		action: (node: HTMLElement) => {
 			let unsubEscapeKeydown = noop;
-			let unsubPortal = noop;
 
 			if (closeOnEscape.get()) {
 				const escapeKeydown = useEscapeKeydown(node, {
@@ -237,18 +236,16 @@ export function createPopover(args?: CreatePopoverProps) {
 				}
 			}
 
-			const unsubDerived = effect([portal, isVisible], ([$portal, $isVisible]) => {
-				unsubPortal();
+			const unsubPortal = effect([portal, isVisible], ([$portal, $isVisible]) => {
 				if (!$isVisible || $portal === null) return;
 				const portalDestination = getPortalDestination(node, $portal);
 				if (portalDestination === null) return;
-				unsubPortal = usePortal(node, portalDestination).destroy;
+				return usePortal(node, portalDestination).destroy;
 			});
 
 			return {
 				destroy() {
 					unsubEscapeKeydown();
-					unsubDerived();
 					unsubPortal();
 				},
 			};

--- a/src/lib/builders/popover/create.ts
+++ b/src/lib/builders/popover/create.ts
@@ -217,16 +217,13 @@ export function createPopover(args?: CreatePopoverProps) {
 			return {
 				hidden: $isVisible ? undefined : true,
 				tabindex: -1,
-				style: styleToString({
-					display: $isVisible ? undefined : 'none',
-				}),
+				style: $isVisible ? undefined : styleToString({ display: 'none' }),
 				'aria-hidden': 'true',
 				'data-state': stateAttr($isVisible),
 			} as const;
 		},
 		action: (node: HTMLElement) => {
 			let unsubEscapeKeydown = noop;
-			let unsubDerived = noop;
 			let unsubPortal = noop;
 
 			if (closeOnEscape.get()) {
@@ -240,9 +237,9 @@ export function createPopover(args?: CreatePopoverProps) {
 				}
 			}
 
-			unsubDerived = effect([portal], ([$portal]) => {
+			const unsubDerived = effect([portal, isVisible], ([$portal, $isVisible]) => {
 				unsubPortal();
-				if ($portal === null) return;
+				if (!$isVisible || $portal === null) return;
 				const portalDestination = getPortalDestination(node, $portal);
 				if (portalDestination === null) return;
 				unsubPortal = usePortal(node, portalDestination).destroy;


### PR DESCRIPTION
Currently when using `forceVisible: false` and using a dialog, menu overlay, popover overlay, we mount the portal before the element is actually open. This can create z-index conflicts.

This is easily solved by only mounting the portal when `isVisible` is `true`