### PR TITLE
fix: compatibility with exactOptionalPropertyTypes

### DIFF
--- a/src/lib/builders/accordion/types.ts
+++ b/src/lib/builders/accordion/types.ts
@@ -12,14 +12,14 @@ export type CreateAccordionProps<Multiple extends boolean = false> = {
 	 *
 	 * @default false
 	 */
-	multiple?: Multiple;
+	multiple?: Multiple | undefined;
 
 	/**
 	 * When `true`, prevents the user from interacting with the accordion.
 	 *
 	 * @default false
 	 */
-	disabled?: boolean;
+	disabled?: boolean | undefined;
 
 	/**
 	 * Whether the accordion content should be displayed even if it is not open.
@@ -29,12 +29,12 @@ export type CreateAccordionProps<Multiple extends boolean = false> = {
 	 *
 	 * @default false
 	 */
-	forceVisible?: boolean;
+	forceVisible?: boolean | undefined;
 
 	/**
 	 * The uncontrolled default value of the accordion.
 	 */
-	defaultValue?: AccordionValue<Multiple>;
+	defaultValue?: AccordionValue<Multiple> | undefined;
 
 	/**
 	 * The controlled value store for the accordion.
@@ -55,7 +55,7 @@ export type CreateAccordionProps<Multiple extends boolean = false> = {
 export type AccordionItemProps =
 	| {
 			value: string;
-			disabled?: boolean;
+			disabled?: boolean | undefined;
 	  }
 	| string;
 

--- a/src/lib/builders/avatar/types.ts
+++ b/src/lib/builders/avatar/types.ts
@@ -18,21 +18,21 @@ export type CreateAvatarProps = {
 	 *
 	 * @default 0
 	 */
-	delayMs?: number;
+	delayMs?: number | undefined;
 
 	/**
 	 * The controlled loading status store for the avatar.
 	 *
 	 * @see https://melt-ui.com/docs/controlled#bring-your-own-store
 	 */
-	loadingStatus?: Writable<ImageLoadingStatus>;
+	loadingStatus?: Writable<ImageLoadingStatus> | undefined;
 
 	/**
 	 * A callback invoked when the loading status store of the avatar changes.
 	 *
 	 * @see https://melt-ui.com/docs/controlled#change-functions
 	 */
-	onLoadingStatusChange?: ChangeFn<ImageLoadingStatus>;
+	onLoadingStatusChange?: ChangeFn<ImageLoadingStatus> | undefined;
 };
 
 export type Avatar = BuilderReturn<typeof createAvatar>;

--- a/src/lib/builders/calendar/types.ts
+++ b/src/lib/builders/calendar/types.ts
@@ -23,7 +23,7 @@ export type CreateCalendarProps<
 	 *
 	 * @default false
 	 */
-	preventDeselect?: boolean;
+	preventDeselect?: boolean | undefined;
 
 	/**
 	 * The minimum selectable date. When provided, the
@@ -32,7 +32,7 @@ export type CreateCalendarProps<
 	 *
 	 * @default undefined
 	 */
-	minValue?: DateValue;
+	minValue?: DateValue | undefined;
 
 	/**
 	 * The maximum selectable date. When provided, the
@@ -41,7 +41,7 @@ export type CreateCalendarProps<
 	 *
 	 * @default undefined
 	 */
-	maxValue?: DateValue;
+	maxValue?: DateValue | undefined;
 
 	/**
 	 * The default value for the date picker. When provided,
@@ -50,7 +50,7 @@ export type CreateCalendarProps<
 	 *
 	 * @default undefined;
 	 */
-	defaultValue?: S;
+	defaultValue?: S | undefined;
 
 	/**
 	 * A function called when the value of the date picker changes.
@@ -62,7 +62,7 @@ export type CreateCalendarProps<
 	 *
 	 * @default undefined
 	 */
-	onValueChange?: ChangeFn<S | undefined>;
+	onValueChange?: ChangeFn<S | undefined> | undefined;
 
 	/**
 	 * A writable store than can be used to control the value of the
@@ -72,7 +72,7 @@ export type CreateCalendarProps<
 	 *
 	 * @default undefined;
 	 */
-	value?: Writable<S | undefined>;
+	value?: Writable<S | undefined> | undefined;
 
 	/**
 	 * The date that is used to display the initial month and
@@ -86,7 +86,7 @@ export type CreateCalendarProps<
 	 *
 	 * @default CalendarDate - the current date at midnight.
 	 */
-	defaultPlaceholder?: DateValue;
+	defaultPlaceholder?: DateValue | undefined;
 
 	/**
 	 * A writable store that can be used to externally control the placeholder date.
@@ -103,7 +103,7 @@ export type CreateCalendarProps<
 	 *
 	 * @default Writable<CalendarDate> - set to the current date at midnight.
 	 */
-	placeholder?: Writable<DateValue>;
+	placeholder?: Writable<DateValue> | undefined;
 
 	/**
 	 * A function called when the placeholder value changes. It takes a single argument,
@@ -117,7 +117,7 @@ export type CreateCalendarProps<
 	 *
 	 * @default undefined
 	 */
-	onPlaceholderChange?: ChangeFn<DateValue>;
+	onPlaceholderChange?: ChangeFn<DateValue> | undefined;
 
 	/**
 	 * Applicable only when `numberOfMonths` is greater than 1.
@@ -132,7 +132,7 @@ export type CreateCalendarProps<
 	 *
 	 * @default false
 	 */
-	pagedNavigation?: boolean;
+	pagedNavigation?: boolean | undefined;
 
 	/**
 	 * The day of the week to start the calendar on, which must
@@ -141,7 +141,7 @@ export type CreateCalendarProps<
 	 *
 	 * @defaultValue 0 (Sunday)
 	 */
-	weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+	weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | undefined;
 
 	/**
 	 * How the string representation of the weekdays provided via the `weekdays` state store
@@ -157,7 +157,7 @@ export type CreateCalendarProps<
 	 *
 	 * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#weekday
 	 */
-	weekdayFormat?: Intl.DateTimeFormatOptions['weekday'];
+	weekdayFormat?: Intl.DateTimeFormatOptions['weekday'] | undefined;
 
 	/**
 	 * A function that receives a date and returns `true` or `false` to indicate whether
@@ -171,7 +171,7 @@ export type CreateCalendarProps<
 	 *
 	 * @default undefined;
 	 */
-	isDateDisabled?: Matcher;
+	isDateDisabled?: Matcher | undefined;
 
 	/**
 	 * Dates matching the provided matchers are marked as "unavailable." Unlike disabled dates,
@@ -186,7 +186,7 @@ export type CreateCalendarProps<
 	 *
 	 * @default undefined;
 	 */
-	isDateUnavailable?: Matcher;
+	isDateUnavailable?: Matcher | undefined;
 
 	/**
 	 * Display 6 weeks per month, regardless the month's number of weeks.
@@ -198,7 +198,7 @@ export type CreateCalendarProps<
 	 *
 	 * @default false
 	 */
-	fixedWeeks?: boolean;
+	fixedWeeks?: boolean | undefined;
 
 	/**
 	 * Determines the number of months to display on the calendar simultaneously.
@@ -206,7 +206,7 @@ export type CreateCalendarProps<
 	 *
 	 * @default 1
 	 */
-	numberOfMonths?: number;
+	numberOfMonths?: number | undefined;
 
 	/**
 	 * This label is exclusively used for accessibility, remaining hidden from the page.
@@ -218,21 +218,21 @@ export type CreateCalendarProps<
 	 * - 'Appointment date' will be read as 'Appointment date, January 2021' if the current month is January 2021.
 	 * - 'Booking date' will be read as 'Booking date, January 2021' if the current month is January 2021.
 	 */
-	calendarLabel?: string;
+	calendarLabel?: string | undefined;
 
 	/**
 	 * The default locale setting.
 	 *
 	 * @default 'en'
 	 */
-	locale?: string;
+	locale?: string | undefined;
 
 	/**
 	 * The default locale setting.
 	 *
 	 * @default 'en'
 	 */
-	multiple?: Multiple;
+	multiple?: Multiple | undefined;
 
 	/**
 	 * Whether the calendar is disabled. When true, the user will not
@@ -241,7 +241,7 @@ export type CreateCalendarProps<
 	 *
 	 * @default false
 	 */
-	disabled?: boolean;
+	disabled?: boolean | undefined;
 
 	/**
 	 * Whether the calendar is readonly. When true, the user will be able
@@ -251,12 +251,12 @@ export type CreateCalendarProps<
 	 *
 	 * @default false
 	 */
-	readonly?: boolean;
+	readonly?: boolean | undefined;
 
 	/**
 	 * Optionally override the default ids we assign to the elements
 	 */
-	ids?: Partial<IdObj<CalendarIdParts>>;
+	ids?: Partial<IdObj<CalendarIdParts>> | undefined;
 };
 
 export type Calendar = ReturnType<typeof createCalendar>;

--- a/src/lib/builders/checkbox/types.ts
+++ b/src/lib/builders/checkbox/types.ts
@@ -10,35 +10,35 @@ export type CreateCheckboxProps = {
 	 *
 	 * @default false
 	 */
-	disabled?: boolean;
+	disabled?: boolean | undefined;
 
 	/**
 	 * When `true`, indicates that the user must check the checkbox before the owning form can be submitted.
 	 *
 	 * @default false;
 	 */
-	required?: boolean;
+	required?: boolean | undefined;
 
 	/**
 	 * The name of the checkbox. Submitted with its owning form as part of a name/value pair.
 	 *
 	 * @default undefined
 	 */
-	name?: string;
+	name?: string | undefined;
 
 	/**
 	 * The value given as data when submitted with a `name`.
 	 *
 	 * @default 'on'
 	 */
-	value?: string;
+	value?: string | undefined;
 
 	/**
 	 * The uncontrolled default checked status of the checkbox.
 	 *
 	 * @default false
 	 */
-	defaultChecked?: boolean | 'indeterminate';
+	defaultChecked?: boolean | 'indeterminate' | undefined;
 
 	/**
 	 * The controlled checked state store of the checkbox.
@@ -46,14 +46,14 @@ export type CreateCheckboxProps = {
 	 *
 	 * @see https://melt-ui.com/docs/controlled#bring-your-own-store
 	 */
-	checked?: Writable<boolean | 'indeterminate'>;
+	checked?: Writable<boolean | 'indeterminate'> | undefined;
 
 	/**
 	 * The callback invoked when the checked state store of the checkbox changes.
 	 *
 	 * @see https://melt-ui.com/docs/controlled#change-functions
 	 */
-	onCheckedChange?: ChangeFn<boolean | 'indeterminate'>;
+	onCheckedChange?: ChangeFn<boolean | 'indeterminate'> | undefined;
 };
 
 export type Checkbox = BuilderReturn<typeof createCheckbox>;

--- a/src/lib/builders/collapsible/types.ts
+++ b/src/lib/builders/collapsible/types.ts
@@ -8,7 +8,7 @@ export type CreateCollapsibleProps = {
 	/**
 	 * Whether the collapsible is disabled which prevents it from being opened.
 	 */
-	disabled?: boolean;
+	disabled?: boolean | undefined;
 
 	/**
 	 * Whether the collapsible content should be displayed even if it is not open.
@@ -18,14 +18,14 @@ export type CreateCollapsibleProps = {
 	 *
 	 * @default false
 	 */
-	forceVisible?: boolean;
+	forceVisible?: boolean | undefined;
 
 	/**
 	 * Whether the collapsible is open by default.
 	 *
 	 * @default false
 	 */
-	defaultOpen?: boolean;
+	defaultOpen?: boolean | undefined;
 
 	/**
 	 * Optionally pass a writable store to control the open state of the collapsible.
@@ -33,14 +33,14 @@ export type CreateCollapsibleProps = {
 	 *
 	 * @see https://melt-ui.com/docs/controlled#bring-your-own-store
 	 */
-	open?: Writable<boolean>;
+	open?: Writable<boolean> | undefined;
 
 	/**
 	 * A callback called when the value of the `open` store should be changed.
 	 *
 	 * @see https://melt-ui.com/docs/controlled#change-functions
 	 */
-	onOpenChange?: ChangeFn<boolean>;
+	onOpenChange?: ChangeFn<boolean> | undefined;
 };
 
 export type Collapsible = BuilderReturn<typeof createCollapsible>;

