### PR TITLE
feat: added support to specify a root element when using listbox elem…

### DIFF
--- a/.changeset/hungry-scissors-greet.md
+++ b/.changeset/hungry-scissors-greet.md
@@ -1,0 +1,5 @@
+---
+"@melt-ui/svelte": minor
+---
+
+feat: added support to specify a root element when using listbox elem…

--- a/src/docs/components/preview-wrapper.svelte
+++ b/src/docs/components/preview-wrapper.svelte
@@ -17,6 +17,10 @@
 				lg: 'h-[24rem] sm:h-[32rem]',
 				auto: 'h-auto py-6 lg:py-12',
 			},
+			position: {
+				default: 'relative',
+				static: 'static',
+			}
 		},
 		defaultVariants: {
 			variant: 'default',
@@ -30,10 +34,11 @@
 
 	export let variant: PreviewVariants['variant'] = 'default';
 	export let size: PreviewVariants['size'] = 'default';
+	export let position: PreviewVariants['position'] = 'default';
 	export let id: string | undefined = undefined;
 </script>
 
-<div class={cn(previewVariants({ variant, size }))} data-variant={variant} {id}>
+<div class={cn(previewVariants({ variant, size, position }))} data-variant={variant} {id}>
 	<div class={cn('z-10 mx-auto inline-block px-4')}>
 		<slot />
 	</div>

--- a/src/docs/components/preview.svelte
+++ b/src/docs/components/preview.svelte
@@ -22,6 +22,7 @@
 	};
 
 	export type PreviewProps = {
+		class: string;
 		code: {
 			[codingStyle: string]: CodeEntry | null;
 		};
@@ -45,11 +46,13 @@
 		viewCode: boolean;
 		variant?: PreviewVariants['variant'];
 		size?: PreviewVariants['size'];
+		position?: PreviewVariants['position'];
 	};
 
 	export let code: $$Props['code'];
 	export let variant: $$Props['variant'] = 'dark';
 	export let size: $$Props['size'] = 'default';
+	export let position: $$Props['position'] = 'default';
 
 	const usingPreprocessor = getUsingPreprocessor();
 
@@ -197,7 +200,7 @@
 			{/key}
 		</TabsRoot>
 	{:else}
-		<PreviewWrapper {variant} {size}>
+		<PreviewWrapper {variant} {size} {position}>
 			<slot />
 		</PreviewWrapper>
 	{/if}

--- a/src/docs/content/builders/combobox.md
+++ b/src/docs/content/builders/combobox.md
@@ -51,7 +51,7 @@ The `group` and `groupLabel` elements can be used to group combobox list items.
   <svelte:component this={previews.group} /> 
 </Preview>
 
-### Shdaow dom
+### Shadow dom
 
 By default, the comboBox uses the `document` as the root element to query its internal components. By
 utilizing the `rootElement` property you can override this behaviour, this is especially useful when

--- a/src/docs/content/builders/combobox.md
+++ b/src/docs/content/builders/combobox.md
@@ -51,6 +51,16 @@ The `group` and `groupLabel` elements can be used to group combobox list items.
   <svelte:component this={previews.group} /> 
 </Preview>
 
+### Shdaow dom
+
+By default, the comboBox uses the `document` as the root element to query its internal components. By
+utilizing the `rootElement` property you can override this behaviour, this is especially useful when
+running inside the shadow-dom.
+
+<Preview code={snippets.shadow} position="static">
+    <svelte:component this={previews.shadow} />
+</Preview>
+
 ## API Reference
 
 <APIReference {schemas} />

