### PR TITLE
fix: add `data-state` to Listbox builder

### DIFF
--- a/.changeset/old-bees-breathe.md
+++ b/.changeset/old-bees-breathe.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": minor
+---
+
+fix: add `data-state` to select & combobox (closes #1199)

--- a/src/lib/builders/listbox/create.ts
+++ b/src/lib/builders/listbox/create.ts
@@ -277,6 +277,7 @@ export function createListbox<
 				'aria-controls': $menuId,
 				'aria-expanded': $open,
 				'aria-labelledby': $labelId,
+				'data-state': $open ? 'open' : 'closed',
 				// autocomplete: 'off',
 				id: $triggerId,
 				role: 'combobox',


### PR DESCRIPTION
The listbox builder is used by the Select & the Combobox builder. This also closes #1193