### PR TITLE
docs: Remove unused `import` code in the document

### DIFF
--- a/src/docs/content/controlled.md
+++ b/src/docs/content/controlled.md
@@ -59,7 +59,6 @@ interaction.
 ```svelte {10}
 <script lang="ts">
 	import { createDialog } from '@melt-ui/svelte'
-	import { writable } from 'svelte/store'
 
 	const {
 		elements: { trigger, overlay, content, title, description, close },


### PR DESCRIPTION
Remove an unused `import` in the docs
This also closes https://github.com/melt-ui/melt-ui/issues/1097