--- a/src/lib/builders/date-field/types.ts
+++ b/src/lib/builders/date-field/types.ts
@@ -12,7 +12,7 @@ export type DateFieldProps = {
 	 *
 	 * @default undefined;
 	 */
-	defaultValue?: DateValue;
+	defaultValue?: DateValue | undefined;
 
 	/**
 	 * A function called when the value of the date field changes.
@@ -24,7 +24,7 @@ export type DateFieldProps = {
 	 *
 	 * @default undefined
 	 */
-	onValueChange?: ChangeFn<DateValue | undefined>;
+	onValueChange?: ChangeFn<DateValue | undefined> | undefined;
 
 	/**
 	 * A writable store than can be used to control the value of the
@@ -34,7 +34,7 @@ export type DateFieldProps = {
 	 *
 	 * @default undefined;
 	 */
-	value?: Writable<DateValue | undefined>;
+	value?: Writable<DateValue | undefined> | undefined;
 
 	/**
 	 * The date that is used when the date field is empty to
@@ -42,7 +42,7 @@ export type DateFieldProps = {
 	 *
 	 * @default CalendarDate - the current date at midnight.
 	 */
-	defaultPlaceholder?: DateValue;
+	defaultPlaceholder?: DateValue | undefined;
 
 	/**
 	 * A writable store that can be used to control the placeholder
@@ -55,7 +55,7 @@ export type DateFieldProps = {
 	 * the field. The `placeholder` store is used as the starting
 	 * point for cycling through the individual date segments.
 	 */
-	placeholder?: Writable<DateValue>;
+	placeholder?: Writable<DateValue> | undefined;
 
 	/**
 	 * A function called when the placeholder value changes. It receives
@@ -70,7 +70,7 @@ export type DateFieldProps = {
 	 *
 	 * @default undefined
 	 */
-	onPlaceholderChange?: ChangeFn<DateValue>;
+	onPlaceholderChange?: ChangeFn<DateValue> | undefined;
 
 	/**
 	 * Any dates that match the provided matchers will be
@@ -79,7 +79,7 @@ export type DateFieldProps = {
 	 *
 	 * @default undefined;
 	 */
-	isDateUnavailable?: Matcher;
+	isDateUnavailable?: Matcher | undefined;
 
 	/**
 	 * The minimum acceptable date. When provided, the
@@ -88,7 +88,7 @@ export type DateFieldProps = {
 	 *
 	 * @default undefined
 	 */
-	minValue?: DateValue;
+	minValue?: DateValue | undefined;
 
 	/**
 	 * The maximum acceptable date. When provided, the
@@ -97,7 +97,7 @@ export type DateFieldProps = {
 	 *
 	 * @default undefined
 	 */
-	maxValue?: DateValue;
+	maxValue?: DateValue | undefined;
 
 	/**
 	 * If true, the date field will be disabled and users
@@ -106,7 +106,7 @@ export type DateFieldProps = {
 	 *
 	 * @default false
 	 */
-	disabled?: boolean;
+	disabled?: boolean | undefined;
 
 	/**
 	 * If true, the date field will be readonly, and users
@@ -115,7 +115,7 @@ export type DateFieldProps = {
 	 *
 	 * @default false
 	 */
-	readonly?: boolean;
+	readonly?: boolean | undefined;
 
 	/**
 	 *
@@ -123,7 +123,7 @@ export type DateFieldProps = {
 	 *
 	 * @default undefined
 	 */
-	readonlySegments?: EditableSegmentPart[];
+	readonlySegments?: EditableSegmentPart[] | undefined;
 
 	/**
 	 * The format to use for displaying the time in the input.
@@ -133,14 +133,14 @@ export type DateFieldProps = {
 	 *
 	 * Defaults to the locale's default time format.
 	 */
-	hourCycle?: 12 | 24;
+	hourCycle?: 12 | 24 | undefined;
 
 	/**
 	 * The locale to use for formatting the date field.
 	 *
 	 * @default 'en'
 	 */
-	locale?: string;
+	locale?: string | undefined;
 
 	/**
 	 * The granularity of the date field. This determines which
@@ -158,14 +158,14 @@ export type DateFieldProps = {
 	 *
 	 * @default 'day'
 	 */
-	granularity?: Granularity;
+	granularity?: Granularity | undefined;
 
 	/**
 	 * Whether or not to hide the timeZoneName segment from the date field.
 	 *
 	 * @default false;
 	 */
-	hideTimeZone?: boolean;
+	hideTimeZone?: boolean | undefined;
 
 	/**
 	 * The name to use for the hidden input element of the date field,
@@ -174,7 +174,7 @@ export type DateFieldProps = {
 	 *
 	 * @default undefined;
 	 */
-	name?: string;
+	name?: string | undefined;
 
 	/**
 	 *
@@ -183,7 +183,7 @@ export type DateFieldProps = {
 	 *
 	 * @default false
 	 */
-	required?: boolean;
+	required?: boolean | undefined;
 
 	/**
 	 * Override any of the element IDs set by the builder.
@@ -193,7 +193,7 @@ export type DateFieldProps = {
 	 * accessibility and functionality of the date field if
 	 * implemented incorrectly.
 	 */
-	ids?: Partial<IdObj<DateFieldIdParts>>;
+	ids?: Partial<IdObj<DateFieldIdParts>> | undefined;
 };
 
 export type CreateDateFieldProps = DateFieldProps;

--- a/src/lib/builders/date-picker/types.ts
+++ b/src/lib/builders/date-picker/types.ts
@@ -15,7 +15,7 @@ export type DatePickerProps = {
 	 *
 	 * @default undefined;
 	 */
-	defaultValue?: DateValue;
+	defaultValue?: DateValue | undefined;
 
 	/**
 	 * A function called when the value of the date picker changes.
@@ -27,7 +27,7 @@ export type DatePickerProps = {
 	 *
 	 * @default undefined
 	 */
-	onValueChange?: ChangeFn<DateValue | undefined>;
+	onValueChange?: ChangeFn<DateValue | undefined> | undefined;
 
 	/**
 	 * A writable store than can be used to control the value of the
@@ -37,7 +37,7 @@ export type DatePickerProps = {
 	 *
 	 * @default undefined;
 	 */
-	value?: Writable<DateValue | undefined>;
+	value?: Writable<DateValue | undefined> | undefined;
 
 	/**
 	 * The date that is used to display the initial month and
@@ -51,7 +51,7 @@ export type DatePickerProps = {
 	 *
 	 * @default CalendarDate - the current date at midnight.
 	 */
-	defaultPlaceholder?: DateValue;
+	defaultPlaceholder?: DateValue | undefined;
 
 	/**
 	 * A writable store that can be used to control the placeholder
@@ -74,7 +74,7 @@ export type DatePickerProps = {
 	 *
 	 * @default Writable<CalendarDate> - the current date at midnight.
 	 */
-	placeholder?: Writable<DateValue>;
+	placeholder?: Writable<DateValue> | undefined;
 
 	/**
 	 * A function called when the placeholder value changes. It receives
@@ -89,7 +89,7 @@ export type DatePickerProps = {
 	 *
 	 * @default undefined
 	 */
-	onPlaceholderChange?: ChangeFn<DateValue>;
+	onPlaceholderChange?: ChangeFn<DateValue> | undefined;
 
 	/**
 	 * Any dates that match the provided matchers will
@@ -100,7 +100,7 @@ export type DatePickerProps = {
 	 *
 	 * @default undefined;
 	 */
-	isDateDisabled?: Matcher;
+	isDateDisabled?: Matcher | undefined;
 
 	/**
 	 * Any dates that match the provided matchers will be
@@ -117,12 +117,12 @@ export type DatePickerProps = {
 	 *
 	 * @default undefined;
 	 */
-	isDateUnavailable?: Matcher;
+	isDateUnavailable?: Matcher | undefined;
 
 	/**
 	 * @default 'en'
 	 */
-	locale?: string;
+	locale?: string | undefined;
 };
 
 type ModifiedDateFieldProps = Omit<

--- a/src/lib/builders/date-range-field/types.ts
+++ b/src/lib/builders/date-range-field/types.ts
@@ -12,7 +12,7 @@ export type DateRangeFieldProps = {
 	 *
 	 * @default undefined;
 	 */
-	defaultValue?: DateRange;
+	defaultValue?: DateRange | undefined;
 
 	/**
 	 * A function called when the value of the date field changes.
@@ -24,7 +24,7 @@ export type DateRangeFieldProps = {
 	 *
 	 * @default undefined
 	 */
-	onValueChange?: ChangeFn<DateRange>;
+	onValueChange?: ChangeFn<DateRange> | undefined;
 
 	/**
 	 * A writable store than can be used to control the value of the
@@ -34,7 +34,7 @@ export type DateRangeFieldProps = {
 	 *
 	 * @default undefined;
 	 */
-	value?: Writable<DateRange>;
+	value?: Writable<DateRange> | undefined;
 
 	/**
 	 * The date that is used when the date field is empty to
@@ -42,7 +42,7 @@ export type DateRangeFieldProps = {
 	 *
 	 * @default CalendarDate - the current date at midnight.
 	 */
-	defaultPlaceholder?: DateValue;
+	defaultPlaceholder?: DateValue | undefined;
 
 	/**
 	 * A writable store that can be used to control the placeholder
@@ -57,7 +57,7 @@ export type DateRangeFieldProps = {
 	 *
 	 * @default Writable<CalendarDate> - the current date at midnight.
 	 */
-	placeholder?: Writable<DateValue>;
+	placeholder?: Writable<DateValue> | undefined;
 
 	/**
 	 * A function called when the placeholder value changes. It receives
@@ -72,7 +72,7 @@ export type DateRangeFieldProps = {
 	 *
 	 * @default undefined
 	 */
-	onPlaceholderChange?: ChangeFn<DateValue>;
+	onPlaceholderChange?: ChangeFn<DateValue> | undefined;
 
 	/**
 	 * Any dates that match the provided matchers will be
@@ -81,24 +81,24 @@ export type DateRangeFieldProps = {
 	 *
 	 * @default undefined;
 	 */
-	isDateUnavailable?: Matcher;
+	isDateUnavailable?: Matcher | undefined;
 
 	/**
 	 * @default 'en'
 	 */
-	locale?: string;
+	locale?: string | undefined;
 
 	/**
 	 * The value to be used as the `name` attribute for the
 	 * `startHiddenInput` element.
 	 */
-	startName?: string;
+	startName?: string | undefined;
 
 	/**
 	 * The value to be used as the `name` attribute for the
 	 * `endHiddenInput` element.
 	 */
-	endName?: string;
+	endName?: string | undefined;
 
 	/**
 	 *
@@ -106,7 +106,7 @@ export type DateRangeFieldProps = {
 	 *
 	 * @default undefined
 	 */
-	readonlySegments?: { start: EditableSegmentPart[]; end: EditableSegmentPart[] };
+	readonlySegments?: { start: EditableSegmentPart[]; end: EditableSegmentPart[] } | undefined;
 
 	/**
 	 * Override any of the element IDs set by the builder.
@@ -116,9 +116,9 @@ export type DateRangeFieldProps = {
 	 * accessibility and functionality of the date field if
 	 * implemented incorrectly.
 	 */
-	ids?: Partial<IdObj<DateRangeFieldIdParts>>;
-	startIds?: Partial<IdObj<DateFieldIdParts>>;
-	endIds?: Partial<IdObj<DateFieldIdParts>>;
+	ids?: Partial<IdObj<DateRangeFieldIdParts>> | undefined;
+	startIds?: Partial<IdObj<DateFieldIdParts>> | undefined;
+	endIds?: Partial<IdObj<DateFieldIdParts>> | undefined;
 };
 
 export type CreateDateRangeFieldProps = Expand<

