### PR TITLE
chore: add `prepare` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 		"dev": "vite dev",
 		"build": "vite build && npm run package",
 		"deploy": "vite build",
+		"prepare": "svelte-kit sync",
 		"preview": "vite preview",
 		"package": "svelte-kit sync && svelte-package && publint",
 		"prepublishOnly": "npm run package",


### PR DESCRIPTION
After cloning the repository and installing the dependencies, it would be nice
if `svelte-kit sync` was executed automatically and preparing the repository
(basically adding all the types and tsconfig files).