--- a/src/docs/previews/combobox/shadow/tailwind/ComboBox.svelte
+++ b/src/docs/previews/combobox/shadow/tailwind/ComboBox.svelte
@@ -1,0 +1,149 @@
+<script lang="ts">
+	import { createCombobox, melt } from '$lib/index.js';
+	import { Check, ChevronDown, ChevronUp } from '$icons/index.js';
+	import { fly } from 'svelte/transition';
+	export let componentRoot;
+	type Manga = {
+		author: string;
+		title: string;
+		disabled: boolean;
+	};
+
+	let mangas: Manga[] = [
+		{
+			author: 'Kentaro Miura',
+			title: 'Berserk',
+			disabled: false,
+		},
+		{
+			author: 'Hajime Isayama',
+			title: 'Attack on Titan',
+			disabled: false,
+		},
+		{
+			author: 'Junji Ito',
+			title: 'Uzumaki',
+			disabled: false,
+		},
+		{
+			author: 'Yomi Sarachi',
+			title: 'Steins Gate',
+			disabled: false,
+		},
+		{
+			author: 'Tite Kubo',
+			title: 'Bleach',
+			disabled: false,
+		},
+		{
+			author: 'Masashi Kishimoto',
+			title: 'Naruto',
+			disabled: true,
+		},
+		{
+			author: 'Katsura Hoshino',
+			title: 'D.Gray Man',
+			disabled: false,
+		},
+		{
+			author: 'Tsugumi Ohba',
+			title: 'Death Note',
+			disabled: false,
+		},
+		{
+			author: 'ONE',
+			title: 'Mob Psycho 100',
+			disabled: false,
+		},
+		{
+			author: 'Hiromu Arakawa',
+			title: 'Fullmetal Alchemist',
+			disabled: false,
+		},
+	];
+
+	const {
+		elements: { menu, input, option, label },
+		states: { open, inputValue, touchedInput },
+		helpers: { isSelected },
+	} = createCombobox({
+		forceVisible: true,
+		multiple: true,
+		rootElement: componentRoot
+	});
+
+	$: filteredMangas = $touchedInput
+		? mangas.filter(({ title, author }) => {
+				const normalizedInput = $inputValue.toLowerCase();
+				return (
+					title.toLowerCase().includes(normalizedInput) ||
+					author.toLowerCase().includes(normalizedInput)
+				);
+		  })
+		: mangas;
+</script>
+
+<div class="root">
+	<!-- svelte-ignore a11y-label-has-associated-control - $label contains the 'for' attribute -->
+	<label use:melt={$label}>
+		<span class="label"
+			>Choose your favorite manga:</span
+		>
+	</label>
+
+	<div style:position="relative">
+		<input
+			use:melt={$input}
+			class="input"
+			placeholder="Best book ever"
+		/>
+		<div class="chevron">
+			{#if $open}
+				<ChevronUp style="width: 1rem; height: 1rem;" />
+			{:else}
+				<ChevronDown style="width: 1rem; height: 1rem;" />
+			{/if}
+		</div>
+	</div>
+</div>
+{#if $open}
+	<ul
+		class="menu"
+		use:melt={$menu}
+		transition:fly={{ duration: 150, y: -5 }}
+	>
+		<!-- svelte-ignore a11y-no-noninteractive-tabindex -->
+		<div
+			class="menu-inner"
+			tabindex="0"
+		>
+			{#each filteredMangas as book, index (index)}
+				<li
+					use:melt={$option({
+						value: book,
+						label: book.title,
+						disabled: book.disabled,
+					})}
+					class="menu-item"
+				>
+					{#if $isSelected(book)}
+						<div class="check">
+							<Check style="width: 1rem; height: 1rem;" />
+						</div>
+					{/if}
+					<div class="text-wrapper">
+						<span class="title-text">{book.title}</span>
+						<span class="author-text">{book.author}</span>
+					</div>
+				</li>
+			{:else}
+				<li
+					class="relative cursor-pointer rounded-md py-1 pl-8 pr-4
+				data-[highlighted]:bg-magnum-100 data-[highlighted]:text-magnum-700"
+				>
+					No results found
+				</li>
+			{/each}
+		</div>
+	</ul>
+{/if}

--- a/src/docs/previews/combobox/shadow/tailwind/index.svelte
+++ b/src/docs/previews/combobox/shadow/tailwind/index.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import ComboBox from './ComboBox.svelte';
+
+	export let elementRoot: HTMLElement;
+
+	onMount(() => {
+		if (elementRoot) {
+			const shadowRoot = elementRoot.attachShadow({ mode: 'open' });
+			const styleElement = document.createElement('style');
+			styleElement.innerHTML = `
+				.root {
+					display: flex; flex-direction: column; gap: .25rem;
+				}
+				.label {
+					font-weight: 500; font-size: .875rem; line-height: 1.25rem; color: #793a15;
+				}
+				.input {
+					display: flex; height: 2.5rem; align-items: center; justify-content: space-between; border-radius: .5rem;
+				  background-color: white; padding: 0 3rem 0 .75rem; color: black;
+				}
+				.chevron {
+					position: absolute; right: 0.5rem; top: 50%; z-index: 10; transform: translateY(-50%); color: #793a15;
+				}
+				.menu {
+					padding: 0; margin: 0;
+					border-radius: .5rem; overflow: hidden; display: flex; flex-direction: column; max-height: 300px; z-index: 10;
+  			}
+				.menu-inner {
+					color: #000; padding: .5rem; background-color: white; overflow-y: auto; gap: 0px;
+					display: flex; flex-direction: column; max-height: 100%;
+				}
+				.menu-item {
+					position: relative; cursor: pointer; scroll-margin-top: 0.5rem; scroll-margin-bottom: 0.5rem;
+					color: #262626; text-transform: capitalize; font-weight: 600; padding: .25rem 1rem .25rem 1rem;
+					border-radius: .375rem;
+				}
+				.menu-item:hover {
+					color: #793a15; background: #fce0ac;
+				}
+				.text-wrapper {
+					padding-left: 1rem;
+				}
+				.title-text { font-weight: 500 }
+				.author-text { opacity: .75; font-size: .875rem; line-height: 1.25rem; display: block; }
+				.check {
+					position: absolute; left: .5rem; top: 50%; color: #f38d1c;
+					translate: 0 calc(-50% + 1px);
+				}
+    }`;
+
+			const componentRoot = document.createElement('div');
+			shadowRoot.appendChild(componentRoot);
+
+			shadowRoot.appendChild(styleElement);
+			new ComboBox({
+				target: componentRoot,
+				props: {
+					componentRoot,
+				},
+			});
+		}
+	});
+</script>
+
+<main bind:this={elementRoot} />

--- a/src/docs/previews/combobox/shadow/tailwind/index.svelte
+++ b/src/docs/previews/combobox/shadow/tailwind/index.svelte
@@ -35,7 +35,7 @@
 					color: #262626; text-transform: capitalize; font-weight: 600; padding: .25rem 1rem .25rem 1rem;
 					border-radius: .375rem;
 				}
-				.menu-item:hover {
+				.menu-item[data-highlighted] {
 					color: #793a15; background: #fce0ac;
 				}
 				.text-wrapper {

--- a/src/lib/builders/listbox/types.ts
+++ b/src/lib/builders/listbox/types.ts
@@ -144,7 +144,7 @@ export type CreateListboxProps<
 
 	/**
 	 * If not undefined, the listbox menu will be rendered within the provided element or selector.
-	 *
+	 * Otherwise, the `rootElement`, if provided, will be used.
 	 * @default 'body'
 	 */
 	portal?: PortalConfig | null;
@@ -186,6 +186,13 @@ export type CreateListboxProps<
 	 * Optionally override the default ids we assign to the elements
 	 */
 	ids?: Partial<IdObj<ListboxIdParts>>;
+
+	/**
+	 * By default, MeltUI uses the `document` as the root element to find your components, if you are using a shadow-dom or want to specify you own root element you should provide it here.
+	 *
+	 * @default document
+	 */
+	rootElement?: ParentNode;
 };
 
 export type ListboxOptionProps<Value = unknown> = ListboxOption<Value> & {

--- a/src/lib/internal/actions/floating/action.ts
+++ b/src/lib/internal/actions/floating/action.ts
@@ -13,7 +13,7 @@ import {
 	autoUpdate,
 } from '@floating-ui/dom';
 import type { FloatingConfig } from './types.js';
-import { isHTMLElement, isObject, noop } from '$lib/internal/helpers/index.js';
+import { isAttachedToDocument, isHTMLElement, isObject, noop } from '$lib/internal/helpers/index.js';
 import type { Placement, VirtualElement } from '@floating-ui/core';
 
 const defaultConfig = {
@@ -107,9 +107,8 @@ export function useFloating(
 
 	function compute() {
 		if (!reference || !floating) return;
-		// if the reference is no longer in the document (e.g. it was removed), ignore it
-		if (isHTMLElement(reference) && !reference.ownerDocument.documentElement.contains(reference))
-			return;
+		if (!isAttachedToDocument(reference)) return;
+
 		const { placement, strategy } = options;
 
 		computePosition(reference, floating, {

--- a/src/lib/internal/actions/interact-outside/action.ts
+++ b/src/lib/internal/actions/interact-outside/action.ts
@@ -4,9 +4,10 @@ import {
 	isElement,
 	executeCallbacks,
 	noop,
-	debounce,
+	debounce, isShadowRoot, isHTMLElement,
 } from '$lib/internal/helpers/index.js';
 import type {
+	ComputedEventData,
 	InteractOutsideConfig,
 	InteractOutsideEvent,
 	InteractOutsideInterceptEventType,
@@ -16,7 +17,7 @@ import type { Action } from 'svelte/action';
 
 const layers = new Set<HTMLElement>();
 
-export const useInteractOutside = ((node, config = {}) => {
+export const useInteractOutside = ((node, config: InteractOutsideConfig = {}) => {
 	let unsubEvents = noop;
 	let unsubPointerDown = noop;
 	let unsubPointerUp = noop;
@@ -84,7 +85,13 @@ export const useInteractOutside = ((node, config = {}) => {
 	) => {
 		return addEventListener(documentObj, eventType, (e: HTMLElementEventMap[E]) => {
 			interceptedEvents[eventType] = false;
-			handler?.(e);
+			const computedData: ComputedEventData = {};
+
+			if (isHTMLElement(e.target) && isShadowRoot(e.target.shadowRoot)) {
+				computedData.shadowTarget = e.composedPath()[0];
+			}
+
+			handler?.(e, computedData);
 		});
 	};
 
@@ -102,10 +109,10 @@ export const useInteractOutside = ((node, config = {}) => {
 		 * Debouncing `onPointerDown` ensures that other events can be flagged as not intercepted,
 		 * allowing a comprehensive check for intercepted events thereafter.
 		 */
-		const onPointerDownDebounced = debounce((e: InteractOutsideEvent) => {
+		const onPointerDownDebounced = debounce((e: InteractOutsideEvent, computedEventData?: ComputedEventData) => {
 			if (!wasTopLayerInPointerDownCapture || isAnyEventIntercepted()) return;
 			if (onInteractOutside && isValidEvent(e, node)) onInteractOutsideStart?.(e);
-			const target = e.target;
+			const target = computedEventData?.shadowTarget ? computedEventData.shadowTarget : e.target;
 			if (isElement(target) && isOrContainsTarget(node, target)) {
 				isPointerDownInside = true;
 			}

--- a/src/lib/internal/actions/interact-outside/types.ts
+++ b/src/lib/internal/actions/interact-outside/types.ts
@@ -10,8 +10,17 @@ export type InteractOutsideInterceptEventType =
 	| 'click';
 
 export type InteractOutsideInterceptHandler<E extends InteractOutsideInterceptEventType> = (
-	ev: HTMLElementEventMap[E]
+	ev: HTMLElementEventMap[E],
+	computedEventData?: ComputedEventData,
 ) => void;
+
+/**
+ * Some event data is lost when the event is delayed, debounced or throttled
+ * as described in the dom-spec - https://dom.spec.whatwg.org/#event-path
+ * For this reason we can pre-save any needed data and store
+ * it here before being passed on the related events
+ * */
+export type ComputedEventData = { shadowTarget?: EventTarget };
 
 export type InteractOutsideConfig = {
 	/**
@@ -19,7 +28,7 @@ export type InteractOutsideConfig = {
 	 * which is either a `pointerup`, `mouseup`, or `touchend`
 	 * event, depending on the user's input device.
 	 */
-	onInteractOutside?: (e: InteractOutsideEvent) => void;
+	onInteractOutside?: (e: InteractOutsideEvent, computedEventData?: ComputedEventData) => void;
 
 	/**
 	 * Callback fired when an outside interaction event starts,

--- a/src/lib/internal/helpers/elements.ts
+++ b/src/lib/internal/helpers/elements.ts
@@ -37,6 +37,10 @@ export function getPortalDestination(
 }
 
 export function isOrContainsTarget(node: HTMLElement, target: Element) {
+	if (target.shadowRoot) {
+
+	}
+
 	return node === target || node.contains(target);
 }
 

--- a/src/lib/internal/helpers/is.ts
+++ b/src/lib/internal/helpers/is.ts
@@ -10,6 +10,10 @@ export function isDocument(element: unknown): element is Document {
 	return element instanceof Document;
 }
 
+export function isShadowRoot(element: unknown): element is ShadowRoot {
+	return element instanceof ShadowRoot;
+}
+
 export function isElement(element: unknown): element is Element {
 	return element instanceof Element;
 }
@@ -78,4 +82,18 @@ export function isReadable(value: unknown): value is Readable<unknown> {
 
 export function isWritable(value: unknown): value is Writable<unknown> {
 	return isReadable(value) && 'set' in value;
+}
+
+export function isAttachedToDocument(element: unknown): boolean {
+	if (!isHTMLElement(element)) return false;
+
+	const rootNode = element.getRootNode()
+
+	if (rootNode === document) return true;
+
+	if (isShadowRoot(rootNode)) {
+		return rootNode.ownerDocument === document;
+	}
+
+	return false;
 }

--- a/src/lib/internal/helpers/makeElement.ts
+++ b/src/lib/internal/helpers/makeElement.ts
@@ -4,9 +4,18 @@ import { isBrowser, isHTMLElement, noop } from './index.js';
 import { removeUndefined } from './object.js';
 import { lightable } from './store/lightable.js';
 
+/* @deprecated
+*  We need to stop using `data-melt-id` and use normal ids for a11y compatibility.
+*  Use the `id` and use `getElementById` */
 export function getElementByMeltId(id: string, rootElement?: ParentNode) {
 	if (!isBrowser) return null;
 	const el = (rootElement ?? document).querySelector(`[data-melt-id="${id}"]`);
+	return isHTMLElement(el) ? el : null;
+}
+
+export function getElementById(id: string, rootElement?: ParentNode) {
+	if (!isBrowser) return null;
+	const el = (rootElement ?? document).querySelector(`[id="${id}"]`);
 	return isHTMLElement(el) ? el : null;
 }
 


### PR DESCRIPTION
This one fixes https://github.com/melt-ui/melt-ui/issues/1083

This adds a new param `rootElement` to all listbox elements, by default it will still be the `document` but it now supports a shadow dom root.

I also had to do some minor changes to the floating action to make it support shadow dom encapsulated elements.

I added an example for combobox but it should work on all listbox elements