### PR TITLE
Search results clickable now on melt docs.

### DIFF
--- a/src/routes/(landing-ui)/search.svelte
+++ b/src/routes/(landing-ui)/search.svelte
@@ -121,7 +121,7 @@
 		</div>
 
 		<div
-			class="z-10 flex max-h-[min(600px,50vh)] flex-col"
+			class="z-50 flex max-h-[min(600px,50vh)] flex-col"
 			use:melt={$menu}
 			class:hidden={!$inputValue}
 		>


### PR DESCRIPTION
Search Results had lower z-index than the overlay.

# Before
![image](https://github.com/user-attachments/assets/1cfc52a1-eed5-4a4a-ab84-56cb10e1ddf2)

# After
![Screenshot 2024-09-20 at 9 09 35 PM](https://github.com/user-attachments/assets/be15bf13-87fa-498d-af39-56a1edcd88e3)