--- a/src/lib/builders/date-range-picker/types.ts
+++ b/src/lib/builders/date-range-picker/types.ts
@@ -15,7 +15,7 @@ type DateRangePickerProps = {
 	 *
 	 * @default undefined;
 	 */
-	defaultValue?: DateRange;
+	defaultValue?: DateRange | undefined;
 
 	/**
 	 * A function called when the value of the date field changes.
@@ -27,7 +27,7 @@ type DateRangePickerProps = {
 	 *
 	 * @default undefined
 	 */
-	onValueChange?: ChangeFn<DateRange>;
+	onValueChange?: ChangeFn<DateRange> | undefined;
 
 	/**
 	 * A writable store than can be used to control the value of the
@@ -37,7 +37,7 @@ type DateRangePickerProps = {
 	 *
 	 * @default undefined;
 	 */
-	value?: Writable<DateRange>;
+	value?: Writable<DateRange> | undefined;
 
 	/**
 	 * The date that is used to display the initial month and
@@ -51,7 +51,7 @@ type DateRangePickerProps = {
 	 *
 	 * @default CalendarDate - the current date at midnight.
 	 */
-	defaultPlaceholder?: DateValue;
+	defaultPlaceholder?: DateValue | undefined;
 
 	/**
 	 * A writable store that can be used to control the placeholder
@@ -74,7 +74,7 @@ type DateRangePickerProps = {
 	 *
 	 * @default Writable<CalendarDate> - the current date at midnight.
 	 */
-	placeholder?: Writable<DateValue>;
+	placeholder?: Writable<DateValue> | undefined;
 
 	/**
 	 * A function called when the placeholder value changes. It receives
@@ -89,7 +89,7 @@ type DateRangePickerProps = {
 	 *
 	 * @default undefined
 	 */
-	onPlaceholderChange?: ChangeFn<DateValue>;
+	onPlaceholderChange?: ChangeFn<DateValue> | undefined;
 
 	/**
 	 * Any dates that match the provided matchers will
@@ -100,7 +100,7 @@ type DateRangePickerProps = {
 	 *
 	 * @default undefined;
 	 */
-	isDateDisabled?: Matcher;
+	isDateDisabled?: Matcher | undefined;
 
 	/**
 	 * Any dates that match the provided matchers will be
@@ -117,12 +117,12 @@ type DateRangePickerProps = {
 	 *
 	 * @default undefined;
 	 */
-	isDateUnavailable?: Matcher;
+	isDateUnavailable?: Matcher | undefined;
 
 	/**
 	 * @default 'en'
 	 */
-	locale?: string;
+	locale?: string | undefined;
 };
 
 type ModifiedDateFieldProps = Omit<

--- a/src/lib/builders/dialog/types.ts
+++ b/src/lib/builders/dialog/types.ts
@@ -12,7 +12,7 @@ export type CreateDialogProps = {
 	 *
 	 * @default true
 	 */
-	preventScroll?: boolean;
+	preventScroll?: boolean | undefined;
 
 	/**
 	 * Escape behavior type.
@@ -23,14 +23,14 @@ export type CreateDialogProps = {
 	 *
 	 * @defaultValue `close`
 	 */
-	escapeBehavior?: EscapeBehaviorType;
+	escapeBehavior?: EscapeBehaviorType | undefined;
 
 	/**
 	 * If true, the dialog will close when the user clicks outside of it.
 	 *
 	 * @default true
 	 */
-	closeOnOutsideClick?: boolean;
+	closeOnOutsideClick?: boolean | undefined;
 
 	/**
 	 * A custom event handler for the "outside click" event, which
@@ -38,40 +38,40 @@ export type CreateDialogProps = {
 	 * If `event.preventDefault()` is called within the function,
 	 * the dialog will not close when the user clicks outside of it.
 	 */
-	onOutsideClick?: (event: PointerEvent | MouseEvent | TouchEvent) => void;
+	onOutsideClick?: ((event: PointerEvent | MouseEvent | TouchEvent) => void) | undefined;
 
 	/**
 	 * The `role` attribute to apply to the dialog.
 	 *
 	 * @default 'dialog'
 	 */
-	role?: 'dialog' | 'alertdialog';
+	role?: 'dialog' | 'alertdialog' | undefined;
 
 	/**
 	 * If true, the dialog will be open by default.
 	 *
 	 * @default false
 	 */
-	defaultOpen?: boolean;
+	defaultOpen?: boolean | undefined;
 
 	/**
 	 * A writable store that controls the open state of the dialog.
 	 * @see [Controlled Usage](https://melt-ui.com/docs/controlled#bring-your-own-store)
 	 */
-	open?: Writable<boolean>;
+	open?: Writable<boolean> | undefined;
 
 	/**
 	 * A function that will be called when the open state of the dialog changes.
 	 * @see [Controlled Usage](https://melt-ui.com/docs/controlled#change-functions)
 	 */
-	onOpenChange?: ChangeFn<boolean>;
+	onOpenChange?: ChangeFn<boolean> | undefined;
 
 	/**
 	 * If not undefined, the dialog content will be rendered within the provided element or selector.
 	 *
 	 * @default 'body'
 	 */
-	portal?: PortalConfig | null;
+	portal?: PortalConfig | null | undefined;
 
 	/**
 	 * If true, the dialog will be visible regardless of the open state.
@@ -80,24 +80,24 @@ export type CreateDialogProps = {
 	 *
 	 * @default false
 	 */
-	forceVisible?: boolean;
+	forceVisible?: boolean | undefined;
 
 	/**
 	 * Override the default autofocus behavior of the dialog
 	 * on open.
 	 */
-	openFocus?: FocusProp;
+	openFocus?: FocusProp | undefined;
 
 	/**
 	 * Override the default autofocus behavior of the dialog
 	 * on close.
 	 */
-	closeFocus?: FocusProp;
+	closeFocus?: FocusProp | undefined;
 
 	/**
 	 * Optionally override the default ids we assign to the elements
 	 */
-	ids?: Partial<IdObj<DialogIdParts>>;
+	ids?: Partial<IdObj<DialogIdParts>> | undefined;
 };
 
 export type Dialog = BuilderReturn<typeof createDialog>;

--- a/src/lib/builders/hidden-input/types.ts
+++ b/src/lib/builders/hidden-input/types.ts
@@ -3,10 +3,10 @@ import type { HTMLInputAttributes } from 'svelte/elements';
 
 export type CreateHiddenInputProps = {
 	value: MaybeReadable<string>;
-	disabled?: MaybeReadable<boolean>;
+	disabled?: MaybeReadable<boolean> | undefined;
 	name?: MaybeReadable<string | undefined> | undefined;
-	required?: MaybeReadable<boolean>;
-	prefix?: string;
-	type?: MaybeReadable<HTMLInputAttributes['type']>;
-	checked?: MaybeReadable<boolean | undefined | 'indeterminate'>;
+	required?: MaybeReadable<boolean> | undefined;
+	prefix?: string | undefined;
+	type?: MaybeReadable<HTMLInputAttributes['type']> | undefined;
+	checked?: MaybeReadable<boolean | undefined | 'indeterminate'> | undefined;
 };

--- a/src/lib/builders/link-preview/types.ts
+++ b/src/lib/builders/link-preview/types.ts
@@ -15,14 +15,14 @@ export type CreateLinkPreviewProps = {
 	 *
 	 * @default  placement: 'bottom'
 	 */
-	positioning?: FloatingConfig;
+	positioning?: FloatingConfig | undefined;
 
 	/**
 	 * Whether or not the linkpreview is open by default.
 	 *
 	 * @default false
 	 */
-	defaultOpen?: boolean;
+	defaultOpen?: boolean | undefined;
 
 	/**
 	 * A controlled open state store for the linkpreview. If provided, the
@@ -30,21 +30,21 @@ export type CreateLinkPreviewProps = {
 	 *
 	 * @see https://melt-ui.com/docs/controlled#bring-your-own-store
 	 */
-	open?: Writable<boolean>;
+	open?: Writable<boolean> | undefined;
 
 	/**
 	 * A callback for when the open state changes
 	 *
 	 * @see https://melt-ui.com/docs/controlled#change-functions
 	 */
-	onOpenChange?: ChangeFn<boolean>;
+	onOpenChange?: ChangeFn<boolean> | undefined;
 
 	/**
 	 * The delay in milliseconds to hover before opening the linkpreview
 	 *
 	 * @default 700
 	 */
-	openDelay?: number;
+	openDelay?: number | undefined;
 
 	/**
 	 * The delay in milliseconds after the pointer leaves the
@@ -52,7 +52,7 @@ export type CreateLinkPreviewProps = {
 	 *
 	 * @default 300
 	 */
-	closeDelay?: number;
+	closeDelay?: number | undefined;
 
 	/**
 	 * Whether or not to close the linkpreview when the pointer is clicked
@@ -60,7 +60,7 @@ export type CreateLinkPreviewProps = {
 	 *
 	 * @default true
 	 */
-	closeOnOutsideClick?: boolean;
+	closeOnOutsideClick?: boolean | undefined;
 
 	/**
 	 * A custom event handler for the "outside click" event, which
@@ -68,7 +68,7 @@ export type CreateLinkPreviewProps = {
 	 * If `event.preventDefault()` is called within the function,
 	 * the dialog will not close when the user clicks outside of it.
 	 */
-	onOutsideClick?: (event: InteractOutsideEvent) => void;
+	onOutsideClick?: ((event: InteractOutsideEvent) => void) | undefined;
 
 	/**
 	 * Escape behavior type.
@@ -79,21 +79,21 @@ export type CreateLinkPreviewProps = {
 	 *
 	 * @defaultValue `close`
 	 */
-	escapeBehavior?: EscapeBehaviorType;
+	escapeBehavior?: EscapeBehaviorType | undefined;
 
 	/**
 	 * Whether should prevent text selection overflowing the element when the element is the top layer.
 	 *
 	 * @defaultValue `true`
 	 */
-	preventTextSelectionOverflow?: boolean;
+	preventTextSelectionOverflow?: boolean | undefined;
 
 	/**
 	 * The size of the optional arrow element in pixels
 	 *
 	 * @default 8
 	 */
-	arrowSize?: number;
+	arrowSize?: number | undefined;
 
 	/**
 	 * Whether the menu content should be displayed even if it is not open.
@@ -103,19 +103,19 @@ export type CreateLinkPreviewProps = {
 	 *
 	 * @default false
 	 */
-	forceVisible?: boolean;
+	forceVisible?: boolean | undefined;
 
 	/**
 	 * If not undefined, the popover will be rendered within the provided element or selector.
 	 *
 	 * @default 'body'
 	 */
-	portal?: PortalConfig | null;
+	portal?: PortalConfig | null | undefined;
 
 	/**
 	 * Optionally override the default ids we assign to the elements
 	 */
-	ids?: Partial<IdObj<LinkPreviewIdParts>>;
+	ids?: Partial<IdObj<LinkPreviewIdParts>> | undefined;
 };
 
 export type LinkPreview = BuilderReturn<typeof createLinkPreview>;

--- a/src/lib/builders/listbox/types.ts
+++ b/src/lib/builders/listbox/types.ts
@@ -12,7 +12,7 @@ export type { ListboxComponentEvents } from './events.js';
 
 export type ListboxOption<Value = unknown> = {
 	value: Value;
-	label?: string;
+	label?: string | undefined;
 };
 
 export type ListboxSelected<Multiple extends boolean, Value> = WhenTrue<
@@ -31,19 +31,19 @@ export type CreateListboxProps<
 	 *
 	 * @default  placement: 'bottom'
 	 */
-	positioning?: FloatingConfig;
+	positioning?: FloatingConfig | undefined;
 
 	/**
 	 * The size of the arrow in pixels.
 	 * @default undefined
 	 */
-	arrowSize?: number;
+	arrowSize?: number | undefined;
 
 	/**
 	 * Determines behavior when scrolling items into view.
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView#block
 	 */
