### PR TITLE
feat: expose active state on slider

### DIFF
--- a/.changeset/flat-books-jam.md
+++ b/.changeset/flat-books-jam.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": minor
+---
+
+feat: expose active state on slider

--- a/src/docs/data/builders/slider.ts
+++ b/src/docs/data/builders/slider.ts
@@ -108,9 +108,10 @@ const builder = builderSchema(BUILDER_NAME, {
 			description: 'A writable store that can be used to get the current value of the slider.',
 		},
 		{
-			name: 'ticks',
-			type: 'Readable<number>',
-			description: 'A readable store that can be used to get the current number of ticks.',
+			name: 'active',
+			type: 'Readable<boolean>',
+			description:
+				'A readable store that can be used to get whether the slider is actively being interacted with.',
 		},
 	],
 	options: OPTION_PROPS,

--- a/src/lib/builders/slider/create.ts
+++ b/src/lib/builders/slider/create.ts
@@ -570,6 +570,7 @@ export const createSlider = (props?: CreateSliderProps) => {
 		},
 		states: {
 			value,
+			active: isActive,
 		},
 		options,
 	};


### PR DESCRIPTION
It is sometimes desirable to customize the behaviour of the slider based on whether it is active / being interacted with.

For example, I have a slider that snaps to certain predefined values when the user drags the slider, but can be set with a text input to non-snapped values on my project.

Due to `steps`, the slider calls `value.update` whenever `$value` changes, even if the change comes from an external interaction. To prevent this, I've patched `@melt-ui/svelte` to expose the `isActive` store as `active`, enabling the following behaviour:

```ts
export let valueStore: Writable<number>;

const {
	elements: { root, range, thumbs },
	states: { active }
} = createSlider({
	value: {
		...derived(valueStore, ($value) => [$value]),
		set(newValue: number[]) {
			if (!$active) return;
			valueStore.set(newValue[0]);
		},
		update(updater: Updater<number>) {
			if (!$active) return;
			valueStore.update((prev) => updater([prev])[0]);
		}
	},
	min,
	max
});
```

I use it in my [project](https://github.com/bryanmylee/natural-light/blob/main/src/routes/TemperatureSlider.svelte) via a patch.