### PR TITLE
fix accessibility issue with popover trigger (fixes #1181)

### DIFF
--- a/src/lib/builders/popover/create.ts
+++ b/src/lib/builders/popover/create.ts
@@ -160,13 +160,13 @@ export function createPopover(args?: CreatePopoverProps) {
 	}
 
 	const trigger = makeElement(name('trigger'), {
-		stores: [isVisible, ids.content, ids.trigger],
-		returned: ([$isVisible, $contentId, $triggerId]) => {
+		stores: [open, ids.content, ids.trigger],
+		returned: ([$open, $contentId, $triggerId]) => {
 			return {
 				role: 'button',
 				'aria-haspopup': 'dialog',
-				'aria-expanded': $isVisible ? 'true' : 'false',
-				'data-state': stateAttr($isVisible),
+				'aria-expanded': $open ? 'true' : 'false',
+				'data-state': stateAttr($open),
 				'aria-controls': $contentId,
 				id: $triggerId,
 			} as const;

--- a/src/tests/popover/Popover.spec.ts
+++ b/src/tests/popover/Popover.spec.ts
@@ -161,4 +161,16 @@ describe('Popover (Default)', () => {
 		await waitFor(() => expect(content).not.toBeVisible());
 		expect(getByTestId('content-2')).toBeVisible();
 	});
+
+	describe('aria-expanded attribute', () => {
+		it('should be true when open', async () => {
+			const { trigger } = await open();
+			expect(trigger).toHaveAttribute('aria-expanded', 'true');
+		});
+
+		it('should be false when closed', async () => {
+			const { trigger } = setup({ forceVisible: true });
+			expect(trigger).toHaveAttribute('aria-expanded', 'false');
+		});
+	});
 });


### PR DESCRIPTION
`isVisible` is always true when `forceVisible` option is true, `open` state variable should be used instead

fixes #1181