### PR TITLE
docs: fix context menu submenu not reopening after escape due to #1108

### DIFF
--- a/src/docs/previews/context-menu/main/tailwind/index.svelte
+++ b/src/docs/previews/context-menu/main/tailwind/index.svelte
@@ -9,12 +9,15 @@
 	const {
 		elements: { trigger, menu, item, separator },
 		builders: { createSubmenu, createMenuRadioGroup, createCheckboxItem },
+		states: { open },
 	} = createContextMenu({
 		loop: true,
+		forceVisible: true,
 	});
 
 	const {
 		elements: { subMenu: subMenuA, subTrigger: subTriggerA },
+		states: { subOpen },
 	} = createSubmenu();
 
 	const {
@@ -47,60 +50,64 @@
 <span class="trigger" use:melt={$trigger} aria-label="Update dimensions">
 	Right click me.
 </span>
-<div class="force-dark menu" use:melt={$menu}>
-	<div class="item" use:melt={$item}>About Melt UI</div>
-	<div class="item" use:melt={$item}>Check for Updates...</div>
-	<div class="separator" use:melt={$separator} />
-	<div class="item" use:melt={$checkboxItem}>
-		<div class="check">
-			{#if $settingsSync}
-				<Check class="size-4" />
-			{/if}
+{#if $open}
+	<div class="force-dark menu" use:melt={$menu}>
+		<div class="item" use:melt={$item}>About Melt UI</div>
+		<div class="item" use:melt={$item}>Check for Updates...</div>
+		<div class="separator" use:melt={$separator} />
+		<div class="item" use:melt={$checkboxItem}>
+			<div class="check">
+				{#if $settingsSync}
+					<Check class="size-4" />
+				{/if}
+			</div>
+			Settings Sync is On
 		</div>
-		Settings Sync is On
-	</div>
-	<div class="item" use:melt={$subTriggerA}>
-		Profiles
-		<div class="rightSlot">
-			<ChevronRight class="size-4" />
+		<div class="item" use:melt={$subTriggerA}>
+			Profiles
+			<div class="rightSlot">
+				<ChevronRight class="size-4" />
+			</div>
 		</div>
-	</div>
-	<div class="menu subMenu" use:melt={$subMenuA}>
-		<div class="text">People</div>
-		<div use:melt={$radioGroup}>
-			{#each personsArr as person}
-				<div class="item" use:melt={$radioItem({ value: person })}>
-					<div class="check">
-						{#if $isChecked(person)}
-							<div class="dot" />
-						{/if}
-					</div>
-					{person}
+		{#if $subOpen}
+			<div class="menu subMenu" use:melt={$subMenuA}>
+				<div class="text">People</div>
+				<div use:melt={$radioGroup}>
+					{#each personsArr as person}
+						<div class="item" use:melt={$radioItem({ value: person })}>
+							<div class="check">
+								{#if $isChecked(person)}
+									<div class="dot" />
+								{/if}
+							</div>
+							{person}
+						</div>
+					{/each}
 				</div>
-			{/each}
-		</div>
-	</div>
-	<div use:melt={$separator} class="separator" />
+			</div>
+		{/if}
+		<div use:melt={$separator} class="separator" />
 
-	<div class="item" use:melt={$checkboxItemA}>
-		<div class="check">
-			{#if $hideMeltUI}
-				<Check class="size-4" />
-			{/if}
+		<div class="item" use:melt={$checkboxItemA}>
+			<div class="check">
+				{#if $hideMeltUI}
+					<Check class="size-4" />
+				{/if}
+			</div>
+			Hide Melt UI
+			<div class="rightSlot">⌘H</div>
 		</div>
-		Hide Melt UI
-		<div class="rightSlot">⌘H</div>
+		<div class="item" use:melt={$item} data-disabled>
+			Show All Components
+			<div class="rightSlot">⇧⌘N</div>
+		</div>
+		<div use:melt={$separator} class="separator" />
+		<div class="item" use:melt={$item}>
+			Quit Melt UI
+			<div class="rightSlot">⌘Q</div>
+		</div>
 	</div>
-	<div class="item" use:melt={$item} data-disabled>
-		Show All Components
-		<div class="rightSlot">⇧⌘N</div>
-	</div>
-	<div use:melt={$separator} class="separator" />
-	<div class="item" use:melt={$item}>
-		Quit Melt UI
-		<div class="rightSlot">⌘Q</div>
-	</div>
-</div>
+{/if}
 
 <style lang="postcss">
 	.menu {


### PR DESCRIPTION
When opening context menu, and opening a submenu, when pressing escape, the whole menu closes as expected. However, when reopening the context menu, and hovering over the submenu trigger, the submenu doesn't open. This issue only happens when using `forceVisible: false`, due to action cleanup functions not running on children as documented in https://github.com/melt-ui/melt-ui/issues/1108



https://github.com/melt-ui/melt-ui/assets/53095479/c47c45a7-1f63-4e5f-b0b8-f15ad070ebf1

