### PR TITLE
changed input type of email box in landing page from password to email

### DIFF
--- a/src/routes/(landing-ui)/tabs.svelte
+++ b/src/routes/(landing-ui)/tabs.svelte
@@ -88,7 +88,7 @@
 			<label class="mb-2.5 block text-sm leading-none text-neutral-900" for="changeEmail">
 				New email
 			</label>
-			<input id="changeEmail" type="password" />
+			<input id="changeEmail" type="email" />
 		</fieldset>
 		<div class="mt-5 flex justify-end">
 			<button class="save">Save changes</button>


### PR DESCRIPTION
### The problem
On the landing page, on of the settings tab of the tab component, the input box which has the label "New email" actually has an input type of password, not email.

### The solution
I simply changed the input type of that input element from type="password" to  type="email".

