### PR TITLE
chore: fix missing `Expand` type import

### DIFF
--- a/src/lib/internal/helpers/id.ts
+++ b/src/lib/internal/helpers/id.ts
@@ -1,4 +1,5 @@
 import { nanoid } from 'nanoid/non-secure';
+import type { Expand } from '../types.js';
 
 /**
  * A function that generates a random id


### PR DESCRIPTION
add a missing import for the `Expand` type. 

### Before
![image](https://github.com/melt-ui/melt-ui/assets/53095479/d58c48b5-7771-4e3c-9050-88cbb3c6da0e)


### After
![image](https://github.com/melt-ui/melt-ui/assets/53095479/94955889-cf60-4b90-a1b4-5c76066fb388)
