### PR TITLE
allow zeroes as value in hours segment

### DIFF
--- a/src/lib/builders/date-field/create.ts
+++ b/src/lib/builders/date-field/create.ts
@@ -1175,15 +1175,25 @@ export function createDateField(props?: CreateDateFieldProps) {
 		states.hour.hasTouched = true;
 
 		const $hourCycle = hourCycle.get();
+		const $locale = locale.get();
+
+		const hourCycleBasedOnLocale =
+			$hourCycle === 24
+				? $hourCycle
+				: Intl.DateTimeFormat($locale, { hour: 'numeric' }).resolvedOptions().hour12
+				? 12
+				: 24;
 
 		if (e.key === kbd.ARROW_UP) {
 			updateSegment('hour', (prev) => {
 				if (prev === null) {
-					const next = dateRef.cycle('hour', 1, { hourCycle: $hourCycle }).hour;
+					const next = dateRef.cycle('hour', 1, { hourCycle: hourCycleBasedOnLocale }).hour;
 					announcer.announce(next);
 					return next;
 				}
-				const next = dateRef.set({ hour: prev }).cycle('hour', 1, { hourCycle: $hourCycle }).hour;
+				const next = dateRef
+					.set({ hour: prev })
+					.cycle('hour', 1, { hourCycle: hourCycleBasedOnLocale }).hour;
 				announcer.announce(next);
 				return next;
 			});
@@ -1192,11 +1202,13 @@ export function createDateField(props?: CreateDateFieldProps) {
 		if (e.key === kbd.ARROW_DOWN) {
 			updateSegment('hour', (prev) => {
 				if (prev === null) {
-					const next = dateRef.cycle('hour', -1, { hourCycle: $hourCycle }).hour;
+					const next = dateRef.cycle('hour', -1, { hourCycle: hourCycleBasedOnLocale }).hour;
 					announcer.announce(next);
 					return next;
 				}
-				const next = dateRef.set({ hour: prev }).cycle('hour', -1, { hourCycle: $hourCycle }).hour;
+				const next = dateRef
+					.set({ hour: prev })
+					.cycle('hour', -1, { hourCycle: hourCycleBasedOnLocale }).hour;
 				announcer.announce(next);
 				return next;
 			});
@@ -1230,7 +1242,12 @@ export function createDateField(props?: CreateDateFieldProps) {
 					if (num === 0) {
 						states.hour.lastKeyZero = true;
 						announcer.announce(null);
-						return null;
+
+						if (hourCycleBasedOnLocale === 12) {
+							return null;
+						} else {
+							return 0;
+						}
 					}
 
 					/**


### PR DESCRIPTION
**Resolved Issue**  
Zeroes were not allowed as a valid value in the hours field when using the keyboard, but could still be set with the arrow controls. This was a problem for 24-hour format, because it uses 0 as "24th hour".

**Previous Behavior**  
- The value `0` could not be entered in the hours segment using the keyboard but could be set using the arrows.  
- When the `locale` was set to a region using the 24-hour format and `hourCycle` was set to 12, the arrows would cycle between 0–12 or 13–23, depending on the starting value.

**Updated Behavior**  
- The value `0` can now be entered in the hours segment using both the keyboard and the arrows.  
- When the `locale` is set to a region using the 24-hour format and `hourCycle` is set to 12, the `hourCycle` setting is ignored. The arrows now cycle through the full range of 0–23.