### PR TITLE
feat: add rootMargin to TableOfContents builder

### DIFF
--- a/.changeset/rude-pugs-tease.md
+++ b/.changeset/rude-pugs-tease.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": minor
+---
+
+feat: add rootMargin to TableOfContents builder

--- a/src/docs/data/builders/table-of-contents.ts
+++ b/src/docs/data/builders/table-of-contents.ts
@@ -36,6 +36,12 @@ const builder: APISchema = {
 `'lowest-parents'` means that parents of the heading with the lowest visible content are also considered active, and the same goes for `'highest-parents'`.",
 		},
 		{
+			name: 'rootMargin',
+			type: 'string',
+			description:
+				'The root margin for the intersection observer. Refer to the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/rootMargin) for more information.',
+		},
+		{
 			name: 'scrollOffset',
 			type: 'number',
 			default: '0',

--- a/src/lib/builders/table-of-contents/create.ts
+++ b/src/lib/builders/table-of-contents/create.ts
@@ -32,6 +32,7 @@ export function createTableOfContents(args: CreateTableOfContentsArgs) {
 		selector,
 		exclude,
 		activeType,
+		rootMargin,
 		scrollBehaviour,
 		scrollOffset,
 		headingFilterFn,
@@ -301,6 +302,7 @@ export function createTableOfContents(args: CreateTableOfContentsArgs) {
 			observer = new IntersectionObserver(handleElementObservation, {
 				root: null,
 				threshold: observer_threshold,
+				rootMargin,
 			});
 			elementsList.forEach((el) => observer?.observe(el));
 		}

--- a/src/lib/builders/table-of-contents/types.ts
+++ b/src/lib/builders/table-of-contents/types.ts
@@ -49,6 +49,10 @@ export type CreateTableOfContentsArgs = {
 	 */
 	activeType?: ActiveType;
 	/**
+	 * Root margin for the intersection observer.
+	 */
+	rootMargin?: string;
+	/**
 	 * A custom filter function for headings.
 	 */
 	headingFilterFn?: HeadingFilterFn;

--- a/src/lib/builders/table-of-contents/types.ts
+++ b/src/lib/builders/table-of-contents/types.ts
@@ -49,7 +49,7 @@ export type CreateTableOfContentsArgs = {
 	 */
 	activeType?: ActiveType;
 	/**
-	 * Root margin for the intersection observer.
+	 * The root margin for the intersection observer. Refer to the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/rootMargin) for more information.
 	 */
 	rootMargin?: string;
 	/**


### PR DESCRIPTION
## Motivation
TableOfContents interaction observer allows passing in scroll offset, which can be used to account for fixed/sticky headers when scrolling, but there is no way to cater for that in interaction observer.

## Changes
This PR adds a rootMargin argument for TableOfContents builder, which is then passed to the InteractionObserver constructor, thus catering for viewport customisation and use cases like fixed headers/footers.