### PR TITLE
Fix main/module/exports for "."

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
-			"svelte": "./dist/index.js"
+			"svelte": "./dist/index.js",
+			"default": "./dist/index.js"
 		},
 		"./internal/*": {
 			"types": "./dist/internal/*/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -35,11 +35,13 @@
 		},
 		"./internal/*": {
 			"types": "./dist/internal/*/index.d.ts",
-			"svelte": "./dist/internal/*/index.js"
+			"svelte": "./dist/internal/*/index.js",
+			"default": "./dist/internal/*/index.js"
 		},
 		"./internal/types": {
 			"types": "./dist/internal/types.d.ts",
-			"svelte": "./dist/internal/types.js"
+			"svelte": "./dist/internal/types.js",
+			"default": "./dist/internal/types.js"
 		}
 	},
 	"typesVersions": {


### PR DESCRIPTION
Using `vitest 3`, I get this error when I run my tests: 

```
Error: Failed to resolve entry for package "@melt-ui/svelte". The package may have incorrect main/module/exports specified in its package.json: No known conditions for "." specifier in "@melt-ui/svelte" package
```

Adding this default export is fixing the issue. _(I have it locally in my pnpm paches atm)_