### PR TITLE
test(combobox): add interact outside tests

### DIFF
--- a/src/tests/combobox/Combobox.spec.ts
+++ b/src/tests/combobox/Combobox.spec.ts
@@ -154,7 +154,7 @@ describe('Combobox', () => {
 		expect(getByTestId('menu')).toBeVisible();
 	});
 
-	test.skip('Closes on outside click by default', async () => {
+	test('Closes on outside click by default', async () => {
 		const user = userEvent.setup();
 		const { getByTestId } = render(ComboboxTest);
 		const input = getByTestId('input');
@@ -207,6 +207,22 @@ describe('Combobox', () => {
 		expect(menu).not.toBeVisible();
 		await user.click(toggleBtn);
 		expect(menu).toBeVisible();
+	});
+
+	test('should not prevent focusing on another input on outside interaction of combobox', async () => {
+		const user = userEvent.setup();
+		const { getByTestId } = render(ComboboxTest, { closeOnEscape: false });
+
+		const input = getByTestId('input');
+		const menu = getByTestId('menu');
+		const otherInput = getByTestId('other-input');
+
+		await user.click(input);
+		expect(menu).toBeVisible();
+
+		await user.click(otherInput);
+		expect(otherInput).toHaveFocus();
+		await waitFor(() => expect(menu).not.toBeVisible());
 	});
 
 	test.todo('Selects multiple items when `multiple` is true');

--- a/src/tests/combobox/ComboboxTest.svelte
+++ b/src/tests/combobox/ComboboxTest.svelte
@@ -67,4 +67,6 @@
 		</div>
 	</ul>
 	<div data-testid="outside-click" />
+
+	<input type="text" data-testid="other-input" aria-label="other input" />
 </main>


### PR DESCRIPTION
add regression tests to prevent issue reported in https://github.com/melt-ui/melt-ui/pull/1038#issuecomment-2016526702 
when combobox is open and clicking outside on a different input, the combobox closes as expected, however the click on the input is prevented and the it does not get focused. You should be able to click onto an input while the combobox is open and have the input be focused after the combobox closes.