### PR TITLE
Fix: tooltip closes while pointer is still inside trigger

### DIFF
--- a/.changeset/moody-jokes-peel.md
+++ b/.changeset/moody-jokes-peel.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+Fixed bug where tooltip would close while the pointer is still inside trigger (closes #886)


### PR DESCRIPTION
closes https://github.com/melt-ui/melt-ui/issues/886

The reason issue https://github.com/melt-ui/melt-ui/issues/886 occurs is because `clientX` is smaller by 1 than `triggerRect.left`, which causes us to inaccurately "think" that the pointer is outside the trigger which causes the tooltip to close. This is due to sub-pixel rendering and rounding issues by the browser. 

To make sure this doesn't happen, we now keep track of 2 extra variables `isPointerInsideTrigger` and `isPointerInsideContent` that are set on `pointerenter` and `pointerleave` for the trigger and content respectively. And `isPointerInsideTrigger` and `isPointerInsideContent` are taken into account in addition to `pointInPolygon()` when deciding whether the pointer is inside the tooltip area.

### Before

https://github.com/melt-ui/melt-ui/assets/53095479/85d98203-f883-4996-8f8e-d39087c38c94

### After

https://github.com/melt-ui/melt-ui/assets/53095479/0d996b7f-4093-4667-b35d-c933fe7bf697

