### PR TITLE
docs: completes documentation for localization using specific calendar system for the calendar. 

### DIFF
--- a/src/docs/content/builders/calendar.md
+++ b/src/docs/content/builders/calendar.md
@@ -479,7 +479,7 @@ are available for use.
 		/* ... */
 	} = createCalendar({
 		locale: 'fa',
-		new CalendarDate(new PersianCalendar(), 1403, 2, 12)  
+		defaultValue: new CalendarDate(new PersianCalendar(), 1403, 2, 12)  
 	})
 </script>
 ```

--- a/src/docs/content/builders/calendar.md
+++ b/src/docs/content/builders/calendar.md
@@ -464,6 +464,26 @@ constructor.
 	<svelte:component this={previews.locale} />
 </Preview>
 
+The Calendar builder also supports the use of specific calendar systems, such as the Persian
+calendar. You can achieve this by providing the defaultValue or defaultPlaceholder props with the
+desired calendar system. Various calendar systems supported by
+[@internationalized/date](https://react-spectrum.adobe.com/internationalized/date/Calendar.html#implementations)
+are available for use.
+
+```svelte showLineNumbers {3,8,9}
+<script lang="ts">
+	import { createCalendar, melt } from '@melt-ui/svelte'
+	import { PersianCalendar} from '@internationalized/date';
+
+	const {
+		/* ... */
+	} = createCalendar({
+		locale: 'fa',
+		new CalendarDate(new PersianCalendar(), 1403, 2, 12)  
+	})
+</script>
+```
+
 ### Prevent Deselection
 
 By default, users can deselect a selected date without selecting another, by selecting the date


### PR DESCRIPTION
This pull request updates the documentation to include instructions for utilizing different calendar systems for complete localization in the Calendar builder. Users can now refer to the documentation to learn how to configure the Calendar builder to support various calendar systems, such as the Persian calendar, to meet their localization needs.
Merely using the locale prop does not change the calendar system; instead, it adjusts the weekdays and month names while retaining the Georgian calendar for the month display.

Changes:
-Extends the documentation to include detailed instructions on configuring different calendar systems for the calendar. 