### PR TITLE
fix(Calendar): sometimes first day of next month is missing

### DIFF
--- a/.changeset/curly-mails-jump.md
+++ b/.changeset/curly-mails-jump.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": patch
+---
+
+fix(Calendar): sometimes first day of next month is missing

--- a/src/lib/internal/helpers/date/calendar.ts
+++ b/src/lib/internal/helpers/date/calendar.ts
@@ -94,7 +94,7 @@ function createMonth(props: CreateMonthProps): Month<DateValue> {
 		let startFrom = nextMonthDays[nextMonthDays.length - 1];
 
 		if (!startFrom) {
-			startFrom = dateObj.add({ months: 1 }).set({ day: 1 });
+			startFrom = endOfMonth(dateObj);
 		}
 
 		const extraDaysArray = Array.from({ length: extraDays }, (_, i) => {


### PR DESCRIPTION
Solves https://github.com/melt-ui/melt-ui/issues/1213.

This was solved by me in https://github.com/radix-vue/radix-vue/pull/1029 but @epr3 suggest you might also need this fix. 

Root cause: when 6th week will start in new month then `startFrom` will be `undefined`. Currently `if (!startFrom)` was using first day of next month, but then in creation of extraDaysArray all dates were incremented which resulted in first day of new month being missed.

I am not familliar with Svelte so I do not have any test case for this. But you might want to cross check with how it **might be** tested in radix-vue: https://github.com/radix-vue/radix-vue/pull/1029/files#diff-a067dd33cc3ddceb2d881b1d1984509071d713079564a97d9ea182084284e2f8

At least using August 2024 instead of January 1980 might help if you are into this, but my conclusion is it most probably will not be worth it, especially from performance perspective. 