-	scrollAlignment?: 'nearest' | 'center';
+	scrollAlignment?: 'nearest' | 'center' | undefined;
 
 	/**
 	 * Whether or not the listbox should loop through the list when
@@ -51,11 +51,11 @@ export type CreateListboxProps<
 	 *
 	 * @default true
 	 */
-	loop?: boolean;
+	loop?: boolean | undefined;
 
-	disabled?: boolean;
-	required?: boolean;
-	name?: string;
+	disabled?: boolean | undefined;
+	required?: boolean | undefined;
+	name?: string | undefined;
 
 	/**
 	 * Whether or not the listbox should be open by default
@@ -65,19 +65,19 @@ export type CreateListboxProps<
 	 *
 	 * @default false
 	 */
-	defaultOpen?: boolean;
+	defaultOpen?: boolean | undefined;
 
 	/**
 	 * An optional controlled store that manages the open state of the listbox.
 	 */
-	open?: Writable<boolean>;
+	open?: Writable<boolean> | undefined;
 
 	/**
 	 * Change function that is called when the listbox's `open` state changes.
 	 *
 	 * @see https://melt-ui.com/docs/controlled#change-functions
 	 */
-	onOpenChange?: ChangeFn<boolean>;
+	onOpenChange?: ChangeFn<boolean> | undefined;
 
 	/**
 	 * The default selected option.
@@ -86,19 +86,19 @@ export type CreateListboxProps<
 	 *
 	 * @default undefined
 	 */
-	defaultSelected?: S;
+	defaultSelected?: S | undefined;
 
 	/**
 	 * An optional controlled store that manages the selected option of the listbox.
 	 */
-	selected?: Writable<S>;
+	selected?: Writable<S> | undefined;
 
 	/**
 	 * A change handler for the selected store called when the selected would normally change.
 	 *
 	 * @see https://melt-ui.com/docs/controlled#change-functions
 	 */
-	onSelectedChange?: ChangeFn<S | undefined>;
+	onSelectedChange?: ChangeFn<S | undefined> | undefined;
 
 	/**
 	 * Whether or not to close the listbox menu when the user clicks
@@ -106,7 +106,7 @@ export type CreateListboxProps<
 	 *
 	 * @default true
 	 */
-	closeOnOutsideClick?: boolean;
+	closeOnOutsideClick?: boolean | undefined;
 
 	/**
 	 * Escape behavior type.
@@ -117,7 +117,7 @@ export type CreateListboxProps<
 	 *
 	 * @defaultValue `close`
 	 */
-	escapeBehavior?: EscapeBehaviorType;
+	escapeBehavior?: EscapeBehaviorType | undefined;
 
 	/**
 	 * A custom event handler for the "outside click" event, which
@@ -125,7 +125,7 @@ export type CreateListboxProps<
 	 * If `event.preventDefault()` is called within the function,
 	 * the dialog will not close when the user clicks outside of it.
 	 */
-	onOutsideClick?: (event: InteractOutsideEvent) => void;
+	onOutsideClick?: ((event: InteractOutsideEvent) => void) | undefined;
 
 	/**
 	 * Whether or not to prevent scrolling the page when the
@@ -133,21 +133,21 @@ export type CreateListboxProps<
 	 *
 	 * @default true
 	 */
-	preventScroll?: boolean;
+	preventScroll?: boolean | undefined;
 
 	/**
 	 * Whether should prevent text selection overflowing the element when the element is the top layer.
 	 *
 	 * @defaultValue `true`
 	 */
-	preventTextSelectionOverflow?: boolean;
+	preventTextSelectionOverflow?: boolean | undefined;
 
 	/**
 	 * If not undefined, the listbox menu will be rendered within the provided element or selector.
 	 *
 	 * @default 'body'
 	 */
-	portal?: PortalConfig | null;
+	portal?: PortalConfig | null | undefined;
 
 	/**
 	 * Whether the menu content should be displayed even if it is not open.
@@ -157,42 +157,42 @@ export type CreateListboxProps<
 	 *
 	 * @default false
 	 */
-	forceVisible?: boolean;
+	forceVisible?: boolean | undefined;
 
-	multiple?: Multiple;
+	multiple?: Multiple | undefined;
 
 	/**
 	 * The name of the builder using listbox.
 	 *
 	 * @default 'listbox
 	 */
-	builder?: string;
+	builder?: string | undefined;
 
 	/**
 	 * Whether or not to enable typeahead.
 	 *
 	 * @default true
 	 */
-	typeahead?: boolean;
+	typeahead?: boolean | undefined;
 
 	/**
 	 * IF true, whenever an option is hovered, the highlightedItem will be set to that option.
 	 *
 	 * @default true
 	 */
-	highlightOnHover?: boolean;
+	highlightOnHover?: boolean | undefined;
 
 	/**
 	 * Optionally override the default ids we assign to the elements
 	 */
-	ids?: Partial<IdObj<ListboxIdParts>>;
+	ids?: Partial<IdObj<ListboxIdParts>> | undefined;
 };
 
 export type ListboxOptionProps<Value = unknown> = ListboxOption<Value> & {
 	/**
 	 *  Is the item disabled?
 	 */
-	disabled?: boolean;
+	disabled?: boolean | undefined;
 };
 
 export type Listbox<

--- a/src/lib/builders/menu/types.ts
+++ b/src/lib/builders/menu/types.ts
@@ -16,27 +16,27 @@ export type _CreateMenuProps = {
 	 *
 	 * @default  placement: 'bottom'
 	 */
-	positioning?: FloatingConfig;
+	positioning?: FloatingConfig | undefined;
 
 	/**
 	 * The size of the arrow in pixels.
 	 * @default 8
 	 */
-	arrowSize?: number;
+	arrowSize?: number | undefined;
 
 	/**
 	 * The direction of the text in the dropdown menu
 	 *
 	 * @default 'ltr'
 	 */
-	dir?: TextDirection;
+	dir?: TextDirection | undefined;
 
 	/**
 	 * Whether or not to prevent scrolling when the menu is open.
 	 *
 	 * @default true
 	 */
-	preventScroll?: boolean;
+	preventScroll?: boolean | undefined;
 
 	/**
 	 * Escape behavior type.
@@ -47,28 +47,28 @@ export type _CreateMenuProps = {
 	 *
 	 * @defaultValue `close`
 	 */
-	escapeBehavior?: EscapeBehaviorType;
+	escapeBehavior?: EscapeBehaviorType | undefined;
 
 	/**
 	 * Whether or not to close the menu when an internal item is clicked.
 	 *
 	 * @default true
 	 */
-	closeOnItemClick?: boolean;
+	closeOnItemClick?: boolean | undefined;
 
 	/**
 	 * If not `undefined`, the menu will be rendered within the provided element or selector.
 	 *
 	 * @default 'body'
 	 */
-	portal?: PortalConfig | null;
+	portal?: PortalConfig | null | undefined;
 
 	/**
 	 * Whether or not to close the menu when a click occurs outside of it.
 	 *
 	 * @default true
 	 */
-	closeOnOutsideClick?: boolean;
+	closeOnOutsideClick?: boolean | undefined;
 
 	/**
 	 * A custom event handler for the "outside click" event, which
@@ -76,21 +76,21 @@ export type _CreateMenuProps = {
 	 * If `event.preventDefault()` is called within the function,
 	 * the dialog will not close when the user clicks outside of it.
 	 */
-	onOutsideClick?: (event: InteractOutsideEvent) => void;
+	onOutsideClick?: ((event: InteractOutsideEvent) => void) | undefined;
 
 	/**
 	 * Whether should prevent text selection overflowing the element when the element is the top layer.
 	 *
 	 * @defaultValue `true`
 	 */
-	preventTextSelectionOverflow?: boolean;
+	preventTextSelectionOverflow?: boolean | undefined;
 
 	/**
 	 * Whether or not to loop the menu navigation.
 	 *
 	 * @default false
 	 */
-	loop?: boolean;
+	loop?: boolean | undefined;
 
 	/**
 	 * Whether the menu is open by default or not.
@@ -99,7 +99,7 @@ export type _CreateMenuProps = {
 	 *
 	 * @default false
 	 */
-	defaultOpen?: boolean;
+	defaultOpen?: boolean | undefined;
 
 	/**
 	 * A controlled open state store for the menu. If provided, the
@@ -107,14 +107,14 @@ export type _CreateMenuProps = {
 	 *
 	 * @see https://melt-ui.com/docs/controlled#bring-your-own-store
 	 */
-	open?: Writable<boolean>;
+	open?: Writable<boolean> | undefined;
 
 	/**
 	 * A callback for when the open state changes.
 	 *
 	 * @see https://melt-ui.com/docs/controlled#change-functions
 	 */
-	onOpenChange?: ChangeFn<boolean>;
+	onOpenChange?: ChangeFn<boolean> | undefined;
 
 	/**
 	 * Whether the menu content should be displayed even if it is not open.
@@ -124,57 +124,57 @@ export type _CreateMenuProps = {
 	 *
 	 * @default false
 	 */
-	forceVisible?: boolean;
+	forceVisible?: boolean | undefined;
 
 	/**
 	 * Whether to use typeahead to automatically focus elements.
 	 * @default true
 	 */
-	typeahead?: boolean;
+	typeahead?: boolean | undefined;
 
 	/**
 	 * Override the default autofocus behavior of the menu
 	 * on close.
 	 */
-	closeFocus?: FocusProp;
+	closeFocus?: FocusProp | undefined;
 
 	/**
 	 * Optionally prevent focusing the first item in the menu
 	 */
-	disableFocusFirstItem?: boolean;
+	disableFocusFirstItem?: boolean | undefined;
 
 	/**
 	 * Optionally override the default ids we assign to the elements
 	 */
-	ids?: Partial<IdObj<_MenuIdParts>>;
+	ids?: Partial<IdObj<_MenuIdParts>> | undefined;
 };
 
 export type _CreateSubmenuProps = Pick<
 	_CreateMenuProps,
 	'arrowSize' | 'positioning' | 'open' | 'onOpenChange' | 'ids'
 > & {
-	disabled?: boolean;
+	disabled?: boolean | undefined;
 };
 
 export type _CreateRadioGroupProps = {
-	defaultValue?: string;
-	value?: Writable<string>;
-	onValueChange?: ChangeFn<string | null>;
+	defaultValue?: string | undefined;
+	value?: Writable<string> | undefined;
+	onValueChange?: ChangeFn<string | null> | undefined;
 };
 
 export type _ItemProps = {
-	disabled?: boolean;
+	disabled?: boolean | undefined;
 };
 
 export type _CheckboxItemProps = _ItemProps & {
-	defaultChecked?: boolean | 'indeterminate';
-	checked?: Writable<boolean | 'indeterminate'>;
-	onCheckedChange?: ChangeFn<boolean | 'indeterminate'>;
+	defaultChecked?: boolean | 'indeterminate' | undefined;
+	checked?: Writable<boolean | 'indeterminate'> | undefined;
+	onCheckedChange?: ChangeFn<boolean | 'indeterminate'> | undefined;
 };
 
 export type _RadioItemProps = {
 	value: string;
-	disabled?: boolean;
+	disabled?: boolean | undefined;
 };
 
 export type _RadioItemActionProps = _ItemProps;
@@ -219,7 +219,7 @@ export type _MenuBuilderOptions = {
 	 */
 	removeScroll: boolean;
 
-	ids?: Partial<IdObj<_MenuIdParts>>;
+	ids?: Partial<IdObj<_MenuIdParts>> | undefined;
 };
 
 export type _MenuParts =

--- a/src/lib/builders/menubar/types.ts
+++ b/src/lib/builders/menubar/types.ts
@@ -13,7 +13,7 @@ export type CreateMenubarProps = {
 	 *
 	 * @default true
 	 */
-	loop?: boolean;
+	loop?: boolean | undefined;
 
 	/**
 	 * Escape behavior type.
@@ -24,7 +24,7 @@ export type CreateMenubarProps = {
 	 *
 	 * @defaultValue `close`
 	 */
-	escapeBehavior?: EscapeBehaviorType;
+	escapeBehavior?: EscapeBehaviorType | undefined;
 
 	/**
 	 * Whether to prevent scrolling the body when any menu within
@@ -32,12 +32,12 @@ export type CreateMenubarProps = {
 	 *
 	 * @default true
 	 */
-	preventScroll?: boolean;
+	preventScroll?: boolean | undefined;
 
 	/**
 	 * Optionally override the default ids we assign to the elements
 	 */
-	ids?: Partial<IdObj<MenubarIdParts>>;
+	ids?: Partial<IdObj<MenubarIdParts>> | undefined;
 };
 
 export type CreateMenubarMenuProps = Omit<_Menu['builder'], 'preventScroll'>;

