### PR TITLE
Feat: add a pushState function as parameter to the table of content builder

### DIFF
--- a/.changeset/purple-eggs-flow.md
+++ b/.changeset/purple-eggs-flow.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": minor
+---
+
+feat: add a pushState prop to createTableOfContents

--- a/src/docs/data/builders/table-of-contents.ts
+++ b/src/docs/data/builders/table-of-contents.ts
@@ -60,6 +60,12 @@ const builder: APISchema = {
 			description:
 				'Allows you to overwrite the default scroll function with your own custom one. The scroll function gets the heading id passed to it.',
 		},
+		{
+			name: 'pushStateFn',
+			type: 'PushStateFn',
+			description:
+				"Allows you to overwrite the browser pushState function. The pushState function receives the fragment that corresponds to the heading id. It is intended to be used with SvelteKit's navigation module.",
+		},
 	],
 	builders: [
 		{

--- a/src/docs/previews/table-of-contents/main/tailwind/index.svelte
+++ b/src/docs/previews/table-of-contents/main/tailwind/index.svelte
@@ -2,6 +2,7 @@
 	import { Bird } from '$icons/index.js';
 	import Tree from './tree.svelte';
 	import { createTableOfContents } from '$lib/index.js';
+	import { pushState } from '$app/navigation';
 
 	const {
 		elements: { item },
@@ -10,6 +11,7 @@
 		selector: '#toc-builder-preview',
 		exclude: ['h1', 'h4', 'h5', 'h6'],
 		activeType: 'all',
+		pushStateFn: pushState,
 		headingFilterFn: (heading) => !heading.hasAttribute('data-toc-ignore'),
 		scrollFn: (id) => {
 			/**

--- a/src/docs/previews/table-of-contents/main/tailwind/index.svelte
+++ b/src/docs/previews/table-of-contents/main/tailwind/index.svelte
@@ -11,6 +11,10 @@
 		selector: '#toc-builder-preview',
 		exclude: ['h1', 'h4', 'h5', 'h6'],
 		activeType: 'all',
+		/**
+		 * Here we can optionally provide SvelteKit's `pushState` function.
+		 * This function preserve navigation state within the framework.
+		 */
 		pushStateFn: pushState,
 		headingFilterFn: (heading) => !heading.hasAttribute('data-toc-ignore'),
 		scrollFn: (id) => {

--- a/src/lib/builders/table-of-contents/create.ts
+++ b/src/lib/builders/table-of-contents/create.ts
@@ -36,6 +36,7 @@ export function createTableOfContents(args: CreateTableOfContentsArgs) {
 		scrollOffset,
 		headingFilterFn,
 		scrollFn,
+		pushStateFn,
 	} = argsWithDefaults;
 
 	const { name } = createElHelpers('table-of-contents');
@@ -373,7 +374,11 @@ export function createTableOfContents(args: CreateTableOfContentsArgs) {
 
 					// Add items hash to URL
 					if (id) {
-						history.pushState({}, '', `#${id}`);
+						if (pushStateFn) {
+							pushStateFn(`#${id}`, {});
+						} else {
+							history.pushState({}, '', `#${id}`);
+						}
 					}
 				})
 			);

--- a/src/lib/builders/table-of-contents/types.ts
+++ b/src/lib/builders/table-of-contents/types.ts
@@ -20,7 +20,7 @@ export type HeadingFilterFn = (heading: HTMLHeadingElement) => boolean;
 
 export type ScrollFn = (id: string) => void;
 
-export type pushStateFn = (url: string | URL, state: object) => void;
+export type PushStateFn = (url: string | URL, state: object) => void;
 
 export type CreateTableOfContentsArgs = {
 	/**
@@ -62,7 +62,7 @@ export type CreateTableOfContentsArgs = {
 	/**
 	 * A custom pushState function, expected to be SvelteKit's pushState function.
 	 */
-	pushStateFn?: pushStateFn;
+	pushStateFn?: PushStateFn;
 };
 
 export type ElementHeadingLU = {

--- a/src/lib/builders/table-of-contents/types.ts
+++ b/src/lib/builders/table-of-contents/types.ts
@@ -20,6 +20,8 @@ export type HeadingFilterFn = (heading: HTMLHeadingElement) => boolean;
 
 export type ScrollFn = (id: string) => void;
 
+export type pushStateFn = (url: string | URL, state: object) => void;
+
 export type CreateTableOfContentsArgs = {
 	/**
 	 * The ID of the container holding the page content.
@@ -56,6 +58,11 @@ export type CreateTableOfContentsArgs = {
 	 * A custom scroll function.
 	 */
 	scrollFn?: ScrollFn;
+
+	/**
+	 * A custom pushState function, expected to be SvelteKit's pushState function.
+	 */
+	pushStateFn?: pushStateFn;
 };
 
 export type ElementHeadingLU = {


### PR DESCRIPTION
Hello! This is a first attempt to provide the pushState function from SvelteKit to the Table of Contents builder. Using history.pushState not only throws a warning but also breaks some of SvelteKit's $page store state. I'd love to hear your comments and explore other possible implementation approaches.