### PR TITLE
Fix: Only preventDefault if there is a highlighted item

### DIFF
--- a/src/lib/builders/listbox/create.ts
+++ b/src/lib/builders/listbox/create.ts
@@ -366,13 +366,13 @@ export function createListbox<
 						(e.key === kbd.ENTER && !e.isComposing) ||
 						(e.key === kbd.SPACE && isHTMLButtonElement(node))
 					) {
-						e.preventDefault();
 						const $highlightedItem = highlightedItem.get();
 						if ($highlightedItem) {
+							e.preventDefault();
 							selectItem($highlightedItem);
-						}
-						if (!multiple.get()) {
-							closeMenu();
+							if (!multiple.get()) {
+								closeMenu();
+							}
 						}
 					}
 					// Pressing Alt + Up should close the menu.


### PR DESCRIPTION
Hello, I'm relatively new to PR's and am glad to explain or fix anything that would be needed.

In the `listbox` input the key input handler called `preventDefault` unnecessarily. The comment above on line 364 says that pressing enter with a highlighted item should select it, which should mean that when there is no highlighted item nothing should happen.

The current behaviour prevents the input from being used as expected in forms when pressing `Enter`, instead first closing the list and on the second press of `Enter` submitting the form.

My current use case is a searchbox with result showing up in the listbox content as you type using bits-ui, which uses this listbox. This is placed in a form that should include the search input as typed when pressing enter, but currently it requires pressing it twice.