### PR TITLE
fix(pagination): do not add page-0 to pagesToShow

### DIFF
--- a/src/lib/builders/pagination/helpers.ts
+++ b/src/lib/builders/pagination/helpers.ts
@@ -6,9 +6,13 @@ export function getPageItems({
 	siblingCount = 1,
 }: GetPageItemsArgs): Array<PageItem> {
 	const pageItems: Array<PageItem> = [];
-	const pagesToShow = new Set([1, totalPages]);
+	const pagesToShow = new Set([1]);
 	const firstItemWithSiblings = 3 + siblingCount;
 	const lastItemWithSiblings = totalPages - 2 - siblingCount;
+
+	if(totalPages > 1) {
+		pagesToShow.add(totalPages);
+	}
 
 	if (firstItemWithSiblings > lastItemWithSiblings) {
 		for (let p = 2; p <= totalPages - 1; p++) {


### PR DESCRIPTION
Hi,

This is my first contribution to melt-ui.
I am submitting this PR to fix a bug on the Pagination component when there is no element.

<img width="191" alt="image" src="https://github.com/melt-ui/melt-ui/assets/8796095/48fb8f54-7088-4c43-9c72-1b0bd535e85d">

```js
const {
  elements: { root, pageTrigger, prevButton, nextButton },
  states: { pages, range }
} = createPagination({
  count: 0,
  perPage: 20,
  defaultPage: 1,
  siblingCount: 1
});
$: console.log($pages); // [{"type": "page","value": 0,"key": "page-0"}, {"type": "page", "value": 1,"key": "page-1" }]
```

As you can see, when count = 0, the pagination component creates "page-0" and "page-1" but I think it should only create "page-1"
When count = 1, the component behave correctly and renders only "page-1"
