### PR TITLE
fix: show toasts with `closeDelay: undefined`

### DIFF
--- a/src/lib/builders/toast/create.ts
+++ b/src/lib/builders/toast/create.ts
@@ -33,9 +33,9 @@ export function createToaster<T = object>(props?: CreateToasterProps) {
 
 	const addToast = (props: AddToastProps<T>) => {
 		const propsWithDefaults = {
-			...props,
 			closeDelay: closeDelay.get(),
 			type: type.get(),
+			...props,
 		} satisfies AddToastProps<T>;
 
 		const ids = {
@@ -49,7 +49,7 @@ export function createToaster<T = object>(props?: CreateToasterProps) {
 				? null
 				: window.setTimeout(() => {
 						removeToast(ids.content);
-				  }, propsWithDefaults.closeDelay);
+				  }, propsWithDefaults.closeDelay ?? defaults.closeDelay);
 
 		const getPercentage = () => {
 			const { createdAt, pauseDuration, closeDelay, pausedAt } = toast;

--- a/src/lib/builders/toast/create.ts
+++ b/src/lib/builders/toast/create.ts
@@ -33,9 +33,9 @@ export function createToaster<T = object>(props?: CreateToasterProps) {
 
 	const addToast = (props: AddToastProps<T>) => {
 		const propsWithDefaults = {
-			closeDelay: closeDelay.get(),
-			type: type.get(),
 			...props,
+			closeDelay: props.closeDelay ?? closeDelay.get(),
+			type: props.type ?? type.get(),
 		} satisfies AddToastProps<T>;
 
 		const ids = {
@@ -49,7 +49,7 @@ export function createToaster<T = object>(props?: CreateToasterProps) {
 				? null
 				: window.setTimeout(() => {
 						removeToast(ids.content);
-				  }, propsWithDefaults.closeDelay ?? defaults.closeDelay);
+				  }, propsWithDefaults.closeDelay);
 
 		const getPercentage = () => {
 			const { createdAt, pauseDuration, closeDelay, pausedAt } = toast;

--- a/src/lib/builders/toast/create.ts
+++ b/src/lib/builders/toast/create.ts
@@ -33,9 +33,9 @@ export function createToaster<T = object>(props?: CreateToasterProps) {
 
 	const addToast = (props: AddToastProps<T>) => {
 		const propsWithDefaults = {
+			...props,
 			closeDelay: closeDelay.get(),
 			type: type.get(),
-			...props,
 		} satisfies AddToastProps<T>;
 
 		const ids = {


### PR DESCRIPTION
## Description

This PR fixes a small issue with toasts not showing up when passing `closeDelay: undefined`. The expected behaviour would be that the toasts are shown for the default 5 seconds.

I tried to simply move the spreading of the props in the creation of the `propsWithDefaults` variable, which does work - kind of. The problem then would be that `closeDelay` could not be changed then...

So I checked if the closeDelay is undefined and use the default instead. I'm not sure if the solution is what you had in mind and if you wanted a better or more verbose approach, but this ensures the correct bahaviour.

Closes #1176 