### PR TITLE
chore: refactor tags input

### DIFF
--- a/.changeset/real-colts-run.md
+++ b/.changeset/real-colts-run.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+Refactored tags input internals.


### PR DESCRIPTION
Add `isEditing` helper to avoid repeating logic for checking if a tag is being edited. 

This refactor is also essential to https://github.com/melt-ui/melt-ui/pull/1080/ where we add `useInteractOutside` to a tag only when it's being edited to prevent closing parent floating elements when clicking outside of a tag that's being edited.