### PR TITLE
fix(date-range-picker): add selected stores to state

### DIFF
--- a/src/lib/builders/range-calendar/create.ts
+++ b/src/lib/builders/range-calendar/create.ts
@@ -1086,6 +1086,9 @@ export function createRangeCalendar<T extends DateValue = DateValue>(
 			value,
 			startValue,
 			endValue,
+			isSelectionStart,
+			isSelectionEnd,
+			isSelected
 		},
 		helpers: {
 			nextPage,


### PR DESCRIPTION
This should fix #1156 by passing stores to the states property of the date range picker to match the range calendar states.

Perhaps these stores would be better represented as helpers instead of states?