### PR TITLE
feat(listbox): add `highlightOnHover` prop to listboxes

### DIFF
--- a/.changeset/odd-fishes-hang.md
+++ b/.changeset/odd-fishes-hang.md
@@ -1,0 +1,5 @@
+---
+'@melt-ui/svelte': patch
+---
+
+add `highlightOnHover` prop to listboxes

--- a/src/docs/data/builders/combobox.ts
+++ b/src/docs/data/builders/combobox.ts
@@ -32,6 +32,13 @@ const OPTION_PROPS = [
 			'When true, hovering an option will update the `highlightedItem` store, and when the cursor leaves an option the store will be set to `null`',
 	},
 	{
+		name: 'highlightOnOpen',
+		type: 'boolean',
+		default: 'true',
+		description:
+			'When true, opening the combobox will update the `highlightedItem` store with the first selected option',
+	},
+	{
 		name: 'name',
 		type: 'string',
 		description: 'The name to be used for the hidden input.',

--- a/src/docs/data/builders/select.ts
+++ b/src/docs/data/builders/select.ts
@@ -37,6 +37,13 @@ const OPTION_PROPS = [
 		description:
 			'When true, hovering an option will update the `highlightedItem` store, and when the cursor leaves an option the store will be set to `null`',
 	},
+	{
+		name: 'highlightOnOpen',
+		type: 'boolean',
+		default: 'true',
+		description:
+			'When true, opening the select will update the `highlightedItem` store with the first selected option',
+	},
 ];
 
 const BUILDER_NAME = 'select';

--- a/src/lib/builders/listbox/create.ts
+++ b/src/lib/builders/listbox/create.ts
@@ -76,6 +76,7 @@ const defaults = {
 	name: undefined,
 	typeahead: true,
 	highlightOnHover: true,
+	highlightOnOpen: true,
 	onOutsideClick: undefined,
 	preventTextSelectionOverflow: true,
 	rootElement: undefined,
@@ -148,6 +149,7 @@ export function createListbox<
 		typeahead,
 		name: nameProp,
 		highlightOnHover,
+		highlightOnOpen,
 		onOutsideClick,
 		preventTextSelectionOverflow,
 		rootElement,
@@ -223,15 +225,17 @@ export function createListbox<
 	async function openMenu() {
 		open.set(true);
 
-		// Wait a tick for the menu to open then highlight the selected item.
-		await tick();
+		if (highlightOnOpen.get()) {
+			// Wait a tick for the menu to open then highlight the selected item.
+			await tick();
 
-		const menuElement = getElementById(ids.menu.get(), rootElement.get());
-		if (!isHTMLElement(menuElement)) return;
+			const menuElement = getElementById(ids.menu.get(), rootElement.get());
+			if (!isHTMLElement(menuElement)) return;
 
-		const selectedItem = menuElement.querySelector('[aria-selected=true]');
-		if (!isHTMLElement(selectedItem)) return;
-		highlightedItem.set(selectedItem);
+			const selectedItem = menuElement.querySelector('[aria-selected=true]');
+			if (!isHTMLElement(selectedItem)) return;
+			highlightedItem.set(selectedItem);
+		}
 	}
 
 	/** Closes the menu & clears the active trigger */

--- a/src/lib/builders/listbox/types.ts
+++ b/src/lib/builders/listbox/types.ts
@@ -183,6 +183,13 @@ export type CreateListboxProps<
 	highlightOnHover?: boolean;
 
 	/**
+	 * IF true, when the listbox is opened, the highlightedItem will be set to the first selected option.
+	 *
+	 * @default true
+	 */
+	highlightOnOpen?: boolean;
+
+	/**
 	 * Optionally override the default ids we assign to the elements
 	 */
 	ids?: Partial<IdObj<ListboxIdParts>>;


### PR DESCRIPTION
Adds a prop to select and combobox that allows users to disable highlighting the selected (or first selected) option by default when opening the listbox menu. Useful as otherwise the listbox menu will take keyboard inputs starting from the highlighted instead of from the top of the list.