--- a/src/lib/builders/pagination/types.ts
+++ b/src/lib/builders/pagination/types.ts
@@ -14,21 +14,21 @@ export type CreatePaginationProps = {
 	 *
 	 * @default 1
 	 */
-	perPage?: number;
+	perPage?: number | undefined;
 
 	/**
 	 * Number of visible items before and after the current page
 	 *
 	 * @default 1
 	 */
-	siblingCount?: number;
+	siblingCount?: number | undefined;
 
 	/**
 	 * The uncontrolled default page of the pagination.
 	 *
 	 * @default 1
 	 */
-	defaultPage?: number;
+	defaultPage?: number | undefined;
 
 	/**
 	 * The controlled page store for the pagination.
@@ -36,14 +36,14 @@ export type CreatePaginationProps = {
 	 *
 	 * @see https://melt-ui.com/docs/controlled#bring-your-own-store
 	 */
-	page?: Writable<number>;
+	page?: Writable<number> | undefined;
 
 	/**
 	 * The callback invoked when the value of the page store changes.
 	 *
 	 * @see https://melt-ui.com/docs/controlled#change-functions
 	 */
-	onPageChange?: ChangeFn<number>;
+	onPageChange?: ChangeFn<number> | undefined;
 };
 
 export type Page = {
@@ -62,8 +62,8 @@ export type PageItem = (Page | Ellipsis) & {
 
 export type GetPageItemsArgs = {
 	totalPages: number;
-	siblingCount?: number;
-	page?: number;
+	siblingCount?: number | undefined;
+	page?: number | undefined;
 };
 
 export type Pagination = BuilderReturn<typeof createPagination>;

--- a/src/lib/builders/pin-input/types.ts
+++ b/src/lib/builders/pin-input/types.ts
@@ -10,7 +10,7 @@ export type CreatePinInputProps = {
 	 *
 	 * @default '○'
 	 */
-	placeholder?: string;
+	placeholder?: string | undefined;
 
 	/**
 	 * The name of the input. Submitted with its owning form as part
@@ -18,28 +18,28 @@ export type CreatePinInputProps = {
 	 *
 	 * @default undefined
 	 */
-	name?: string;
+	name?: string | undefined;
 
 	/**
 	 * If `true`, prevents the user from interacting with the input.
 	 *
 	 * @default false
 	 */
-	disabled?: boolean;
+	disabled?: boolean | undefined;
 
 	/**
 	 * The type of the input. Use `password` to mask the input.
 	 *
 	 * @default 'text'
 	 */
-	type?: 'text' | 'password';
+	type?: 'text' | 'password' | undefined;
 
 	/**
 	 * The uncontrolled default value of the pin input.
 	 *
 	 * @default []
 	 */
-	defaultValue?: string[];
+	defaultValue?: string[] | undefined;
 
 	/**
 	 * The controlled value store for the pin input.
@@ -47,19 +47,19 @@ export type CreatePinInputProps = {
 	 *
 	 * @see https://melt-ui.com/docs/controlled#bring-your-own-store
 	 */
-	value?: Writable<string[]>;
+	value?: Writable<string[]> | undefined;
 
 	/**
 	 * The callback invoked when the value store of the pin input changes.
 	 *
 	 * @see https://melt-ui.com/docs/controlled#change-functions
 	 */
-	onValueChange?: ChangeFn<string[]>;
+	onValueChange?: ChangeFn<string[]> | undefined;
 
 	/**
 	 * Optionally override the default ids we assign to the elements
 	 */
-	ids?: Partial<IdObj<PinInputIdParts>>;
+	ids?: Partial<IdObj<PinInputIdParts>> | undefined;
 };
 
 export type PinInput = BuilderReturn<typeof createPinInput>;

--- a/src/lib/builders/popover/types.ts
+++ b/src/lib/builders/popover/types.ts
@@ -14,18 +14,18 @@ export type CreatePopoverProps = {
 	/**
 	 * The positioning configuration for the floating element.
 	 */
-	positioning?: FloatingConfig;
+	positioning?: FloatingConfig | undefined;
 
 	/**
 	 * The size of the optional arrow in pixels.
 	 */
-	arrowSize?: number;
+	arrowSize?: number | undefined;
 
 	/**
 	 * The initial state of the `open` store.
 	 * Should only be used if the popover is uncontrolled.
 	 */
-	defaultOpen?: boolean;
+	defaultOpen?: boolean | undefined;
 
 	/**
 	 * A store that controls the open state.
@@ -33,7 +33,7 @@ export type CreatePopoverProps = {
 	 *
 	 * @see https://melt-ui.com/docs/controlled#bring-your-own-store
 	 */
-	open?: Writable<boolean>;
+	open?: Writable<boolean> | undefined;
 
 	/**
 	 * Optional function that runs whenever open should change.
@@ -42,14 +42,14 @@ export type CreatePopoverProps = {
 	 *
 	 * @see https://melt-ui.com/docs/controlled#change-functions
 	 */
-	onOpenChange?: ChangeFn<boolean>;
+	onOpenChange?: ChangeFn<boolean> | undefined;
 
 	/**
 	 * Whether or not to disable the focus trap when the popover is open.
 	 *
 	 * @default false
 	 */
-	disableFocusTrap?: boolean;
+	disableFocusTrap?: boolean | undefined;
 
 	/**
 	 * Escape behavior type.
@@ -60,14 +60,14 @@ export type CreatePopoverProps = {
 	 *
 	 * @defaultValue `close`
 	 */
-	escapeBehavior?: EscapeBehaviorType;
+	escapeBehavior?: EscapeBehaviorType | undefined;
 
 	/**
 	 * Whether or not to close the popover when the escape key is pressed.
 	 *
 	 * @default true
 	 */
-	closeOnOutsideClick?: boolean;
+	closeOnOutsideClick?: boolean | undefined;
 
 	/**
 	 * A custom event handler for the "outside click" event, which
@@ -75,28 +75,28 @@ export type CreatePopoverProps = {
 	 * If `event.preventDefault()` is called within the function,
 	 * the dialog will not close when the user clicks outside of it.
 	 */
-	onOutsideClick?: (event: InteractOutsideEvent) => void;
+	onOutsideClick?: ((event: InteractOutsideEvent) => void) | undefined;
 
 	/**
 	 * Whether should prevent text selection overflowing the element when the element is the top layer.
 	 *
 	 * @defaultValue `true`
 	 */
-	preventTextSelectionOverflow?: boolean;
+	preventTextSelectionOverflow?: boolean | undefined;
 
 	/**
 	 * Whether or not to prevent scrolling when the popover is open.
 	 *
 	 * @default false
 	 */
-	preventScroll?: boolean;
+	preventScroll?: boolean | undefined;
 
 	/**
 	 * If not undefined, the popover will be rendered within the provided element or selector.
 	 *
 	 * @default 'body'
 	 */
-	portal?: PortalConfig | null;
+	portal?: PortalConfig | null | undefined;
 
 	/**
 	 * Whether the menu content should be displayed even if it is not open.
@@ -106,24 +106,24 @@ export type CreatePopoverProps = {
 	 *
 	 * @default false
 	 */
-	forceVisible?: boolean;
+	forceVisible?: boolean | undefined;
 
 	/**
 	 * Override the default autofocus behavior of the popover
 	 * on open.
 	 */
-	openFocus?: FocusProp;
+	openFocus?: FocusProp | undefined;
 
 	/**
 	 * Override the default autofocus behavior of the popover
 	 * on close.
 	 */
-	closeFocus?: FocusProp;
+	closeFocus?: FocusProp | undefined;
 
 	/**
 	 * Optionally override the default ids we assign to the elements
 	 */
-	ids?: Partial<IdObj<PopoverIdParts>>;
+	ids?: Partial<IdObj<PopoverIdParts>> | undefined;
 };
 
 export type Popover = BuilderReturn<typeof createPopover>;

--- a/src/lib/builders/progress/types.ts
+++ b/src/lib/builders/progress/types.ts
@@ -9,7 +9,7 @@ export type CreateProgressProps = {
 	 *
 	 * @default 0
 	 */
-	defaultValue?: number | null;
+	defaultValue?: number | null | undefined;
 
 	/**
 	 * The controlled value store for the radio group.
@@ -17,21 +17,21 @@ export type CreateProgressProps = {
 	 *
 	 * @see https://melt-ui.com/docs/controlled#bring-your-own-store
 	 */
-	value?: Writable<number | null>;
+	value?: Writable<number | null> | undefined;
 
 	/**
 	 * The callback invoked when the value store of the progress changes.
 	 *
 	 * @see https://melt-ui.com/docs/controlled#change-functions
 	 */
-	onValueChange?: ChangeFn<number | null>;
+	onValueChange?: ChangeFn<number | null> | undefined;
 
 	/**
 	 * The maximum value of the progress.
 	 *
 	 * @default 100
 	 */
-	max?: number;
+	max?: number | undefined;
 };
 
 export type Progress = BuilderReturn<typeof createProgress>;

--- a/src/lib/builders/radio-group/types.ts
+++ b/src/lib/builders/radio-group/types.ts
@@ -10,7 +10,7 @@ export type CreateRadioGroupProps = {
 	 *
 	 * @default false
 	 */
-	disabled?: boolean;
+	disabled?: boolean | undefined;
 
 	/**
 	 * When `true`, indicates that the user must select a radio button before
@@ -18,9 +18,9 @@ export type CreateRadioGroupProps = {
 	 *
 	 * @default false
 	 */
-	required?: boolean;
+	required?: boolean | undefined;
 
-	name?: string;
+	name?: string | undefined;
 
 	/**
 	 * Whether or not the radio group should loop around when the end
@@ -28,40 +28,40 @@ export type CreateRadioGroupProps = {
 	 *
 	 * @default false
 	 */
-	loop?: boolean;
+	loop?: boolean | undefined;
 
 	/**
 	 * The orientation of the radio group.
 	 *
 	 * @default 'horizontal'
 	 */
-	orientation?: Orientation;
+	orientation?: Orientation | undefined;
 
 	/**
 	 * The uncontrolled default value of the radio group.
 	 *
 	 * @default undefined
 	 */
-	defaultValue?: string;
+	defaultValue?: string | undefined;
 
 	/**
 	 * The controlled value store for the radio group.
 	 * If provided, this will override the value passed to `defaultValue`.
 	 */
-	value?: Writable<string>;
+	value?: Writable<string> | undefined;
 
 	/**
 	 * The callback invoked when the value store of the radio group changes.
 	 *
 	 * @see https://melt-ui.com/docs/controlled#change-functions
 	 */
-	onValueChange?: ChangeFn<string>;
+	onValueChange?: ChangeFn<string> | undefined;
 };
 
 export type RadioGroupItemProps =
 	| {
 			value: string;
-			disabled?: boolean;
+			disabled?: boolean | undefined;
 	  }
 	| string;
 

--- a/src/lib/builders/range-calendar/types.ts
+++ b/src/lib/builders/range-calendar/types.ts
@@ -13,7 +13,7 @@ export type RangeCalendarProps = {
 	 *
 	 * @default false
 	 */
-	preventDeselect?: boolean;
+	preventDeselect?: boolean | undefined;
 
 	/**
 	 * The minimum selectable date. When provided, the
@@ -22,7 +22,7 @@ export type RangeCalendarProps = {
 	 *
 	 * @default undefined
 	 */
-	minValue?: DateValue;
+	minValue?: DateValue | undefined;
 
 	/**
 	 * The maximum selectable date. When provided, the
@@ -31,7 +31,7 @@ export type RangeCalendarProps = {
 	 *
 	 * @default undefined
 	 */
-	maxValue?: DateValue;
+	maxValue?: DateValue | undefined;
 
 	/**
 	 * The default value for the date field. When provided,
@@ -39,7 +39,7 @@ export type RangeCalendarProps = {
 	 *
 	 * @default undefined;
 	 */
-	defaultValue?: DateRange;
+	defaultValue?: DateRange | undefined;
 
 	/**
 	 * A function called when the value of the date field changes.
@@ -51,7 +51,7 @@ export type RangeCalendarProps = {
 	 *
 	 * @default undefined
 	 */
-	onValueChange?: ChangeFn<DateRange>;
+	onValueChange?: ChangeFn<DateRange> | undefined;
 
 	/**
 	 * A writable store than can be used to control the value of the
@@ -61,7 +61,7 @@ export type RangeCalendarProps = {
 	 *
 	 * @default undefined;
 	 */
-	value?: Writable<DateRange>;
+	value?: Writable<DateRange> | undefined;
 
 	/**
 	 * The date that is used to display the initial month and
@@ -75,7 +75,7 @@ export type RangeCalendarProps = {
 	 *
 	 * @default CalendarDate - the current date at midnight.
 	 */
-	defaultPlaceholder?: DateValue;
+	defaultPlaceholder?: DateValue | undefined;
 
 	/**
 	 * A writable store that can be used to control the placeholder
@@ -98,7 +98,7 @@ export type RangeCalendarProps = {
 	 *
 	 * @default Writable<CalendarDate> - the current date at midnight.
 	 */
-	placeholder?: Writable<DateValue>;
+	placeholder?: Writable<DateValue> | undefined;
 
 	/**
 	 * A function called when the placeholder value changes. It receives
@@ -113,7 +113,7 @@ export type RangeCalendarProps = {
 	 *
 	 * @default undefined
 	 */
-	onPlaceholderChange?: ChangeFn<DateValue>;
+	onPlaceholderChange?: ChangeFn<DateValue> | undefined;
 
 	/**
 	 * Only applicable when `numberOfMonths` is greater than 1.
@@ -130,7 +130,7 @@ export type RangeCalendarProps = {
 	 *
 	 * @default false
 	 */
-	pagedNavigation?: boolean;
+	pagedNavigation?: boolean | undefined;
 
 	/**
 	 * The day of the week to start the calendar on, which must
@@ -139,7 +139,7 @@ export type RangeCalendarProps = {
 	 *
 	 * @default 0 (Sunday)
 	 */
-	weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+	weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | undefined;
 
 	/**
 	 * How the string representation of the weekdays provided via the `weekdays` state
@@ -154,7 +154,7 @@ export type RangeCalendarProps = {
 	 *
 	 * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#weekday
 	 */
-	weekdayFormat?: Intl.DateTimeFormatOptions['weekday'];
+	weekdayFormat?: Intl.DateTimeFormatOptions['weekday'] | undefined;
 
 	/**
 	 * Any dates that match the provided matchers will
@@ -165,7 +165,7 @@ export type RangeCalendarProps = {
 	 *
 	 * @default undefined;
 	 */
-	isDateDisabled?: Matcher;
+	isDateDisabled?: Matcher | undefined;
 
 	/**
 	 * Any dates that match the provided matchers will be
@@ -182,7 +182,7 @@ export type RangeCalendarProps = {
 	 *
 	 * @default undefined;
 	 */
-	isDateUnavailable?: Matcher;
+	isDateUnavailable?: Matcher | undefined;
 
 	/**
 	 * Display 6 weeks per month, regardless the month's number of weeks.
@@ -194,7 +194,7 @@ export type RangeCalendarProps = {
 	 *
 	 * @default false
 	 */
-	fixedWeeks?: boolean;
+	fixedWeeks?: boolean | undefined;
 
 	/**
 	 * The number of months to display on the calendar at once. To control
@@ -202,7 +202,7 @@ export type RangeCalendarProps = {
 	 *
 	 * @default 1
 	 */
-	numberOfMonths?: number;
+	numberOfMonths?: number | undefined;
 
 	/**
 	 * The label for the calendar, which is used for
@@ -219,12 +219,12 @@ export type RangeCalendarProps = {
 	 * @example 'Booking date' - will be read as 'Booking date, January 2021' if the
 	 * current month is January 2021.
 	 */
-	calendarLabel?: string;
+	calendarLabel?: string | undefined;
 
 	/**
 	 * @default 'en'
 	 */
-	locale?: string;
+	locale?: string | undefined;
 
 	/**
 	 * Whether the calendar is disabled. When true, the user will not
@@ -233,7 +233,7 @@ export type RangeCalendarProps = {
 	 *
 	 * @default false
 	 */
-	disabled?: boolean;
+	disabled?: boolean | undefined;
 
 	/**
 	 * Whether the calendar is readonly. When true, the user will be able
@@ -243,7 +243,7 @@ export type RangeCalendarProps = {
 	 *
 	 * @default false
 	 */
-	readonly?: boolean;
+	readonly?: boolean | undefined;
 
 	/**
 	 * Override any of the element IDs set by the builder.
@@ -253,7 +253,7 @@ export type RangeCalendarProps = {
 	 * accessibility and functionality of the date field if
 	 * implemented incorrectly.
 	 */
-	ids?: Partial<IdObj<RangeCalendarIdParts>>;
+	ids?: Partial<IdObj<RangeCalendarIdParts>> | undefined;
 };
 
 export type CreateRangeCalendarProps = RangeCalendarProps;

--- a/src/lib/builders/scroll-area/types.ts
+++ b/src/lib/builders/scroll-area/types.ts
@@ -10,7 +10,7 @@ export type CreateScrollAreaProps = {
 	 *
 	 * @default 'hover'
 	 */
-	type?: ScrollAreaType;
+	type?: ScrollAreaType | undefined;
 
 	/**
 	 * If the type is `"scroll"` or `"hover"`, this determines how long
@@ -19,20 +19,20 @@ export type CreateScrollAreaProps = {
 	 *
 	 * @default 600
 	 */
-	hideDelay?: number;
+	hideDelay?: number | undefined;
 
 	/**
 	 * The reading direction of the scroll area.
 	 *
 	 * @default 'ltr'
 	 */
-	dir?: TextDirection;
+	dir?: TextDirection | undefined;
 
 	/**
 	 * Optionally override the default ids assigned to the
 	 * elements.
 	 */
-	ids?: Partial<IdObj<ScrollAreaIdParts>>;
+	ids?: Partial<IdObj<ScrollAreaIdParts>> | undefined;
 };
 
 export type ScrollArea = ReturnType<typeof createScrollArea>;

--- a/src/lib/builders/separator/types.ts
+++ b/src/lib/builders/separator/types.ts
@@ -7,7 +7,7 @@ export type CreateSeparatorProps = {
 	 *
 	 * @default 'horizontal'
 	 */
-	orientation?: Orientation;
+	orientation?: Orientation | undefined;
 
 	/*
 	 * Whether the separator is purely decorative or not. If true,
@@ -16,7 +16,7 @@ export type CreateSeparatorProps = {
 	 *
 	 * @default false
 	 */
-	decorative?: boolean;
+	decorative?: boolean | undefined;
 };
 
 export type Separator = BuilderReturn<typeof createSeparator>;

--- a/src/lib/builders/slider/types.ts
+++ b/src/lib/builders/slider/types.ts
@@ -12,53 +12,53 @@ export type CreateSliderProps = {
 	 *
 	 * @default []
 	 */
-	defaultValue?: number[];
+	defaultValue?: number[] | undefined;
 
 	/**
 	 * The controlled value store for the switch.
 	 * If provided, this will override the value passed to `defaultValue`.
 	 */
-	value?: Writable<number[]>;
+	value?: Writable<number[]> | undefined;
 
 	/**
 	 * The callback invoked when the value store of the slider changes.
 	 *
 	 * @see https://melt-ui.com/docs/controlled#change-functions
 	 */
-	onValueChange?: ChangeFn<number[]>;
+	onValueChange?: ChangeFn<number[]> | undefined;
 
 	/**
 	 * The callback invoked when the user has committed the value of the slider.
 	 */
-	onValueCommitted?: (value: number[]) => void;
+	onValueCommitted?: ((value: number[]) => void) | undefined;
 
 	/**
 	 * The minimum value of the slider.
 	 *
 	 * @default 0
 	 */
-	min?: number;
+	min?: number | undefined;
 
 	/**
 	 * The maximum value of the slider.
 	 *
 	 * @default 100
 	 */
-	max?: number;
+	max?: number | undefined;
 
 	/**
 	 * The amount to increment or decrement the value of the slider.
 	 *
 	 * @default 1
 	 */
-	step?: number;
+	step?: number | undefined;
 
 	/**
 	 * The orientation of the slider.
 	 *
 	 * @default 'horizontal'
 	 */
-	orientation?: SliderOrientation;
+	orientation?: SliderOrientation | undefined;
 
 	/**
 	 * The direction of the slider.
@@ -68,21 +68,21 @@ export type CreateSliderProps = {
 	 *
 	 * @default 'ltr'
 	 */
-	dir?: 'ltr' | 'rtl';
+	dir?: 'ltr' | 'rtl' | undefined;
 
 	/**
 	 * When `true`, prevents the user from interacting with the slider.
 	 *
 	 * @default false
 	 */
-	disabled?: boolean;
+	disabled?: boolean | undefined;
 
 	/**
 	 * When `false`, disables automatically sorting the value array when moving thumbs past each other.
 	 *
 	 * @default true
 	 */
-	autoSort?: boolean;
+	autoSort?: boolean | undefined;
 };
 
 export type Slider = BuilderReturn<typeof createSlider>;

--- a/src/lib/builders/switch/types.ts
+++ b/src/lib/builders/switch/types.ts
@@ -9,44 +9,44 @@ export type CreateSwitchProps = {
 	 *
 	 * @default false
 	 */
-	defaultChecked?: boolean;
+	defaultChecked?: boolean | undefined;
 
 	/**
 	 * The controlled checked state of the switch.
 	 * If provided, this will override the value passed to `defaultChecked`.
 	 */
-	checked?: Writable<boolean>;
+	checked?: Writable<boolean> | undefined;
 
 	/**
 	 * The callback invoked when the checked state of the switch changes.
 	 */
-	onCheckedChange?: ChangeFn<boolean>;
+	onCheckedChange?: ChangeFn<boolean> | undefined;
 
 	/**
 	 * When `true`, prevents the user from interacting with the switch.
 	 *
 	 * @default false
 	 */
-	disabled?: boolean;
+	disabled?: boolean | undefined;
 
 	/**
 	 * When `true`, indicates that the user must check the switch before the owning form can be submitted.
 	 * @default false
 	 */
-	required?: boolean;
+	required?: boolean | undefined;
 
 	/**
 	 * The name of the switch. Submitted with its owning form as part of a name/value pair.
 	 *
 	 * @default undefined
 	 */
-	name?: string;
+	name?: string | undefined;
 
 	/**
 	 * The value given as data when submitted with a `name`.
 	 * @default undefined
 	 */
-	value?: string;
+	value?: string | undefined;
 };
 
 export type Switch = BuilderReturn<typeof createSwitch>;

--- a/src/lib/builders/table-of-contents/types.ts
+++ b/src/lib/builders/table-of-contents/types.ts
@@ -30,15 +30,15 @@ export type CreateTableOfContentsArgs = {
 	/**
 	 * An array of headings to exclude from the table.
 	 */
-	exclude?: Heading[];
+	exclude?: Heading[] | undefined;
 	/**
 	 * The pixel offset added when scrolling to a heading.
 	 */
-	scrollOffset?: number;
+	scrollOffset?: number | undefined;
 	/**
 	 * The scroll behavior ('smooth' or 'instant').
 	 */
-	scrollBehaviour?: ScrollBehaviour;
+	scrollBehaviour?: ScrollBehaviour | undefined;
 	/**
 	 * The type of headings to consider as active:
 	 * - 'none': No intersection observers are added, and no headings are considered active.
@@ -49,24 +49,24 @@ export type CreateTableOfContentsArgs = {
 	 * - 'lowest-parents': Parents of the heading with the lowest visible content are also considered active.
 	 * - 'highest-parents': Parents of the heading with the highest visible content are also considered active.
 	 */
-	activeType?: ActiveType;
+	activeType?: ActiveType | undefined;
 	/**
 	 * The root margin for the intersection observer. Refer to the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/rootMargin) for more information.
 	 */
-	rootMargin?: string;
+	rootMargin?: string | undefined;
 	/**
 	 * A custom filter function for headings.
 	 */
-	headingFilterFn?: HeadingFilterFn;
+	headingFilterFn?: HeadingFilterFn | undefined;
 	/**
 	 * A custom scroll function.
 	 */
-	scrollFn?: ScrollFn;
+	scrollFn?: ScrollFn | undefined;
 
 	/**
 	 * A custom pushState function, expected to be SvelteKit's pushState function.
 	 */
-	pushStateFn?: PushStateFn;
+	pushStateFn?: PushStateFn | undefined;
 };
 
 export type ElementHeadingLU = {
@@ -82,7 +82,7 @@ export type TableOfContentsItem = {
 	index: number;
 	id: string;
 	node: HTMLHeadingElement;
-	children?: TableOfContentsItem[];
+	children?: TableOfContentsItem[] | undefined;
 };
 
 export type TableOfContents = ReturnType<typeof createTableOfContents>;

--- a/src/lib/builders/tabs/types.ts
+++ b/src/lib/builders/tabs/types.ts
@@ -8,7 +8,7 @@ export type CreateTabsProps = {
 	/**
 	 * The uncontrolled default value of the tabs.
 	 */
-	defaultValue?: string;
+	defaultValue?: string | undefined;
 
 	/**
 	 * The controlled value store for the tabs.
@@ -16,44 +16,44 @@ export type CreateTabsProps = {
 	 *
 	 * @see https://melt-ui.com/docs/controlled#bring-your-own-store
 	 */
-	value?: Writable<string>;
+	value?: Writable<string> | undefined;
 
 	/**
 	 * The callback invoked when the value store of the tabs changes.
 	 *
 	 * @see https://melt-ui.com/docs/controlled#change-functions
 	 */
-	onValueChange?: ChangeFn<string>;
+	onValueChange?: ChangeFn<string> | undefined;
 
 	/**
 	 * The orientation of the tabs.
 	 *
 	 * @default 'horizontal'
 	 */
-	orientation?: Orientation;
+	orientation?: Orientation | undefined;
 
 	/**
 	 * Whether or not the tabs should activate when the trigger is focused.
 	 *
 	 * @default true
 	 */
-	activateOnFocus?: boolean;
+	activateOnFocus?: boolean | undefined;
 
 	/**
 	 * Whether or not the tabs should loop around when the end is reached.
 	 */
-	loop?: boolean;
+	loop?: boolean | undefined;
 
 	/**
 	 * In case no value is set on initialization, sets the value to the first tab
 	 */
-	autoSet?: boolean;
+	autoSet?: boolean | undefined;
 };
 
 export type TabsTriggerProps =
 	| {
 			value: string;
-			disabled?: boolean;
+			disabled?: boolean | undefined;
 	  }
 	| string;
 

--- a/src/lib/builders/tags-input/types.ts
+++ b/src/lib/builders/tags-input/types.ts
@@ -4,20 +4,20 @@ import type { Writable } from 'svelte/store';
 import type { createTagsInput } from './create.js';
 export type { TagsInputComponentEvents } from './events.js';
 export type CreateTagsInputProps = {
-	placeholder?: string;
-	disabled?: boolean;
-	editable?: boolean;
-	selected?: Tag;
-	defaultTags?: string[] | Tag[];
-	tags?: Writable<Tag[]>;
-	onTagsChange?: ChangeFn<Tag[]>;
-	unique?: boolean;
-	trim?: boolean;
-	blur?: Blur;
-	addOnPaste?: boolean;
-	maxTags?: number;
-	allowed?: string[];
-	denied?: string[];
+	placeholder?: string | undefined;
+	disabled?: boolean | undefined;
+	editable?: boolean | undefined;
+	selected?: Tag | undefined;
+	defaultTags?: string[] | Tag[] | undefined;
+	tags?: Writable<Tag[]> | undefined;
+	onTagsChange?: ChangeFn<Tag[]> | undefined;
+	unique?: boolean | undefined;
+	trim?: boolean | undefined;
+	blur?: Blur | undefined;
+	addOnPaste?: boolean | undefined;
+	maxTags?: number | undefined;
+	allowed?: string[] | undefined;
+	denied?: string[] | undefined;
 	/**
 	 * Optional validator/parser function that runs on tag addition.
 	 *
@@ -27,7 +27,7 @@ export type CreateTagsInputProps = {
 	 *
 	 * @param tag The tag to be added
 	 */
-	add?: AddTag;
+	add?: AddTag | undefined;
 	/**
 	 * Optional validator/parser function that runs on tag removal.
 	 *
@@ -37,7 +37,7 @@ export type CreateTagsInputProps = {
 	 *
 	 * @param tag The tag to be removed
 	 */
-	remove?: RemoveTag;
+	remove?: RemoveTag | undefined;
 	/**
 	 * Optional validator/parser function that runs on tag update.
 	 *
@@ -47,7 +47,7 @@ export type CreateTagsInputProps = {
 	 *
 	 * @param tag The tag to be updated
 	 */
-	update?: UpdateTag;
+	update?: UpdateTag | undefined;
 };
 
 export type Blur = 'nothing' | 'add' | 'clear';
@@ -60,8 +60,8 @@ export type Tag = {
 export type TagProps = {
 	id: string;
 	value: string;
-	disabled?: boolean;
-	editable?: boolean;
+	disabled?: boolean | undefined;
+	editable?: boolean | undefined;
 };
 
 export type UpdateTag = (tag: Tag) => (Tag | never) | Promise<Tag | never>;

--- a/src/lib/builders/toast/types.ts
+++ b/src/lib/builders/toast/types.ts
@@ -6,9 +6,9 @@ export type EmptyType = Record<never, never>;
 export type CreateToasterProps = {
 	// Time in milliseconds before the toast is automatically closed.
 	// If set to 0, the toast will not be automatically closed.
-	closeDelay?: number;
-	type?: 'foreground' | 'background';
-	hover?: 'pause' | 'pause-all' | null;
+	closeDelay?: number | undefined;
+	type?: 'foreground' | 'background' | undefined;
+	hover?: 'pause' | 'pause-all' | null | undefined;
 };
 
 export type AddToastProps<T = object> = Omit<CreateToasterProps, 'hover'> & {
@@ -27,7 +27,7 @@ export type Toast<T = object> = {
 	data: T;
 	timeout: number | null;
 	createdAt: number;
-	pausedAt?: number;
+	pausedAt?: number | undefined;
 	pauseDuration: number;
 	getPercentage: () => number;
 };

--- a/src/lib/builders/toggle-group/types.ts
+++ b/src/lib/builders/toggle-group/types.ts
@@ -6,20 +6,20 @@ export type { ToggleGroupComponentEvents } from './events.js';
 export type ToggleGroupType = 'single' | 'multiple';
 
 export type CreateToggleGroupProps<T extends ToggleGroupType = 'single'> = {
-	defaultValue?: T extends 'single' ? string : string[];
-	value?: Writable<string | string[] | undefined>;
-	onValueChange?: ChangeFn<string | string[] | undefined>;
-	type?: T;
-	disabled?: boolean;
-	rovingFocus?: boolean;
-	loop?: boolean;
-	orientation?: Orientation;
+	defaultValue?: (T extends 'single' ? string : string[]) | undefined;
+	value?: Writable<string | string[] | undefined> | undefined;
+	onValueChange?: ChangeFn<string | string[] | undefined> | undefined;
+	type?: T | undefined;
+	disabled?: boolean | undefined;
+	rovingFocus?: boolean | undefined;
+	loop?: boolean | undefined;
+	orientation?: Orientation | undefined;
 };
 
 export type ToggleGroupItemProps =
 	| {
 			value: string;
-			disabled?: boolean;
+			disabled?: boolean | undefined;
 	  }
 	| string;
 

--- a/src/lib/builders/toggle/types.ts
+++ b/src/lib/builders/toggle/types.ts
@@ -5,10 +5,10 @@ import type { ChangeFn } from '$lib/internal/helpers/index.js';
 export type { ToggleComponentEvents } from './events.js';
 
 export type CreateToggleProps = {
-	disabled?: boolean;
-	defaultPressed?: boolean;
-	pressed?: Writable<boolean>;
-	onPressedChange?: ChangeFn<boolean>;
+	disabled?: boolean | undefined;
+	defaultPressed?: boolean | undefined;
+	pressed?: Writable<boolean> | undefined;
+	onPressedChange?: ChangeFn<boolean> | undefined;
 };
 
 export type Toggle = BuilderReturn<typeof createToggle>;

--- a/src/lib/builders/toolbar/types.ts
+++ b/src/lib/builders/toolbar/types.ts
@@ -6,22 +6,22 @@ export type { ToolbarComponentEvents } from './events.js';
 export type ToolbarGroupType = 'single' | 'multiple';
 
 export type CreateToolbarProps = {
-	loop?: boolean;
-	orientation?: Orientation;
+	loop?: boolean | undefined;
+	orientation?: Orientation | undefined;
 };
 
 export type CreateToolbarGroupProps<T extends ToolbarGroupType = 'single'> = {
-	defaultValue?: T extends 'single' ? string : string[];
-	value?: Writable<string | string[] | undefined>;
-	onValueChange?: ChangeFn<string | string[] | undefined>;
-	type?: T;
-	disabled?: boolean;
+	defaultValue?: (T extends 'single' ? string : string[]) | undefined;
+	value?: Writable<string | string[] | undefined> | undefined;
+	onValueChange?: ChangeFn<string | string[] | undefined> | undefined;
+	type?: T | undefined;
+	disabled?: boolean | undefined;
 };
 
 export type ToolbarGroupItemProps =
 	| {
 			value: string;
-			disabled?: boolean;
+			disabled?: boolean | undefined;
 	  }
 	| string;
 

--- a/src/lib/builders/tooltip/types.ts
+++ b/src/lib/builders/tooltip/types.ts
@@ -9,15 +9,15 @@ import type { Writable } from 'svelte/store';
 import type { TooltipIdParts, createTooltip } from './create.js';
 export type { TooltipComponentEvents } from './events.js';
 export type CreateTooltipProps = {
-	positioning?: FloatingConfig;
-	arrowSize?: number;
-	defaultOpen?: boolean;
-	open?: Writable<boolean>;
-	onOpenChange?: ChangeFn<boolean>;
-	closeOnPointerDown?: boolean;
-	openDelay?: number;
-	closeDelay?: number;
-	forceVisible?: boolean;
+	positioning?: FloatingConfig | undefined;
+	arrowSize?: number | undefined;
+	defaultOpen?: boolean | undefined;
+	open?: Writable<boolean> | undefined;
+	onOpenChange?: ChangeFn<boolean> | undefined;
+	closeOnPointerDown?: boolean | undefined;
+	openDelay?: number | undefined;
+	closeDelay?: number | undefined;
+	forceVisible?: boolean | undefined;
 	/**
 	 * Escape behavior type.
 	 * `close`: Closes the element immediately.
@@ -27,26 +27,26 @@ export type CreateTooltipProps = {
 	 *
 	 * @defaultValue `close`
 	 */
-	escapeBehavior?: EscapeBehaviorType;
+	escapeBehavior?: EscapeBehaviorType | undefined;
 
-	disableHoverableContent?: boolean;
+	disableHoverableContent?: boolean | undefined;
 	/**
 	 * If set to `true`, whenever you open this tooltip, all other tooltips
 	 * with `group` also set to `true` will close. If you pass in a string
 	 * instead, only tooltips with the same `group` value will be closed.
 	 */
-	group?: boolean | string;
+	group?: boolean | string | undefined;
 	/**
 	 * If not undefined, the tooltip will be rendered within the provided element or selector.
 	 *
 	 * @default 'body'
 	 */
-	portal?: PortalConfig | null;
+	portal?: PortalConfig | null | undefined;
 
 	/**
 	 * Optionally override the default ids we assign to the elements
 	 */
-	ids?: Partial<IdObj<TooltipIdParts>>;
+	ids?: Partial<IdObj<TooltipIdParts>> | undefined;
 };
 
 export type Tooltip = BuilderReturn<typeof createTooltip>;

--- a/src/lib/builders/tree/types.ts
+++ b/src/lib/builders/tree/types.ts
@@ -10,14 +10,14 @@ export type CreateTreeViewProps = {
 	 *
 	 * @default false
 	 */
-	forceVisible?: boolean;
+	forceVisible?: boolean | undefined;
 
 	/**
 	 * Which tree items are expanded by default.
 	 *
 	 * @default []
 	 */
-	defaultExpanded?: string[];
+	defaultExpanded?: string[] | undefined;
 
 	/**
 	 * Optionally pass a writable store to control the expanded items of the tree.
@@ -25,14 +25,14 @@ export type CreateTreeViewProps = {
 	 *
 	 * @see https://melt-ui.com/docs/controlled#bring-your-own-store
 	 */
-	expanded?: Writable<string[]>;
+	expanded?: Writable<string[]> | undefined;
 
 	/**
 	 * A callback called when the value of the `expanded` store should be changed.
 	 *
 	 * @see https://melt-ui.com/docs/controlled#change-functions
 	 */
-	onExpandedChange?: ChangeFn<string[]>;
+	onExpandedChange?: ChangeFn<string[]> | undefined;
 };
 
 export type TreeParts = 'label' | 'item' | 'group';

--- a/src/lib/internal/actions/escape-keydown/types.ts
+++ b/src/lib/internal/actions/escape-keydown/types.ts
@@ -17,15 +17,15 @@ export type EscapeKeydownConfig = {
 	 *
 	 * @defaultValue `close`
 	 */
-	behaviorType?: EscapeBehaviorType | WithGet<Readable<EscapeBehaviorType>>;
+	behaviorType?: EscapeBehaviorType | WithGet<Readable<EscapeBehaviorType>> | undefined;
 
 	/**
 	 * Callback when user presses the escape key element.
 	 */
-	handler?: (evt: KeyboardEvent) => void;
+	handler?: ((evt: KeyboardEvent) => void) | undefined;
 
 	/**
 	 * A predicate function or a list of elements that should not trigger the event.
 	 */
-	ignore?: ((e: KeyboardEvent) => boolean) | Element[];
+	ignore?: ((e: KeyboardEvent) => boolean) | Element[] | undefined;
 };

--- a/src/lib/internal/actions/floating/types.ts
+++ b/src/lib/internal/actions/floating/types.ts
@@ -37,14 +37,14 @@ export type FloatingConfig = {
 	 *
 	 * @see https://floating-ui.com/docs/computePosition#placement
 	 */
-	strategy?: 'absolute' | 'fixed';
+	strategy?: 'absolute' | 'fixed' | undefined;
 
 	/**
 	 * The offset of the floating element.
 	 *
 	 * @see https://floating-ui.com/docs/offset#options
 	 */
-	offset?: { mainAxis?: number; crossAxis?: number };
+	offset?: { mainAxis?: number; crossAxis?: number } | undefined;
 
 	/**
 	 * The main axis offset or gap between the reference and floating elements.
@@ -52,7 +52,7 @@ export type FloatingConfig = {
 	 *
 	 * @see https://floating-ui.com/docs/offset#options
 	 */
-	gutter?: number;
+	gutter?: number | undefined;
 
 	/**
 	 * The virtual padding around the viewport edges to check for overflow.
@@ -60,7 +60,7 @@ export type FloatingConfig = {
 	 *
 	 * @see https://floating-ui.com/docs/detectOverflow#padding
 	 */
-	overflowPadding?: number;
+	overflowPadding?: number | undefined;
 
 	/**
 	 * Whether to flip the placement.
@@ -68,7 +68,7 @@ export type FloatingConfig = {
 	 *
 	 * @see https://floating-ui.com/docs/flip
 	 */
-	flip?: boolean | FlipOptions;
+	flip?: boolean | FlipOptions | undefined;
 
 	/**
 	 * Whether the floating element can overlap the reference element.
@@ -76,7 +76,7 @@ export type FloatingConfig = {
 	 *
 	 * @see https://floating-ui.com/docs/shift#options
 	 */
-	overlap?: boolean;
+	overlap?: boolean | undefined;
 
 	/**
 	 * Whether to make the floating element same width as the reference element.
@@ -84,7 +84,7 @@ export type FloatingConfig = {
 	 *
 	 * @see https://floating-ui.com/docs/size
 	 */
-	sameWidth?: boolean;
+	sameWidth?: boolean | undefined;
 
 	/**
 	 * Whether the floating element should fit the viewport.
@@ -92,12 +92,12 @@ export type FloatingConfig = {
 	 *
 	 * @see https://floating-ui.com/docs/size
 	 */
-	fitViewport?: boolean;
+	fitViewport?: boolean | undefined;
 
 	/**
 	 * The overflow boundary of the reference element.
 	 *
 	 * @see https://floating-ui.com/docs/detectoverflow#boundary
 	 */
-	boundary?: Boundary;
+	boundary?: Boundary | undefined;
 } | null;

--- a/src/lib/internal/actions/focus-trap/types.ts
+++ b/src/lib/internal/actions/focus-trap/types.ts
@@ -9,7 +9,7 @@ export type FocusTrapConfig = FocusTrapOptions & {
 	 * Default: `false`. If `false`, when the trap is deactivated,
 	 * focus will *not* return to the element that had focus before activation.
 	 */
-	returnFocusOnDeactivate?: boolean;
+	returnFocusOnDeactivate?: boolean | undefined;
 	/**
 	 * Default: `false`. If `false` or returns `false`, the `Escape` key will not trigger
 	 * deactivation of the focus trap. This can be useful if you want
@@ -17,7 +17,7 @@ export type FocusTrapConfig = FocusTrapOptions & {
 	 * way out. Note that if a function is given, it's only called if the ESC key
 	 * was pressed.
 	 */
-	escapeDeactivates?: boolean | KeyboardEventToBoolean;
+	escapeDeactivates?: boolean | KeyboardEventToBoolean | undefined;
 	/**
 	 * If set and is or returns `true`, a click outside the focus trap will not
 	 * be prevented, even when `clickOutsideDeactivates` is `false`. When
@@ -26,5 +26,5 @@ export type FocusTrapConfig = FocusTrapOptions & {
 	 * if (and even which) clicks are allowed outside the trap in conjunction
 	 * with `clickOutsideDeactivates: false`. Default: `true`.
 	 */
-	allowOutsideClick?: boolean | MouseEventToBoolean;
+	allowOutsideClick?: boolean | MouseEventToBoolean | undefined;
 };

--- a/src/lib/internal/actions/interact-outside/types.ts
+++ b/src/lib/internal/actions/interact-outside/types.ts
@@ -19,7 +19,7 @@ export type InteractOutsideConfig = {
 	 * which is either a `pointerup`, `mouseup`, or `touchend`
 	 * event, depending on the user's input device.
 	 */
-	onInteractOutside?: (e: InteractOutsideEvent) => void;
+	onInteractOutside?: ((e: InteractOutsideEvent) => void) | undefined;
 
 	/**
 	 * Callback fired when an outside interaction event starts,
@@ -30,11 +30,11 @@ export type InteractOutsideConfig = {
 	 * begins an outside interaction, but before the interaction
 	 * completes.
 	 */
-	onInteractOutsideStart?: (e: InteractOutsideEvent) => void;
+	onInteractOutsideStart?: ((e: InteractOutsideEvent) => void) | undefined;
 
 	/**
 	 * Whether or not outside interactions should be handled.
 	 * @default true
 	 */
-	enabled?: boolean;
+	enabled?: boolean | undefined;
 };

--- a/src/lib/internal/actions/modal/types.ts
+++ b/src/lib/internal/actions/modal/types.ts
@@ -4,7 +4,7 @@ export type ModalConfig = {
 	/**
 	 * Handler called when the overlay closes.
 	 */
-	onClose?: () => void;
+	onClose?: (() => void) | undefined;
 	/**
 	 * Whether the modal is able to be closed by interacting outside of it.
 	 * If true, the `onClose` callback will be called when the user interacts
@@ -12,7 +12,7 @@ export type ModalConfig = {
 	 *
 	 * @default true
 	 */
-	closeOnInteractOutside?: boolean;
+	closeOnInteractOutside?: boolean | undefined;
 
 	/**
 	 * If `closeOnInteractOutside` is `true` and this function is provided,
@@ -24,5 +24,5 @@ export type ModalConfig = {
 	 * closing the modal. If `closeOnInteractOutside` is `false`, this function
 	 * will not be called.
 	 */
-	shouldCloseOnInteractOutside?: (event: InteractOutsideEvent) => boolean;
+	shouldCloseOnInteractOutside?: ((event: InteractOutsideEvent) => boolean) | undefined;
 };

--- a/src/lib/internal/actions/popper/types.ts
+++ b/src/lib/internal/actions/popper/types.ts
@@ -10,16 +10,16 @@ import type { ModalConfig } from '../modal/types.js';
 import type { PreventTextSelectionOverflowConfig } from '../prevent-text-selection-overflow/types.js';
 
 export type PopperConfig = {
-	floating?: FloatingConfig;
-	focusTrap?: FocusTrapConfig | null;
-	modal?: ModalConfig | null;
-	portal?: PortalConfig | null;
-	escapeKeydown?: EscapeKeydownConfig | null;
-	preventTextSelectionOverflow?: PreventTextSelectionOverflowConfig | null;
+	floating?: FloatingConfig | undefined;
+	focusTrap?: FocusTrapConfig | null | undefined;
+	modal?: ModalConfig | null | undefined;
+	portal?: PortalConfig | null | undefined;
+	escapeKeydown?: EscapeKeydownConfig | null | undefined;
+	preventTextSelectionOverflow?: PreventTextSelectionOverflowConfig | null | undefined;
 };
 
 export type PopperArgs = {
 	anchorElement: Element | VirtualElement;
 	open: Writable<boolean>;
-	options?: PopperConfig;
+	options?: PopperConfig | undefined;
 };

--- a/src/lib/internal/actions/prevent-text-selection-overflow/types.ts
+++ b/src/lib/internal/actions/prevent-text-selection-overflow/types.ts
@@ -7,5 +7,5 @@ export type PreventTextSelectionOverflowConfig = {
 	 *
 	 * @defaultValue `true`
 	 */
-	enabled?: boolean | WithGet<Readable<boolean>>;
+	enabled?: boolean | WithGet<Readable<boolean>> | undefined;
 };

--- a/src/lib/internal/types.ts
+++ b/src/lib/internal/types.ts
@@ -20,7 +20,7 @@ export type Arrayable<T> = T | T[];
 
 export type CreatePaginationProps = {
 	count: number;
-	perPage?: number;
+	perPage?: number | undefined;
 };
 
 type NullableKeys<T> = {


### PR DESCRIPTION
With [`exactOptionalPropertyTypes`](https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes) enabled, optional properties cannot be `undefined` unless explicitly allowed. This commit explicitly allows optional properties to be `undefined`, making melt-ui usable in projects with `exactOptionalPropertyTypes` enabled.

The issue was discovered when solving https://github.com/huntabyte/bits-ui/issues/516. Updating [bits-ui](https://github.com/huntabyte/bits-ui) solved most of the issues when using [shadcn-svelte](https://github.com/huntabyte/shadcn-svelte) in a project with `exactOptionalPropertyTypes` enabled. Updating [melt-ui](https://github.com/melt-ui/melt-ui) solves the issues for some additional shadcn components, such as Avatar, Pagination, Select and Separator.