### PR TITLE
fix: #1214 Search input not auto focused on activation

### DIFF
--- a/src/routes/(landing-ui)/search.svelte
+++ b/src/routes/(landing-ui)/search.svelte
@@ -52,7 +52,7 @@
 			}
 			return next;
 		},
-		openFocus: comboboxInput,
+		openFocus: () => comboboxInput,
 	});
 
 	let search: Promise<PagefindSearchFragment[]> | null = null;


### PR DESCRIPTION
fixes #1214 
Basically when a user presses Ctrl + K or clicks the search icon, the search input should pop up and the input field should be auto focused. Before this pr the `openFocus` of the search dialog ran before the input field was rendered which passed undefined to `createDialog()` and the focus remained at the default element rather than search input. This pr fix that autofocus issue.