### PR TITLE
fix(slider): incorrect `onValueCommitted` calls

### DIFF
--- a/.changeset/fifty-suits-reflect.md
+++ b/.changeset/fifty-suits-reflect.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+fix(slider): `onValueCommitted` called if the slider had an active state

--- a/src/lib/builders/slider/create.ts
+++ b/src/lib/builders/slider/create.ts
@@ -521,11 +521,11 @@ export const createSlider = (props?: CreateSliderProps) => {
 			};
 
 			const pointerUp = () => {
-				isActive.set(false);
-
-				if (withDefaults?.onValueCommitted) {
+				if (withDefaults?.onValueCommitted && isActive.get()) {
 					withDefaults.onValueCommitted(value.get());
 				}
+
+				isActive.set(false);
 			};
 
 			const unsub = executeCallbacks(


### PR DESCRIPTION
### Motivation

This is a small bug/edge case that was introduced with the addition of
`onValueCommitted` in #1212. I basically discovered the problem when I was using
a `select` within a `Slider`, that the `select` component would not open since
the state was being updated due to incorrect `onValueCommitted` calls.
With this fix, we ensure that `onValueCommitted` is only called when the
`Slider` was actually active, meaning that the `onmousedown` was called in one
of the thumbs of the `Slider`.
