### PR TITLE
fix(date-range-picker): use calendar defaults for accurate options types

### DIFF
--- a/.changeset/silent-tomatoes-pretend.md
+++ b/.changeset/silent-tomatoes-pretend.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+fix(date-range-picker): use calendar defaults for accurate options types

--- a/src/docs/data/builders/calendar.ts
+++ b/src/docs/data/builders/calendar.ts
@@ -101,6 +101,12 @@ const calendarProps = [
 		description: 'Whether to always show 6 weeks in the calendar.',
 	},
 	{
+		name: 'numberOfMonths',
+		type: 'number',
+		default: '1',
+		description: 'The number of months to display on the calendar simultaneously.',
+	},
+	{
 		name: 'calendarLabel',
 		type: 'string',
 		default: '"Event date"',

--- a/src/docs/data/builders/date-picker.ts
+++ b/src/docs/data/builders/date-picker.ts
@@ -103,6 +103,12 @@ const datePickerProps = [
 		description: 'Whether to always show 6 weeks in the calendar.',
 	},
 	{
+		name: 'numberOfMonths',
+		type: 'number',
+		default: '1',
+		description: 'The number of months to display on the calendar simultaneously.',
+	},
+	{
 		name: 'calendarLabel',
 		type: 'string',
 		default: '"Event date"',

--- a/src/docs/data/builders/date-range-picker.ts
+++ b/src/docs/data/builders/date-range-picker.ts
@@ -97,6 +97,12 @@ const dateRangePickerProps = [
 		description: 'Whether to always show 6 weeks in the calendar.',
 	},
 	{
+		name: 'numberOfMonths',
+		type: 'number',
+		default: '1',
+		description: 'The number of months to display on the calendar simultaneously.',
+	},
+	{
 		name: 'calendarLabel',
 		type: 'string',
 		default: '"Event date"',

--- a/src/lib/builders/date-range-picker/create.ts
+++ b/src/lib/builders/date-range-picker/create.ts
@@ -17,6 +17,7 @@ import { createFormatter, dateStore, getDefaultDate } from '$lib/internal/helper
 import type { MeltActionReturn } from '$lib/internal/types.js';
 import { createDateRangeField } from '../date-range-field/create.js';
 import type { DateRangePickerEvents } from './events.js';
+import { defaults as calendarDefaults } from '../calendar/create.js';
 
 const defaults = {
 	isDateDisabled: undefined,
@@ -37,6 +38,18 @@ const defaults = {
 	maxValue: undefined,
 	weekdayFormat: 'narrow',
 	onOutsideClick: undefined,
+	...omit(
+		calendarDefaults,
+		'isDateDisabled',
+		'isDateUnavailable',
+		'value',
+		'locale',
+		'disabled',
+		'readonly',
+		'minValue',
+		'maxValue',
+		'weekdayFormat'
+	),
 } satisfies CreateDateRangePickerProps;
 
 export function createDateRangePicker(props?: CreateDateRangePickerProps) {


### PR DESCRIPTION
Specifically, the `numberOfMonths` prop was typed with `Writable<number | undefined>` instead of `Writable<number>`