### PR TITLE
docs: improve tailwind classes

### DIFF
--- a/src/docs/components/custom-event-dialog.svelte
+++ b/src/docs/components/custom-event-dialog.svelte
@@ -22,8 +22,8 @@
 {#if $open}
 	<div use:melt={$overlay} class="fixed inset-0 z-40 bg-black/50" />
 	<div
-		class="fixed left-[50%] top-[50%] z-50 max-h-[85vh] w-[90vw] max-w-[960px]
-    translate-x-[-50%] translate-y-[-50%] rounded-md
+		class="fixed left-1/2 top-1/2 z-50 max-h-[85vh] w-[90vw] max-w-[960px]
+    -translate-x-1/2 -translate-y-1/2 rounded-md
     bg-neutral-800 p-4 shadow-lg md:p-8"
 		transition:flyAndScale={{
 			duration: 150,

--- a/src/docs/components/tables/custom-events-table.svelte
+++ b/src/docs/components/tables/custom-events-table.svelte
@@ -22,10 +22,8 @@
 				<table class="w-full min-w-[540px] text-left sm:min-w-full">
 					<tbody class="divide-y divide-neutral-700">
 						<tr class="w-full text-neutral-300">
-							<td class="w-[50%] whitespace-nowrap py-2 pl-4 text-sm font-medium sm:pl-0">
-								Event
-							</td>
-							<td class="w-[50%] whitespace-nowrap py-2 text-sm font-medium">Value</td>
+							<td class="w-1/2 whitespace-nowrap py-2 pl-4 text-sm font-medium sm:pl-0"> Event </td>
+							<td class="w-1/2 whitespace-nowrap py-2 text-sm font-medium">Value</td>
 						</tr>
 						{#each data as { name }}
 							<tr>

--- a/src/docs/components/tables/data-attr-table.svelte
+++ b/src/docs/components/tables/data-attr-table.svelte
@@ -21,10 +21,10 @@
 				<table class="w-full min-w-[540px] text-left sm:min-w-full">
 					<tbody class="divide-y divide-neutral-700">
 						<tr class="w-full text-neutral-300">
-							<td class="w-[50%] whitespace-nowrap py-2 pl-4 text-sm font-medium sm:pl-0">
+							<td class="w-1/2 whitespace-nowrap py-2 pl-4 text-sm font-medium sm:pl-0">
 								Data Attribute
 							</td>
-							<td class="w-[50%] whitespace-nowrap py-2 text-sm font-medium">Value</td>
+							<td class="w-1/2 whitespace-nowrap py-2 text-sm font-medium">Value</td>
 						</tr>
 						{#each data as { name, value }}
 							<tr>

--- a/src/docs/components/tables/props-table.svelte
+++ b/src/docs/components/tables/props-table.svelte
@@ -26,11 +26,9 @@
 				<table class="w-full min-w-[540px] text-left sm:min-w-full">
 					<tbody class="divide-y divide-neutral-700">
 						<tr class="w-1/4 text-neutral-300">
-							<td class="w-[25%] whitespace-nowrap py-2 pl-4 text-sm font-medium sm:pl-0">
-								Prop
-							</td>
-							<td class="w-[25%] whitespace-nowrap py-2 text-sm font-medium">Default</td>
-							<td class="w-[50%] whitespace-nowrap py-2 text-sm font-medium">Type / Description</td>
+							<td class="w-1/4 whitespace-nowrap py-2 pl-4 text-sm font-medium sm:pl-0"> Prop </td>
+							<td class="w-1/4 whitespace-nowrap py-2 text-sm font-medium">Default</td>
+							<td class="w-1/2 whitespace-nowrap py-2 text-sm font-medium">Type / Description</td>
 						</tr>
 						{#each data as prop}
 							<tr>

--- a/src/docs/components/tables/returned-props-table.svelte
+++ b/src/docs/components/tables/returned-props-table.svelte
@@ -27,10 +27,10 @@
 				<table class="w-full min-w-[540px] text-left sm:min-w-full">
 					<tbody class="divide-y divide-neutral-700">
 						<tr class="w-1/4 text-neutral-300">
-							<td class="w-[25%] whitespace-nowrap py-2 pl-4 text-sm font-medium sm:pl-0">
+							<td class="w-1/4 whitespace-nowrap py-2 pl-4 text-sm font-medium sm:pl-0">
 								{tableHeading}
 							</td>
-							<td class="w-[75%] whitespace-nowrap py-2 text-sm font-medium">Description</td>
+							<td class="w-3/4 whitespace-nowrap py-2 text-sm font-medium">Description</td>
 						</tr>
 						{#each data as returnedProp}
 							<tr>

--- a/src/docs/components/type-dialog.svelte
+++ b/src/docs/components/type-dialog.svelte
@@ -23,8 +23,8 @@
 {#if $open}
 	<div use:melt={$overlay} class="fixed inset-0 z-40 bg-black/50" />
 	<div
-		class="fixed left-[50%] top-[50%] z-50 max-h-[85vh] w-[90vw] max-w-[960px]
-    translate-x-[-50%] translate-y-[-50%] rounded-md
+		class="fixed left-1/2 top-1/2 z-50 max-h-[85vh] w-[90vw] max-w-[960px]
+    -translate-x-1/2 -translate-y-1/2 rounded-md
     bg-neutral-800 p-4 shadow-lg md:p-8"
 		transition:flyAndScale={{
 			duration: 150,

--- a/src/docs/previews/dialog/alert/tailwind/index.svelte
+++ b/src/docs/previews/dialog/alert/tailwind/index.svelte
@@ -33,8 +33,8 @@
 	<div class="force-dark" use:melt={$portalled}>
 		<div use:melt={$overlay} class="fixed inset-0 z-50 bg-black/50" />
 		<div
-			class="fixed left-[50%] top-[50%] z-50 max-h-[85vh] w-[90vw]
-            max-w-[450px] translate-x-[-50%] translate-y-[-50%] rounded-md bg-white
+			class="fixed left-1/2 top-1/2 z-50 max-h-[85vh] w-[90vw]
+            max-w-[450px] -translate-x-1/2 -translate-y-1/2 rounded-md bg-white
             p-6 shadow-lg"
 			transition:flyAndScale={{
 				duration: 150,

--- a/src/docs/previews/dialog/controlled/tailwind/index.svelte
+++ b/src/docs/previews/dialog/controlled/tailwind/index.svelte
@@ -35,8 +35,8 @@
 	<div class="force-dark" use:melt={$portalled}>
 		<div use:melt={$overlay} class="fixed inset-0 z-50 bg-black/50" />
 		<div
-			class="fixed left-[50%] top-[50%] z-50 max-h-[85vh] w-[90vw]
-            max-w-[450px] translate-x-[-50%] translate-y-[-50%] rounded-md bg-white
+			class="fixed left-1/2 top-1/2 z-50 max-h-[85vh] w-[90vw]
+            max-w-[450px] -translate-x-1/2 -translate-y-1/2 rounded-md bg-white
             p-6 shadow-lg"
 			transition:flyAndScale={{
 				duration: 150,

--- a/src/docs/previews/dialog/main/tailwind/index.svelte
+++ b/src/docs/previews/dialog/main/tailwind/index.svelte
@@ -37,8 +37,8 @@
 			transition:fade={{ duration: 150 }}
 		/>
 		<div
-			class="fixed left-[50%] top-[50%] z-50 max-h-[85vh] w-[90vw]
-            max-w-[450px] translate-x-[-50%] translate-y-[-50%] rounded-xl bg-white
+			class="fixed left-1/2 top-1/2 z-50 max-h-[85vh] w-[90vw]
+            max-w-[450px] -translate-x-1/2 -translate-y-1/2 rounded-xl bg-white
             p-6 shadow-lg"
 			transition:flyAndScale={{
 				duration: 150,

--- a/src/docs/previews/dialog/nested/tailwind/index.svelte
+++ b/src/docs/previews/dialog/nested/tailwind/index.svelte
@@ -42,8 +42,8 @@
 	<div class="force-dark" use:melt={$portalled}>
 		<div use:melt={$overlay} class="fixed inset-0 z-50 bg-black/50" />
 		<div
-			class="fixed left-[50%] top-[50%] z-50 max-h-[85vh] w-[90vw]
-            max-w-[450px] translate-x-[-50%] translate-y-[-50%] rounded-md bg-white
+			class="fixed left-1/2 top-1/2 z-50 max-h-[85vh] w-[90vw]
+            max-w-[450px] -translate-x-1/2 -translate-y-1/2 rounded-md bg-white
             p-6 shadow-lg"
 			transition:flyAndScale={{
 				duration: 150,
@@ -82,8 +82,8 @@
 						class="fixed inset-0 z-50 bg-black/75"
 					/>
 					<div
-						class="fixed left-[50%] top-[50%] z-50 max-h-[85vh] w-[90vw]
-                        max-w-[500px] translate-x-[-50%] translate-y-[-50%] rounded-md bg-white
+						class="fixed left-1/2 top-1/2 z-50 max-h-[85vh] w-[90vw]
+                        max-w-[500px] -translate-x-1/2 -translate-y-1/2 rounded-md bg-white
                         p-6 shadow-2xl"
 						transition:flyAndScale={{
 							duration: 150,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -79,9 +79,9 @@
 			<Slider class="absolute left-1/2 top-[25rem] translate-x-[calc(-50%+30px)]" />
 			<Switch class="absolute left-[52.5rem] top-[3.5rem] sm:left-[62.5rem] sm:top-[3.5rem]" />
 			<TagsInput class="absolute left-[70%] top-[10rem]" />
-			<PinInput class="absolute left-[62%] top-[15rem] sm:left-[67.5%] lg:left-[75%]" />
+			<PinInput class="absolute left-[62%] top-[15rem] sm:left-[67.5%] lg:left-3/4" />
 			<Popover
-				class="absolute left-[25%] top-[10rem] hidden md:flex lg:left-[20%] "
+				class="absolute left-1/4 top-[10rem] hidden md:flex lg:left-[20%] "
 				contentClass="hidden md:block"
 			/>
 			<Tabs class="absolute left-[20rem] top-[30rem] sm:left-0 sm:top-[16rem]" />

--- a/src/stories/Dialog/BaseDialog.svelte
+++ b/src/stories/Dialog/BaseDialog.svelte
@@ -11,8 +11,8 @@
 <div use:melt={$portalled}>
 	<div use:melt={$overlay} class="fixed inset-0 z-40 bg-black/50" />
 	<div
-		class="fixed left-[50%] top-[50%] z-50 max-h-[85vh] w-[90vw] max-w-[450px]
-				translate-x-[-50%] translate-y-[-50%] rounded-md bg-white p-6
+		class="fixed left-1/2 top-1/2 z-50 max-h-[85vh] w-[90vw] max-w-[450px]
+				-translate-x-1/2 -translate-y-1/2 rounded-md bg-white p-6
 				shadow-lg"
 		use:melt={$content}
 	>


### PR DESCRIPTION
replaced a bunch of arbitrary tailwind classes with built-in tailwind classes.
- `top-[50%]` -> `top-1/2`
- `translate-x-[-50%]` -> `-translate-x-1/2`
- etc.